### PR TITLE
chore: Exclude CHANGELOG.md from markdownlint

### DIFF
--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -1,0 +1,1 @@
+CHANGELOG.md


### PR DESCRIPTION
Release-please generates CHANGELOG.md with its own formatting that conflicts
with our markdownlint config. Exclude it via .markdownlintignore.

Needed before release-please PR #3 can pass CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)