### PR TITLE
fix: Use markdownlint-cli2 ignores for CHANGELOG.md

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,9 +46,6 @@ jobs:
 
       - name: Run markdownlint
         uses: DavidAnson/markdownlint-cli2-action@v23
-        with:
-          config: .markdownlint.yml
-          globs: '**/*.md'
 
   # =============================================================================
   # YAML LINT (always runs)

--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -1,0 +1,5 @@
+---
+config:
+  extends: .markdownlint.yml
+ignores:
+  - "CHANGELOG.md"

--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -1,1 +1,0 @@
-CHANGELOG.md


### PR DESCRIPTION
.markdownlintignore is not supported by markdownlint-cli2.
Replace with .markdownlint-cli2.yaml using the ignores property.
Remove explicit config/globs from CI action (cli2 auto-discovers).

Fixes release-please PR #3 markdownlint failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)