### PR TITLE
fix: Use generic updater for galaxy.yml version bump

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,7 +1,7 @@
 ---
 namespace: marcstraube
 name: common
-version: 1.0.0
+version: 1.0.0 # x-release-please-version
 readme: README.md
 authors:
   - Marc Straube <email@marcstraube.de>

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -16,13 +16,7 @@
         {"type": "test", "section": "Tests", "hidden": true},
         {"type": "ci", "section": "CI", "hidden": true}
       ],
-      "extra-files": [
-        {
-          "type": "yaml",
-          "path": "galaxy.yml",
-          "jsonpath": "$.version"
-        }
-      ]
+      "extra-files": ["galaxy.yml"]
     }
   }
 }


### PR DESCRIPTION
Release-please YAML updater strips `---` document start marker when
re-serializing. Switch to generic updater with `x-release-please-version`
marker comment — only replaces the version string, preserves formatting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)