### PR TITLE
chore: Restore galaxy.yml document start and version marker

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,6 +1,7 @@
+---
 namespace: marcstraube
 name: common
-version: 1.0.1
+version: 1.0.1 # x-release-please-version
 readme: README.md
 authors:
   - Marc Straube <email@marcstraube.de>


### PR DESCRIPTION
Release-please v1.0.1 squash stripped `---` and `x-release-please-version`
marker because the PR was created before the generic updater fix (PR #6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)