### PR TITLE
ci: Use GitHub App token for release-please

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -18,9 +18,15 @@ jobs:
     env:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     steps:
-      - uses: googleapis/release-please-action@v4.4.0
+      - uses: actions/create-github-app-token@v3
+        id: app-token
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          app-id: ${{ vars.RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
+
+      - uses: googleapis/release-please-action@v4.4.1
+        with:
+          token: ${{ steps.app-token.outputs.token }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
           target-branch: main


### PR DESCRIPTION
## Summary

- Replace `GITHUB_TOKEN` with `marcstraube-release-bot` app token
- PRs created by release-please now trigger CI workflows automatically
- Uses `actions/create-github-app-token@v3`
- Bump `release-please-action` from v4.4.0 to v4.4.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)