### PR TITLE
chore: Add GitHub Sponsors to FUNDING.yml

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,2 +1,3 @@
+github: marcstraube
 custom:
   - 'https://paypal.me/marcstraube'


### PR DESCRIPTION
## Summary
- Add `github: marcstraube` to FUNDING.yml for GitHub Sponsors support

🤖 Generated with [Claude Code](https://claude.com/claude-code)