### PR TITLE
fix: Remove unnecessary curl prerequisite from nodejs role

### DIFF
--- a/roles/nodejs/molecule/default/prepare.yml
+++ b/roles/nodejs/molecule/default/prepare.yml
@@ -37,10 +37,3 @@
         name: '{{ __prepare_packages[ansible_facts["os_family"]] }}'
         state: present
       when: __prepare_packages[ansible_facts["os_family"]] | length > 0
-
-    # Replace curl-minimal with full curl (RedHat container images)
-    - name: Prepare | Replace curl-minimal with curl (RedHat)  # noqa: command-instead-of-module
-      ansible.builtin.command: dnf swap -y curl-minimal curl
-      changed_when: false
-      failed_when: false
-      when: ansible_facts['os_family'] == 'RedHat'

--- a/roles/nodejs/vars/Debian.yml
+++ b/roles/nodejs/vars/Debian.yml
@@ -5,7 +5,6 @@ __nodejs_packages:
 __nodejs_nvm_packages: []
 
 __nodejs_prerequisite_packages:
-  - 'curl'
   - 'gnupg'
   - 'ca-certificates'
 

--- a/roles/nodejs/vars/RedHat.yml
+++ b/roles/nodejs/vars/RedHat.yml
@@ -5,8 +5,7 @@ __nodejs_packages:
 
 __nodejs_nvm_packages: []
 
-__nodejs_prerequisite_packages:
-  - 'curl'
+__nodejs_prerequisite_packages: []
 
 __nodejs_nodesource_supported: true
 __nodejs_nodesource_key_url: 'https://rpm.nodesource.com/gpgkey/ns-operations-public.key'


### PR DESCRIPTION
## Summary

- Remove `curl` from `__nodejs_prerequisite_packages` in `vars/RedHat.yml` and `vars/Debian.yml`
- Remove `dnf swap curl-minimal curl` workaround from `molecule/default/prepare.yml`

The nodejs role listed curl as a prerequisite for NodeSource installation but never
uses it directly — all downloads use `ansible.builtin.get_url`. This caused Depsolve
conflicts on RedHat container images shipping `curl-minimal` instead of `curl`.

## Test plan

- [x] molecule test on Arch Linux (via n8n role converge)
- [x] molecule test on Debian Trixie (via n8n role converge)
- [x] molecule test on Rocky 9 (via n8n role converge)
- [x] molecule test on Rocky 10 (via n8n role converge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)