### PR TITLE
fix: Use YAML-aware updater for galaxy.yml in release-please

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -16,7 +16,13 @@
         {"type": "test", "section": "Tests", "hidden": true},
         {"type": "ci", "section": "CI", "hidden": true}
       ],
-      "extra-files": ["galaxy.yml"]
+      "extra-files": [
+        {
+          "type": "yaml",
+          "path": "galaxy.yml",
+          "jsonpath": "$.version"
+        }
+      ]
     }
   }
 }


### PR DESCRIPTION
## Summary

- Replace plain string `extra-files` entry with typed YAML updater using `jsonpath`
- Prevents stripping of `---` document start marker and `# x-release-please-version` comment from `galaxy.yml` during version bumps

Same fix already applied in the rocky collection.

## Test plan

- [ ] Merge and verify next release-please PR preserves `---` in galaxy.yml

🤖 Generated with [Claude Code](https://claude.com/claude-code)