### PR TITLE
fix: Use explicit generic updater for galaxy.yml in release-please

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -18,9 +18,8 @@
       ],
       "extra-files": [
         {
-          "type": "yaml",
-          "path": "galaxy.yml",
-          "jsonpath": "$.version"
+          "type": "generic",
+          "path": "galaxy.yml"
         }
       ]
     }


### PR DESCRIPTION
## Summary

- Switch `extra-files` entry for `galaxy.yml` from `type: yaml` (with jsonpath) to `type: generic`
- The YAML updater (js-yaml) strips `---` document start markers and comments from galaxy.yml — a known unfixed bug in release-please GenericYaml
- The generic updater does line-by-line regex matching on the `x-release-please-version` annotation, preserving all formatting

## Test plan

- [ ] Verify `galaxy.yml` still has the `# x-release-please-version` annotation on the version line
- [ ] Merge and verify that the next release-please PR correctly updates the version in `galaxy.yml` without stripping `---` or comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)