### PR TITLE
fix: Default firewalld_enabled to true for network-facing services

### DIFF
--- a/roles/avahi/defaults/main.yml
+++ b/roles/avahi/defaults/main.yml
@@ -129,7 +129,7 @@ avahi_nsswitch_hosts: >-
 #
 
 # Enable firewalld integration (add mDNS service)
-avahi_firewalld_enabled: false
+avahi_firewalld_enabled: true
 
 # firewalld zone to add the mDNS service to
 avahi_firewalld_zone: 'public'

--- a/roles/openssh/defaults/main.yml
+++ b/roles/openssh/defaults/main.yml
@@ -464,7 +464,7 @@ openssh_ssh_audit_enabled: true
 #
 
 # Enable firewalld integration
-openssh_firewalld_enabled: false
+openssh_firewalld_enabled: true
 
 # Firewalld zone for SSH
 openssh_firewalld_zone: 'public'

--- a/roles/snmp/defaults/main.yml
+++ b/roles/snmp/defaults/main.yml
@@ -206,7 +206,7 @@ snmp_extra_config: []
 #
 
 # Enable firewalld rule for SNMP (UDP/TCP 161)
-snmp_firewalld_enabled: false
+snmp_firewalld_enabled: true
 
 # Firewalld zone for SNMP service
 snmp_firewalld_zone: 'public'

--- a/roles/unbound/defaults/main.yml
+++ b/roles/unbound/defaults/main.yml
@@ -265,7 +265,7 @@ unbound_username: ''
 #
 
 # Enable firewalld integration for DNS port
-unbound_firewalld_enabled: false
+unbound_firewalld_enabled: true
 
 # Firewalld zone for service rules
 unbound_firewalld_zone: 'public'


### PR DESCRIPTION
## Summary

- Default `firewalld_enabled` from `false` to `true` for openssh, avahi, unbound, snmp
- All hosts run firewalld — network-facing services should manage their firewall rules by default
- Users who relied on the `false` default need to explicitly set `<role>_firewalld_enabled: false`

Closes #11

## Test plan

- [x] Verified all 4 `firewall.yml` follow the convention pattern (status check + ternary)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)