### PR TITLE
refactor: Unify molecule prepare.yml and fix dependency warnings

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -127,7 +127,7 @@
         "filename": "roles/networkmanager/molecule/default/molecule.yml",
         "hashed_secret": "206c80413b9a96c1312cc346b7d2517b84463edd",
         "is_verified": false,
-        "line_number": 114
+        "line_number": 108
       }
     ],
     "roles/package_management/molecule/default/converge.yml": [
@@ -288,9 +288,9 @@
         "filename": "roles/wireguard/molecule/default/molecule.yml",
         "hashed_secret": "723646f6fe4303a5e36357b70264ef6dd251f153",
         "is_verified": false,
-        "line_number": 86
+        "line_number": 80
       }
     ]
   },
-  "generated_at": "2026-04-14T18:37:49Z"
+  "generated_at": "2026-04-17T00:05:53Z"
 }

--- a/roles/aide/molecule/default/prepare.yml
+++ b/roles/aide/molecule/default/prepare.yml
@@ -4,6 +4,11 @@
   become: true
   gather_facts: true
 
+  vars:
+    __prepare_packages:
+      Archlinux:
+        - base-devel
+
   tasks:
     - name: Prepare | Update package cache (Arch)
       community.general.pacman:
@@ -21,11 +26,11 @@
         update_cache: true
       when: ansible_facts['os_family'] == 'RedHat'
 
-    - name: Prepare | Install base-devel (Arch)
+    - name: Prepare | Install container dependencies
       ansible.builtin.package:
-        name: base-devel
+        name: '{{ __prepare_packages[ansible_facts["os_family"]] }}'
         state: present
-      when: ansible_facts['os_family'] == 'Archlinux'
+      when: ansible_facts['os_family'] in __prepare_packages
 
     - name: Prepare | Create aur_builder user for AUR packages (Arch)
       ansible.builtin.user:

--- a/roles/apparmor/molecule/default/molecule.yml
+++ b/roles/apparmor/molecule/default/molecule.yml
@@ -1,10 +1,4 @@
 ---
-dependency:
-  name: galaxy
-  options:
-    requirements-file: requirements.yml
-    ignore-errors: true
-
 driver:
   name: default
   options:
@@ -95,7 +89,6 @@ verifier:
 scenario:
   name: default
   test_sequence:
-    - dependency
     - destroy
     - syntax
     - create

--- a/roles/apparmor/molecule/default/prepare.yml
+++ b/roles/apparmor/molecule/default/prepare.yml
@@ -4,6 +4,11 @@
   become: true
   gather_facts: true
 
+  vars:
+    __prepare_packages:
+      Archlinux:
+        - grub
+
   tasks:
     - name: Prepare | Update package cache (Arch)
       community.general.pacman:
@@ -16,11 +21,11 @@
         update_cache: true
       when: ansible_facts['os_family'] == 'Debian'
 
-    - name: Prepare | Install GRUB (Arch)
+    - name: Prepare | Install container dependencies
       ansible.builtin.package:
-        name: grub
+        name: '{{ __prepare_packages[ansible_facts["os_family"]] }}'
         state: present
-      when: ansible_facts['os_family'] == 'Archlinux'
+      when: ansible_facts['os_family'] in __prepare_packages
 
     - name: Prepare | Create GRUB default config (Arch)
       ansible.builtin.copy:

--- a/roles/apparmor/molecule/default/requirements.yml
+++ b/roles/apparmor/molecule/default/requirements.yml
@@ -1,3 +1,0 @@
----
-collections:
-  - name: community.general

--- a/roles/auditd/molecule/default/molecule.yml
+++ b/roles/auditd/molecule/default/molecule.yml
@@ -1,10 +1,4 @@
 ---
-dependency:
-  name: galaxy
-  options:
-    requirements-file: requirements.yml
-    ignore-errors: true
-
 driver:
   name: default
   options:
@@ -118,7 +112,6 @@ verifier:
 scenario:
   name: default
   test_sequence:
-    - dependency
     - destroy
     - syntax
     - create

--- a/roles/auditd/molecule/default/requirements.yml
+++ b/roles/auditd/molecule/default/requirements.yml
@@ -1,3 +1,0 @@
----
-collections:
-  - name: community.general

--- a/roles/base/molecule/default/prepare.yml
+++ b/roles/base/molecule/default/prepare.yml
@@ -4,6 +4,17 @@
   become: true
   gather_facts: true
 
+  vars:
+    __prepare_packages:
+      Debian:
+        - systemd
+        - systemd-timesyncd
+        - locales
+        - dbus
+      RedHat:
+        - glibc-langpack-en
+        - glibc-locale-source
+
   tasks:
     - name: Prepare | Update package cache (Arch)
       community.general.pacman:
@@ -21,28 +32,16 @@
         update_cache: true
       when: ansible_facts['os_family'] == 'RedHat'
 
-    - name: Prepare | Install systemd on Debian (minimal image)
-      ansible.builtin.apt:
-        name:
-          - systemd
-          - systemd-timesyncd
-          - locales
-          - dbus
+    - name: Prepare | Install container dependencies
+      ansible.builtin.package:
+        name: '{{ __prepare_packages[ansible_facts["os_family"]] }}'
         state: present
-      when: ansible_facts['os_family'] == 'Debian'
+      when: ansible_facts['os_family'] in __prepare_packages
 
-    - name: Prepare | Replace curl-minimal with curl on RedHat (Docker image conflict)
+    - name: Prepare | Replace curl-minimal with curl (RedHat Docker image conflict)
       ansible.builtin.dnf:
         name:
           - curl
         state: present
         allowerasing: true
-      when: ansible_facts['os_family'] == 'RedHat'
-
-    - name: Prepare | Install glibc-langpack-en on RedHat (minimal image)
-      ansible.builtin.dnf:
-        name:
-          - glibc-langpack-en
-          - glibc-locale-source
-        state: present
       when: ansible_facts['os_family'] == 'RedHat'

--- a/roles/hardening/molecule/default/molecule.yml
+++ b/roles/hardening/molecule/default/molecule.yml
@@ -1,10 +1,4 @@
 ---
-dependency:
-  name: galaxy
-  options:
-    requirements-file: requirements.yml
-    ignore-errors: true
-
 driver:
   name: default
   options:
@@ -94,7 +88,6 @@ verifier:
 scenario:
   name: default
   test_sequence:
-    - dependency
     - destroy
     - syntax
     - create

--- a/roles/hardening/molecule/default/requirements.yml
+++ b/roles/hardening/molecule/default/requirements.yml
@@ -1,4 +1,0 @@
----
-collections:
-  - name: community.general
-  - name: ansible.posix

--- a/roles/hardware_tokens/molecule/default/molecule.yml
+++ b/roles/hardware_tokens/molecule/default/molecule.yml
@@ -1,12 +1,6 @@
 ---
 # Vagrant-based: needs real udev for hardware token rules
 
-dependency:
-  name: galaxy
-  options:
-    requirements-file: requirements.yml
-    ignore-errors: true
-
 driver:
   name: default
   options:
@@ -103,7 +97,6 @@ verifier:
 scenario:
   name: default
   test_sequence:
-    - dependency
     - destroy
     - syntax
     - create

--- a/roles/hardware_tokens/molecule/default/requirements.yml
+++ b/roles/hardware_tokens/molecule/default/requirements.yml
@@ -1,3 +1,0 @@
----
-collections:
-  - name: community.general

--- a/roles/networkmanager/molecule/default/molecule.yml
+++ b/roles/networkmanager/molecule/default/molecule.yml
@@ -1,10 +1,4 @@
 ---
-dependency:
-  name: galaxy
-  options:
-    requirements-file: requirements.yml
-    ignore-errors: true
-
 driver:
   name: default
   options:
@@ -258,7 +252,6 @@ verifier:
 scenario:
   name: default
   test_sequence:
-    - dependency
     - destroy
     - syntax
     - create

--- a/roles/networkmanager/molecule/default/requirements.yml
+++ b/roles/networkmanager/molecule/default/requirements.yml
@@ -1,3 +1,0 @@
----
-collections:
-  - name: community.general

--- a/roles/unbound/molecule/default/prepare.yml
+++ b/roles/unbound/molecule/default/prepare.yml
@@ -4,6 +4,15 @@
   become: true
   gather_facts: true
 
+  vars:
+    __prepare_packages:
+      Archlinux:
+        - unbound
+      Debian:
+        - unbound
+      RedHat:
+        - unbound
+
   tasks:
     - name: Prepare | Update package cache (Arch)
       community.general.pacman:
@@ -21,9 +30,9 @@
         update_cache: true
       when: ansible_facts['os_family'] == 'RedHat'
 
-    - name: Prepare | Pre-install unbound for binary detection
+    - name: Prepare | Install container dependencies
       ansible.builtin.package:
-        name: unbound
+        name: '{{ __prepare_packages[ansible_facts["os_family"]] }}'
         state: present
 
     - name: Prepare | Detect unbound binary path

--- a/roles/wireguard/molecule/default/molecule.yml
+++ b/roles/wireguard/molecule/default/molecule.yml
@@ -1,12 +1,6 @@
 ---
 # Vagrant-based: needs kernel modules (modprobe wireguard)
 
-dependency:
-  name: galaxy
-  options:
-    requirements-file: requirements.yml
-    ignore-errors: true
-
 driver:
   name: default
   options:
@@ -100,7 +94,6 @@ verifier:
 scenario:
   name: default
   test_sequence:
-    - dependency
     - destroy
     - syntax
     - create

--- a/roles/wireguard/molecule/default/requirements.yml
+++ b/roles/wireguard/molecule/default/requirements.yml
@@ -1,5 +1,0 @@
----
-collections:
-  - name: ansible.utils
-  - name: ansible.posix
-  - name: community.general


### PR DESCRIPTION
## Summary

- Convert 4 roles (aide, apparmor, base, unbound) to `__prepare_packages` dict pattern
- 22 remaining roles need no conversion (cache-only, EPEL-only, or AUR-builder-only)
- Remove unused molecule dependency config from 6 Vagrant-based roles (apparmor, auditd, hardening, hardware_tokens, networkmanager, wireguard)
- Fix "1 missing files" warning caused by wrongly renamed `collections.yml` → `requirements.yml`

Closes #17
Closes #21

## Test plan

- [x] aide on Arch (Podman)
- [x] apparmor on Debian (Vagrant) — "1 successful", warning gone
- [x] base on Debian (Podman)
- [x] unbound on Rocky 9 (Podman)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)