### PR TITLE
fix: Repair CI failures and add molecule gate job

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,3 +1,4 @@
 github: marcstraube
+ko_fi: marcstraube
 custom:
   - 'https://paypal.me/marcstraube'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -253,6 +253,34 @@ jobs:
           ANSIBLE_FORCE_COLOR: '1'
 
   # =============================================================================
+  # CI GATE (single required check for branch protection)
+  # =============================================================================
+  ci-gate:
+    name: CI Gate
+    runs-on: ubuntu-latest
+    if: always()
+    needs: [lint, markdown-lint, yaml-lint, build, molecule-compat, molecule-roles]
+    steps:
+      - name: Check required job results
+        run: |
+          # molecule-roles may be skipped when no roles changed
+          results=(
+            "${{ needs.lint.result }}"
+            "${{ needs.markdown-lint.result }}"
+            "${{ needs.yaml-lint.result }}"
+            "${{ needs.build.result }}"
+            "${{ needs.molecule-compat.result }}"
+            "${{ needs.molecule-roles.result }}"
+          )
+          for r in "${results[@]}"; do
+            if [ "$r" = "failure" ] || [ "$r" = "cancelled" ]; then
+              echo "::error::Required job failed or was cancelled: $r"
+              exit 1
+            fi
+          done
+          echo "All required jobs passed (or were skipped)."
+
+  # =============================================================================
   # BUILD (always runs)
   # =============================================================================
   build:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CI](https://github.com/marcstraube/ansible-collection-common/workflows/CI/badge.svg)](https://github.com/marcstraube/ansible-collection-common/actions)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
-[![Sponsor](https://img.shields.io/badge/sponsor-PayPal-blue.svg)](https://paypal.me/marcstraube)
+[![Ko-fi](https://img.shields.io/badge/Ko--fi-Support-ff5e5b?logo=ko-fi&logoColor=white)](https://ko-fi.com/marcstraube)
 
 ## Description
 
@@ -148,6 +148,10 @@ molecule test
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup and guidelines.
+
+## Support
+
+If you find this collection useful, consider [supporting its development](https://github.com/sponsors/marcstraube).
 
 ## License
 

--- a/roles/energy_management/molecule/default/verify.yml
+++ b/roles/energy_management/molecule/default/verify.yml
@@ -5,8 +5,12 @@
 
   tasks:
     #
-    # Load OS-Specific Variables
+    # Load Variables
     #
+
+    - name: Verify | Load common variables
+      ansible.builtin.include_vars:
+        file: '../../vars/main.yml'
 
     - name: Verify | Load OS-specific variables
       ansible.builtin.include_vars: '{{ item }}'

--- a/roles/logrotate/molecule/default/verify.yml
+++ b/roles/logrotate/molecule/default/verify.yml
@@ -5,8 +5,12 @@
 
   tasks:
     #
-    # Load OS-Specific Variables
+    # Load Variables
     #
+
+    - name: Verify | Load common variables
+      ansible.builtin.include_vars:
+        file: '../../vars/main.yml'
 
     - name: Verify | Load OS-specific variables
       ansible.builtin.include_vars: '{{ item }}'

--- a/roles/rkhunter/molecule/default/verify.yml
+++ b/roles/rkhunter/molecule/default/verify.yml
@@ -5,8 +5,12 @@
 
   tasks:
     #
-    # Load OS-Specific Variables
+    # Load Variables
     #
+
+    - name: Verify | Load common variables
+      ansible.builtin.include_vars:
+        file: '../../vars/main.yml'
 
     - name: Verify | Load OS-specific variables
       ansible.builtin.include_vars: '{{ item }}'

--- a/roles/wireguard/molecule/default/verify.yml
+++ b/roles/wireguard/molecule/default/verify.yml
@@ -5,8 +5,12 @@
 
   tasks:
     #
-    # Load OS-Specific Variables
+    # Load Variables
     #
+
+    - name: Verify | Load common variables
+      ansible.builtin.include_vars:
+        file: '../../vars/main.yml'
 
     - name: Verify | Load OS-specific variables
       ansible.builtin.include_vars: '{{ item }}'


### PR DESCRIPTION
## Summary

- Load `vars/main.yml` in verify.yml for roles where the vars refactoring (#32) moved shared variables out of OS-specific files (rkhunter, logrotate, energy_management, wireguard)
- Add `CI Gate` job that aggregates all CI results into a single required check, preventing merges when molecule tests fail
- Add Ko-fi to FUNDING.yml and update README sponsor badge and support section

## Test plan

- [x] Molecule tests passed locally for rkhunter, logrotate, energy_management
- [ ] CI Gate job appears in workflow run and correctly reports overall status
- [ ] `CI Gate` added as required status check in branch protection after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)