### PR TITLE
feat: Add network retry logic to all transient tasks

### DIFF
--- a/roles/aide/molecule/default/prepare.yml
+++ b/roles/aide/molecule/default/prepare.yml
@@ -16,22 +16,30 @@
       community.general.pacman:
         update_cache: true
         upgrade: true
+      retries: 3
+      delay: 5
       when: ansible_facts['os_family'] == 'Archlinux'
 
     - name: Prepare | Update package cache (Debian)
       ansible.builtin.apt:
         update_cache: true
+      retries: 3
+      delay: 5
       when: ansible_facts['os_family'] == 'Debian'
 
     - name: Prepare | Update package cache (RedHat)
       ansible.builtin.dnf:
         update_cache: true
+      retries: 3
+      delay: 5
       when: ansible_facts['os_family'] == 'RedHat'
 
     - name: Prepare | Install container dependencies
       ansible.builtin.package:
         name: '{{ __prepare_packages[ansible_facts["os_family"]] }}'
         state: present
+      retries: 3
+      delay: 5
       when: __prepare_packages[ansible_facts["os_family"]] | length > 0
 
     - name: Prepare | Create aur_builder user for AUR packages (Arch)

--- a/roles/aide/tasks/install.yml
+++ b/roles/aide/tasks/install.yml
@@ -7,6 +7,8 @@
   loop: '{{ __aide_gpg_keys | default([]) }}'
   register: __aide_gpg_import
   changed_when: "'imported:' in __aide_gpg_import.stderr"
+  retries: 5
+  delay: 10
   when: __aide_aur | bool
 
 - name: Install | AIDE package (AUR)
@@ -15,12 +17,16 @@
   kewlfft.aur.aur:
     name: '{{ __aide_aur_packages.aide }}'
     state: present
+  retries: 3
+  delay: 5
   when: __aide_aur | bool
 
 - name: Install | AIDE package (official repos)
   ansible.builtin.package:
     name: '{{ __aide_package }}'
     state: present
+  retries: 3
+  delay: 5
   when: not (__aide_aur | bool)
 
 - name: Install | Ensure AIDE directories exist

--- a/roles/ansible/molecule/default/prepare.yml
+++ b/roles/ansible/molecule/default/prepare.yml
@@ -9,22 +9,30 @@
       community.general.pacman:
         update_cache: true
         upgrade: true
+      retries: 3
+      delay: 5
       when: ansible_facts['os_family'] == 'Archlinux'
 
     - name: Prepare | Update package cache (Debian)
       ansible.builtin.apt:
         update_cache: true
+      retries: 3
+      delay: 5
       when: ansible_facts['os_family'] == 'Debian'
 
     - name: Prepare | Enable EPEL repository (RedHat)
       ansible.builtin.dnf:
         name: epel-release
         state: present
+      retries: 3
+      delay: 5
       when: ansible_facts['os_family'] == 'RedHat'
 
     - name: Prepare | Update package cache (RedHat)
       ansible.builtin.dnf:
         update_cache: true
+      retries: 3
+      delay: 5
       when: ansible_facts['os_family'] == 'RedHat'
 
     - name: Prepare | Create aur_builder user for AUR packages (Arch)

--- a/roles/ansible/tasks/install.yml
+++ b/roles/ansible/tasks/install.yml
@@ -7,6 +7,8 @@
   ansible.builtin.package:
     name: '{{ __ansible_tools_ansible_packages }}'
     state: present
+  retries: 3
+  delay: 5
   when: ansible_tools_ansible_enabled | bool
 
 #
@@ -20,6 +22,8 @@
       ansible.builtin.package:
         name: '{{ __ansible_tools_molecule_packages }}'
         state: present
+      retries: 3
+      delay: 5
       when: ansible_tools_molecule_enabled | bool
 
     - name: Install | molecule-plugins from AUR (Arch)
@@ -30,6 +34,8 @@
         use: 'makepkg'
         extra_args: '--nocheck'
         state: present
+      retries: 3
+      delay: 5
       when:
         - ansible_tools_molecule_enabled | bool
         - ansible_tools_container_driver in ['podman', 'docker']
@@ -41,6 +47,8 @@
         name: '{{ __ansible_tools_aur_packages.podman }}'
         use: 'makepkg'
         state: present
+      retries: 3
+      delay: 5
       when:
         - ansible_tools_molecule_enabled | bool
         - ansible_tools_container_driver == 'podman'
@@ -49,6 +57,8 @@
       ansible.builtin.package:
         name: '{{ __ansible_tools_docker_packages }}'
         state: present
+      retries: 3
+      delay: 5
       when:
         - ansible_tools_molecule_enabled | bool
         - ansible_tools_container_driver == 'docker'
@@ -57,6 +67,8 @@
       ansible.builtin.package:
         name: '{{ __ansible_tools_lint_packages }}'
         state: present
+      retries: 3
+      delay: 5
       when: ansible_tools_lint_enabled | bool
 
 #
@@ -71,6 +83,8 @@
         name: '{{ __ansible_tools_molecule_pipx_package }}'
         state: present
         executable: '{{ __ansible_tools_pipx_cmd }}'
+      retries: 3
+      delay: 5
       when: ansible_tools_molecule_enabled | bool
 
     - name: Install | Inject container driver plugin via pipx (Debian)
@@ -80,6 +94,8 @@
           - '{{ __ansible_tools_driver_inject }}'
         state: inject
         executable: '{{ __ansible_tools_pipx_cmd }}'
+      retries: 3
+      delay: 5
       vars:
         __ansible_tools_driver_inject: >-
           {{ (ansible_tools_container_driver == 'podman')
@@ -95,6 +111,8 @@
         inject_packages: '{{ ansible_tools_extra_plugins }}'
         state: inject
         executable: '{{ __ansible_tools_pipx_cmd }}'
+      retries: 3
+      delay: 5
       when:
         - ansible_tools_molecule_enabled | bool
         - ansible_tools_extra_plugins | length > 0
@@ -104,6 +122,8 @@
         name: 'ansible-lint'
         state: present
         executable: '{{ __ansible_tools_pipx_cmd }}'
+      retries: 3
+      delay: 5
       when: ansible_tools_lint_enabled | bool
 
     - name: Install | yamllint via pipx (Debian)
@@ -111,6 +131,8 @@
         name: 'yamllint'
         state: present
         executable: '{{ __ansible_tools_pipx_cmd }}'
+      retries: 3
+      delay: 5
       when: ansible_tools_lint_enabled | bool
 
 #
@@ -125,6 +147,8 @@
         name: '{{ __ansible_tools_molecule_pipx_package }}'
         state: present
         executable: '{{ __ansible_tools_pipx_cmd }}'
+      retries: 3
+      delay: 5
       when: ansible_tools_molecule_enabled | bool
 
     - name: Install | Inject container driver plugin via pipx (RedHat)
@@ -134,6 +158,8 @@
           - '{{ __ansible_tools_driver_inject }}'
         state: inject
         executable: '{{ __ansible_tools_pipx_cmd }}'
+      retries: 3
+      delay: 5
       vars:
         __ansible_tools_driver_inject: >-
           {{ (ansible_tools_container_driver == 'podman')
@@ -149,6 +175,8 @@
         inject_packages: '{{ ansible_tools_extra_plugins }}'
         state: inject
         executable: '{{ __ansible_tools_pipx_cmd }}'
+      retries: 3
+      delay: 5
       when:
         - ansible_tools_molecule_enabled | bool
         - ansible_tools_extra_plugins | length > 0
@@ -158,6 +186,8 @@
         name: 'ansible-lint'
         state: present
         executable: '{{ __ansible_tools_pipx_cmd }}'
+      retries: 3
+      delay: 5
       when: ansible_tools_lint_enabled | bool
 
     - name: Install | yamllint via pipx (RedHat)
@@ -165,4 +195,6 @@
         name: 'yamllint'
         state: present
         executable: '{{ __ansible_tools_pipx_cmd }}'
+      retries: 3
+      delay: 5
       when: ansible_tools_lint_enabled | bool

--- a/roles/apparmor/molecule/default/prepare.yml
+++ b/roles/apparmor/molecule/default/prepare.yml
@@ -9,17 +9,23 @@
       community.general.pacman:
         update_cache: true
         upgrade: true
+      retries: 3
+      delay: 5
       when: ansible_facts['os_family'] == 'Archlinux'
 
     - name: Prepare | Update package cache (Debian)
       ansible.builtin.apt:
         update_cache: true
+      retries: 3
+      delay: 5
       when: ansible_facts['os_family'] == 'Debian'
 
     - name: Prepare | Install GRUB (Arch)
       ansible.builtin.package:
         name: grub
         state: present
+      retries: 3
+      delay: 5
       when: ansible_facts['os_family'] == 'Archlinux'
 
     - name: Prepare | Create GRUB default config (Arch)

--- a/roles/apparmor/tasks/install.yml
+++ b/roles/apparmor/tasks/install.yml
@@ -3,21 +3,29 @@
   ansible.builtin.package:
     name: '{{ __apparmor_packages }}'
     state: present
+  retries: 3
+  delay: 5
 
 - name: Install | AppArmor utilities
   ansible.builtin.package:
     name: '{{ __apparmor_utils_packages }}'
     state: present
+  retries: 3
+  delay: 5
   when: apparmor_utils_enabled | bool
 
 - name: Install | Extra profiles
   ansible.builtin.package:
     name: '{{ __apparmor_extra_profiles_package }}'
     state: present
+  retries: 3
+  delay: 5
   when: apparmor_extra_profiles_enabled | bool
 
 - name: Install | apparmor-notify
   ansible.builtin.package:
     name: '{{ __apparmor_notify_package }}'
     state: present
+  retries: 3
+  delay: 5
   when: apparmor_notify_enabled | bool

--- a/roles/auditd/molecule/default/prepare.yml
+++ b/roles/auditd/molecule/default/prepare.yml
@@ -9,14 +9,20 @@
       community.general.pacman:
         update_cache: true
         upgrade: true
+      retries: 3
+      delay: 5
       when: ansible_facts['os_family'] == 'Archlinux'
 
     - name: Prepare | Update package cache (Debian)
       ansible.builtin.apt:
         update_cache: true
+      retries: 3
+      delay: 5
       when: ansible_facts['os_family'] == 'Debian'
 
     - name: Prepare | Update package cache (RedHat)
       ansible.builtin.dnf:
         update_cache: true
+      retries: 3
+      delay: 5
       when: ansible_facts['os_family'] == 'RedHat'

--- a/roles/auditd/tasks/install.yml
+++ b/roles/auditd/tasks/install.yml
@@ -3,6 +3,8 @@
   ansible.builtin.package:
     name: '{{ __auditd_packages }}'
     state: present
+  retries: 3
+  delay: 5
 
 - name: Install | Ensure audit log directory exists
   ansible.builtin.file:

--- a/roles/auditd/tasks/remote.yml
+++ b/roles/auditd/tasks/remote.yml
@@ -3,6 +3,8 @@
   ansible.builtin.package:
     name: '{{ __auditd_remote_packages }}'
     state: present
+  retries: 3
+  delay: 5
   when: __auditd_remote_packages | length > 0
 
 - name: Remote | Configure audisp-remote

--- a/roles/avahi/molecule/default/prepare.yml
+++ b/roles/avahi/molecule/default/prepare.yml
@@ -15,20 +15,28 @@
       community.general.pacman:
         update_cache: true
         upgrade: true
+      retries: 3
+      delay: 5
       when: ansible_facts['os_family'] == 'Archlinux'
 
     - name: Prepare | Update package cache (Debian)
       ansible.builtin.apt:
         update_cache: true
+      retries: 3
+      delay: 5
       when: ansible_facts['os_family'] == 'Debian'
 
     - name: Prepare | Update package cache (RedHat)
       ansible.builtin.dnf:
         update_cache: true
+      retries: 3
+      delay: 5
       when: ansible_facts['os_family'] == 'RedHat'
 
     - name: Prepare | Install container dependencies
       ansible.builtin.package:
         name: '{{ __prepare_packages[ansible_facts["os_family"]] }}'
         state: present
+      retries: 3
+      delay: 5
       when: ansible_facts['os_family'] in __prepare_packages

--- a/roles/avahi/tasks/install.yml
+++ b/roles/avahi/tasks/install.yml
@@ -3,9 +3,13 @@
   ansible.builtin.package:
     name: '{{ __avahi_packages }}'
     state: present
+  retries: 3
+  delay: 5
 
 - name: Install | NSS-mDNS packages
   ansible.builtin.package:
     name: '{{ __avahi_nss_packages }}'
     state: present
+  retries: 3
+  delay: 5
   when: avahi_nss_mdns_enabled | bool

--- a/roles/base/molecule/default/prepare.yml
+++ b/roles/base/molecule/default/prepare.yml
@@ -21,22 +21,30 @@
       community.general.pacman:
         update_cache: true
         upgrade: true
+      retries: 3
+      delay: 5
       when: ansible_facts['os_family'] == 'Archlinux'
 
     - name: Prepare | Update package cache (Debian)
       ansible.builtin.apt:
         update_cache: true
+      retries: 3
+      delay: 5
       when: ansible_facts['os_family'] == 'Debian'
 
     - name: Prepare | Update package cache (RedHat)
       ansible.builtin.dnf:
         update_cache: true
+      retries: 3
+      delay: 5
       when: ansible_facts['os_family'] == 'RedHat'
 
     - name: Prepare | Install container dependencies
       ansible.builtin.package:
         name: '{{ __prepare_packages[ansible_facts["os_family"]] }}'
         state: present
+      retries: 3
+      delay: 5
       when: __prepare_packages[ansible_facts["os_family"]] | length > 0
 
     - name: Prepare | Replace curl-minimal with curl on RedHat (Docker image conflict)
@@ -45,4 +53,6 @@
           - curl
         state: present
         allowerasing: true
+      retries: 3
+      delay: 5
       when: ansible_facts['os_family'] == 'RedHat'

--- a/roles/base/tasks/kernel.yml
+++ b/roles/base/tasks/kernel.yml
@@ -17,11 +17,15 @@
   ansible.builtin.package:
     name: '{{ [base_kernel] + base_kernel_extra_packages }}'
     state: present
+  retries: 3
+  delay: 5
 
 - name: Kernel | Install microcode package
   ansible.builtin.package:
     name: '{{ __base_microcode_package }}'
     state: present
+  retries: 3
+  delay: 5
   when:
     - __base_microcode_package is defined
     - __base_microcode_package | length > 0

--- a/roles/base/tasks/locale.yml
+++ b/roles/base/tasks/locale.yml
@@ -3,6 +3,8 @@
   ansible.builtin.package:
     name: '{{ __base_locale_packages }}'
     state: present
+  retries: 3
+  delay: 5
   when:
     - ansible_facts['os_family'] == 'RedHat'
     - __base_locale_packages is defined

--- a/roles/base/tasks/packages.yml
+++ b/roles/base/tasks/packages.yml
@@ -9,15 +9,21 @@
   ansible.builtin.package:
     name: '{{ base_packages }}'
     state: present
+  retries: 3
+  delay: 5
 
 - name: Packages | Install dialog
   ansible.builtin.package:
     name: '{{ __base_dialog_package }}'
     state: present
+  retries: 3
+  delay: 5
   when: base_dialog_enabled | bool
 
 - name: Packages | Install extra packages
   ansible.builtin.package:
     name: '{{ base_extra_packages }}'
     state: present
+  retries: 3
+  delay: 5
   when: base_extra_packages | length > 0

--- a/roles/chrony/molecule/default/prepare.yml
+++ b/roles/chrony/molecule/default/prepare.yml
@@ -23,22 +23,30 @@
       community.general.pacman:
         update_cache: true
         upgrade: true
+      retries: 3
+      delay: 5
       when: ansible_facts['os_family'] == 'Archlinux'
 
     - name: Prepare | Update package cache (Debian)
       ansible.builtin.apt:
         update_cache: true
+      retries: 3
+      delay: 5
       when: ansible_facts['os_family'] == 'Debian'
 
     - name: Prepare | Update package cache (RedHat)
       ansible.builtin.dnf:
         update_cache: true
+      retries: 3
+      delay: 5
       when: ansible_facts['os_family'] == 'RedHat'
 
     - name: Prepare | Install container dependencies
       ansible.builtin.package:
         name: '{{ __prepare_packages[ansible_facts["os_family"]] }}'
         state: present
+      retries: 3
+      delay: 5
 
     - name: Prepare | Stop chrony before applying override
       ansible.builtin.systemd_service:

--- a/roles/chrony/tasks/install.yml
+++ b/roles/chrony/tasks/install.yml
@@ -3,6 +3,8 @@
   ansible.builtin.package:
     name: '{{ __chrony_packages }}'
     state: present
+  retries: 3
+  delay: 5
 
 - name: Install | Disable conflicting services
   ansible.builtin.systemd_service:

--- a/roles/clamav/molecule/default/prepare.yml
+++ b/roles/clamav/molecule/default/prepare.yml
@@ -21,28 +21,38 @@
       community.general.pacman:
         update_cache: true
         upgrade: true
+      retries: 3
+      delay: 5
       when: ansible_facts['os_family'] == 'Archlinux'
 
     - name: Prepare | Update package cache (Debian)
       ansible.builtin.apt:
         update_cache: true
+      retries: 3
+      delay: 5
       when: ansible_facts['os_family'] == 'Debian'
 
     - name: Prepare | Enable EPEL repository (RedHat)
       ansible.builtin.dnf:
         name: epel-release
         state: present
+      retries: 3
+      delay: 5
       when: ansible_facts['os_family'] == 'RedHat'
 
     - name: Prepare | Update package cache (RedHat)
       ansible.builtin.dnf:
         update_cache: true
+      retries: 3
+      delay: 5
       when: ansible_facts['os_family'] == 'RedHat'
 
     - name: Prepare | Install container dependencies
       ansible.builtin.package:
         name: '{{ __prepare_packages[ansible_facts["os_family"]] }}'
         state: present
+      retries: 3
+      delay: 5
 
     # ClamAV daemon may fail to start in containers without override
     - name: Prepare | Create systemd override directory for clamd (Arch)

--- a/roles/clamav/tasks/install.yml
+++ b/roles/clamav/tasks/install.yml
@@ -3,11 +3,15 @@
   ansible.builtin.package:
     name: '{{ __clamav_packages }}'
     state: present
+  retries: 3
+  delay: 5
 
 - name: Install | ClamAV milter packages
   ansible.builtin.package:
     name: '{{ __clamav_milter_packages }}'
     state: present
+  retries: 3
+  delay: 5
   when:
     - clamav_milter_enabled | bool
     - __clamav_milter_packages | length > 0

--- a/roles/docker/molecule/default/prepare.yml
+++ b/roles/docker/molecule/default/prepare.yml
@@ -9,14 +9,20 @@
       community.general.pacman:
         update_cache: true
         upgrade: true
+      retries: 3
+      delay: 5
       when: ansible_facts['os_family'] == 'Archlinux'
 
     - name: Prepare | Update package cache (Debian)
       ansible.builtin.apt:
         update_cache: true
+      retries: 3
+      delay: 5
       when: ansible_facts['os_family'] == 'Debian'
 
     - name: Prepare | Update package cache (RedHat)
       ansible.builtin.dnf:
         update_cache: true
+      retries: 3
+      delay: 5
       when: ansible_facts['os_family'] == 'RedHat'

--- a/roles/docker/tasks/install.yml
+++ b/roles/docker/tasks/install.yml
@@ -5,6 +5,8 @@
       - 'ca-certificates'
       - 'python3-debian'
     state: present
+  retries: 3
+  delay: 5
   when: ansible_facts['os_family'] == 'Debian'
 
 - name: Install | Add Docker apt repository
@@ -16,12 +18,16 @@
     components: stable
     signed_by: '{{ __docker_gpg_url }}'
     state: present
+  retries: 5
+  delay: 10
   register: __docker_apt_repo
   when: ansible_facts['os_family'] == 'Debian'
 
 - name: Install | Update apt cache after repo change
   ansible.builtin.apt:
     update_cache: true
+  retries: 3
+  delay: 5
   when:
     - ansible_facts['os_family'] == 'Debian'
     - __docker_apt_repo is changed
@@ -49,17 +55,23 @@
   ansible.builtin.package:
     name: '{{ __docker_packages }}'
     state: present
+  retries: 3
+  delay: 5
 
 - name: Install | Docker Compose plugin
   ansible.builtin.package:
     name: '{{ __docker_compose_package }}'
     state: present
+  retries: 3
+  delay: 5
   when: docker_compose_enabled | bool
 
 - name: Install | Docker Buildx plugin
   ansible.builtin.package:
     name: '{{ __docker_buildx_package }}'
     state: present
+  retries: 3
+  delay: 5
   when: docker_buildx_enabled | bool
 
 #

--- a/roles/editors/molecule/default/prepare.yml
+++ b/roles/editors/molecule/default/prepare.yml
@@ -9,14 +9,20 @@
       community.general.pacman:
         update_cache: true
         upgrade: true
+      retries: 3
+      delay: 5
       when: ansible_facts['os_family'] == 'Archlinux'
 
     - name: Prepare | Update package cache (Debian)
       ansible.builtin.apt:
         update_cache: true
+      retries: 3
+      delay: 5
       when: ansible_facts['os_family'] == 'Debian'
 
     - name: Prepare | Update package cache (RedHat)
       ansible.builtin.dnf:
         update_cache: true
+      retries: 3
+      delay: 5
       when: ansible_facts['os_family'] == 'RedHat'

--- a/roles/editors/tasks/install.yml
+++ b/roles/editors/tasks/install.yml
@@ -7,6 +7,8 @@
   ansible.builtin.package:
     name: '{{ __editors_nano_package }}'
     state: present
+  retries: 3
+  delay: 5
   when: editors_nano_enabled | bool
 
 #
@@ -17,6 +19,8 @@
   ansible.builtin.package:
     name: '{{ __editors_vim_package }}'
     state: present
+  retries: 3
+  delay: 5
   when: editors_vim_enabled | bool
 
 #
@@ -27,6 +31,8 @@
   ansible.builtin.package:
     name: '{{ __editors_neovim_package }}'
     state: present
+  retries: 3
+  delay: 5
   when:
     - editors_neovim_enabled | bool
     - not (editors_neovim_binary_enabled | default(false) | bool)

--- a/roles/editors/tasks/neovim_binary.yml
+++ b/roles/editors/tasks/neovim_binary.yml
@@ -22,6 +22,8 @@
         owner: root
         group: root
         mode: '0644'
+      retries: 5
+      delay: 10
 
     - name: Neovim Binary | Extract to /usr/local
       ansible.builtin.unarchive:

--- a/roles/energy_management/molecule/default/prepare.yml
+++ b/roles/energy_management/molecule/default/prepare.yml
@@ -9,14 +9,20 @@
       community.general.pacman:
         update_cache: true
         upgrade: true
+      retries: 3
+      delay: 5
       when: ansible_facts['os_family'] == 'Archlinux'
 
     - name: Prepare | Update package cache (Debian)
       ansible.builtin.apt:
         update_cache: true
+      retries: 3
+      delay: 5
       when: ansible_facts['os_family'] == 'Debian'
 
     - name: Prepare | Update package cache (RedHat)
       ansible.builtin.dnf:
         update_cache: true
+      retries: 3
+      delay: 5
       when: ansible_facts['os_family'] == 'RedHat'

--- a/roles/energy_management/tasks/backlight.yml
+++ b/roles/energy_management/tasks/backlight.yml
@@ -6,6 +6,8 @@
   ansible.builtin.package:
     name: '{{ __energy_management_backlight_packages }}'
     state: present
+  retries: 3
+  delay: 5
 
 - name: Backlight | Deploy udev rules
   ansible.builtin.template:

--- a/roles/energy_management/tasks/battery.yml
+++ b/roles/energy_management/tasks/battery.yml
@@ -7,6 +7,8 @@
   ansible.builtin.package:
     name: '{{ __energy_management_tp_smapi_packages }}'
     state: present
+  retries: 3
+  delay: 5
   when:
     - energy_management_battery_tp_smapi_enabled | bool
     - __energy_management_tp_smapi_packages | length > 0

--- a/roles/energy_management/tasks/ppd.yml
+++ b/roles/energy_management/tasks/ppd.yml
@@ -22,6 +22,8 @@
   ansible.builtin.package:
     name: '{{ __energy_management_ppd_packages }}'
     state: present
+  retries: 3
+  delay: 5
 
 - name: PPD | Enable and start PPD service
   ansible.builtin.systemd_service:

--- a/roles/energy_management/tasks/tlp.yml
+++ b/roles/energy_management/tasks/tlp.yml
@@ -21,6 +21,8 @@
   ansible.builtin.package:
     name: '{{ __energy_management_tlp_packages }}'
     state: present
+  retries: 3
+  delay: 5
 
 - name: TLP | Deploy TLP configuration
   ansible.builtin.template:

--- a/roles/fail2ban/molecule/default/prepare.yml
+++ b/roles/fail2ban/molecule/default/prepare.yml
@@ -19,22 +19,30 @@
       community.general.pacman:
         update_cache: true
         upgrade: true
+      retries: 3
+      delay: 5
       when: ansible_facts['os_family'] == 'Archlinux'
 
     - name: Prepare | Update package cache (Debian)
       ansible.builtin.apt:
         update_cache: true
+      retries: 3
+      delay: 5
       when: ansible_facts['os_family'] == 'Debian'
 
     - name: Prepare | Update package cache (RedHat)
       ansible.builtin.dnf:
         update_cache: true
+      retries: 3
+      delay: 5
       when: ansible_facts['os_family'] == 'RedHat'
 
     - name: Prepare | Install container dependencies
       ansible.builtin.package:
         name: '{{ __prepare_packages[ansible_facts["os_family"]] }}'
         state: present
+      retries: 3
+      delay: 5
 
     # Containers lack syslog — create auth log files for sshd jail
     - name: Prepare | Create system auth log (container)

--- a/roles/fail2ban/tasks/install.yml
+++ b/roles/fail2ban/tasks/install.yml
@@ -3,3 +3,5 @@
   ansible.builtin.package:
     name: '{{ __fail2ban_packages }}'
     state: present
+  retries: 3
+  delay: 5

--- a/roles/firejail/molecule/default/prepare.yml
+++ b/roles/firejail/molecule/default/prepare.yml
@@ -9,20 +9,28 @@
       community.general.pacman:
         update_cache: true
         upgrade: true
+      retries: 3
+      delay: 5
       when: ansible_facts['os_family'] == 'Archlinux'
 
     - name: Prepare | Update package cache (Debian)
       ansible.builtin.apt:
         update_cache: true
+      retries: 3
+      delay: 5
       when: ansible_facts['os_family'] == 'Debian'
 
     - name: Prepare | Enable EPEL repository (RedHat)
       ansible.builtin.dnf:
         name: epel-release
         state: present
+      retries: 3
+      delay: 5
       when: ansible_facts['os_family'] == 'RedHat'
 
     - name: Prepare | Update package cache (RedHat)
       ansible.builtin.dnf:
         update_cache: true
+      retries: 3
+      delay: 5
       when: ansible_facts['os_family'] == 'RedHat'

--- a/roles/firejail/tasks/install.yml
+++ b/roles/firejail/tasks/install.yml
@@ -3,4 +3,6 @@
   ansible.builtin.package:
     name: '{{ __firejail_packages }}'
     state: present
+  retries: 3
+  delay: 5
   notify: apply firecfg

--- a/roles/firewalld/molecule/default/prepare.yml
+++ b/roles/firewalld/molecule/default/prepare.yml
@@ -24,22 +24,30 @@
       community.general.pacman:
         update_cache: true
         upgrade: true
+      retries: 3
+      delay: 5
       when: ansible_facts['os_family'] == 'Archlinux'
 
     - name: Prepare | Update package cache (Debian)
       ansible.builtin.apt:
         update_cache: true
+      retries: 3
+      delay: 5
       when: ansible_facts['os_family'] == 'Debian'
 
     - name: Prepare | Update package cache (RedHat)
       ansible.builtin.dnf:
         update_cache: true
+      retries: 3
+      delay: 5
       when: ansible_facts['os_family'] == 'RedHat'
 
     - name: Prepare | Install container dependencies
       ansible.builtin.package:
         name: '{{ __prepare_packages[ansible_facts["os_family"]] }}'
         state: present
+      retries: 3
+      delay: 5
 
     - name: Prepare | Start dbus
       ansible.builtin.systemd_service:
@@ -55,6 +63,8 @@
           - polkitd
         state: present
         update_cache: true
+      retries: 3
+      delay: 5
       when: ansible_facts['os_family'] == 'Debian'
 
     - name: Prepare | Create polkit rules directories (Debian)

--- a/roles/firewalld/tasks/install.yml
+++ b/roles/firewalld/tasks/install.yml
@@ -3,3 +3,5 @@
   ansible.builtin.package:
     name: '{{ __firewalld_packages }}'
     state: present
+  retries: 3
+  delay: 5

--- a/roles/fonts/molecule/default/prepare.yml
+++ b/roles/fonts/molecule/default/prepare.yml
@@ -9,20 +9,28 @@
       community.general.pacman:
         update_cache: true
         upgrade: true
+      retries: 3
+      delay: 5
       when: ansible_facts['os_family'] == 'Archlinux'
 
     - name: Prepare | Update package cache (Debian)
       ansible.builtin.apt:
         update_cache: true
+      retries: 3
+      delay: 5
       when: ansible_facts['os_family'] == 'Debian'
 
     - name: Prepare | Enable EPEL repository (RedHat)
       ansible.builtin.dnf:
         name: epel-release
         state: present
+      retries: 3
+      delay: 5
       when: ansible_facts['os_family'] == 'RedHat'
 
     - name: Prepare | Update package cache (RedHat)
       ansible.builtin.dnf:
         update_cache: true
+      retries: 3
+      delay: 5
       when: ansible_facts['os_family'] == 'RedHat'

--- a/roles/fonts/tasks/install.yml
+++ b/roles/fonts/tasks/install.yml
@@ -3,6 +3,8 @@
   ansible.builtin.package:
     name: '{{ __fonts_fontconfig_package }}'
     state: present
+  retries: 3
+  delay: 5
 
 - name: Install | Build base font package list
   ansible.builtin.set_fact:
@@ -52,5 +54,7 @@
   ansible.builtin.package:
     name: '{{ __fonts_packages }}'
     state: present
+  retries: 3
+  delay: 5
   when: __fonts_packages | length > 0
   notify: Rebuild font cache

--- a/roles/gnupg/molecule/default/prepare.yml
+++ b/roles/gnupg/molecule/default/prepare.yml
@@ -9,14 +9,20 @@
       community.general.pacman:
         update_cache: true
         upgrade: true
+      retries: 3
+      delay: 5
       when: ansible_facts['os_family'] == 'Archlinux'
 
     - name: Prepare | Update package cache (Debian)
       ansible.builtin.apt:
         update_cache: true
+      retries: 3
+      delay: 5
       when: ansible_facts['os_family'] == 'Debian'
 
     - name: Prepare | Update package cache (RedHat)
       ansible.builtin.dnf:
         update_cache: true
+      retries: 3
+      delay: 5
       when: ansible_facts['os_family'] == 'RedHat'

--- a/roles/gnupg/tasks/install.yml
+++ b/roles/gnupg/tasks/install.yml
@@ -3,15 +3,21 @@
   ansible.builtin.package:
     name: '{{ __gnupg_packages }}'
     state: present
+  retries: 3
+  delay: 5
 
 - name: Install | Additional tools
   ansible.builtin.package:
     name: '{{ __gnupg_tools_packages }}'
     state: present
+  retries: 3
+  delay: 5
   when: gnupg_tools_enabled | default(true) | bool
 
 - name: Install | GUI packages
   ansible.builtin.package:
     name: '{{ __gnupg_gui_packages }}'
     state: present
+  retries: 3
+  delay: 5
   when: gnupg_gui_enabled | default(false) | bool

--- a/roles/graphics/molecule/default/prepare.yml
+++ b/roles/graphics/molecule/default/prepare.yml
@@ -9,16 +9,22 @@
       community.general.pacman:
         update_cache: true
         upgrade: true
+      retries: 3
+      delay: 5
       when: ansible_facts['os_family'] == 'Archlinux'
 
     - name: Prepare | Update package cache (Debian)
       ansible.builtin.apt:
         update_cache: true
+      retries: 3
+      delay: 5
       when: ansible_facts['os_family'] == 'Debian'
 
     - name: Prepare | Update package cache (RedHat)
       ansible.builtin.dnf:
         update_cache: true
+      retries: 3
+      delay: 5
       when: ansible_facts['os_family'] == 'RedHat'
 
     - name: Prepare | Ensure /etc/modprobe.d exists

--- a/roles/graphics/tasks/amd.yml
+++ b/roles/graphics/tasks/amd.yml
@@ -15,4 +15,6 @@
   ansible.builtin.package:
     name: '{{ __amd_packages }}'
     state: present
+  retries: 3
+  delay: 5
   when: __amd_packages | length > 0

--- a/roles/graphics/tasks/hybrid.yml
+++ b/roles/graphics/tasks/hybrid.yml
@@ -3,6 +3,8 @@
   ansible.builtin.package:
     name: '{{ __graphics_hybrid_switcheroo }}'
     state: present
+  retries: 3
+  delay: 5
   when:
     - graphics_hybrid_switcheroo_enabled | bool
     - __graphics_hybrid_switcheroo | length > 0
@@ -21,6 +23,8 @@
   ansible.builtin.package:
     name: '{{ __graphics_hybrid_prime_run }}'
     state: present
+  retries: 3
+  delay: 5
   when:
     - graphics_hybrid_prime_run_enabled | bool
     - __graphics_hybrid_prime_run | length > 0

--- a/roles/graphics/tasks/intel.yml
+++ b/roles/graphics/tasks/intel.yml
@@ -21,4 +21,6 @@
   ansible.builtin.package:
     name: '{{ __intel_packages }}'
     state: present
+  retries: 3
+  delay: 5
   when: __intel_packages | length > 0

--- a/roles/graphics/tasks/nvidia.yml
+++ b/roles/graphics/tasks/nvidia.yml
@@ -40,6 +40,8 @@
   ansible.builtin.package:
     name: '{{ __nvidia_packages }}'
     state: present
+  retries: 3
+  delay: 5
   when:
     - __nvidia_packages | length > 0
     - not (graphics_nvidia_legacy_version | length > 0 and __graphics_nvidia_legacy_aur | default(false))

--- a/roles/graphics/tasks/tools.yml
+++ b/roles/graphics/tasks/tools.yml
@@ -17,4 +17,6 @@
   ansible.builtin.package:
     name: '{{ __tools_packages }}'
     state: present
+  retries: 3
+  delay: 5
   when: __tools_packages | length > 0

--- a/roles/hardening/molecule/default/prepare.yml
+++ b/roles/hardening/molecule/default/prepare.yml
@@ -9,14 +9,20 @@
       community.general.pacman:
         update_cache: true
         upgrade: true
+      retries: 3
+      delay: 5
       when: ansible_facts['os_family'] == 'Archlinux'
 
     - name: Prepare | Update package cache (Debian)
       ansible.builtin.apt:
         update_cache: true
+      retries: 3
+      delay: 5
       when: ansible_facts['os_family'] == 'Debian'
 
     - name: Prepare | Update package cache (RedHat)
       ansible.builtin.dnf:
         update_cache: true
+      retries: 3
+      delay: 5
       when: ansible_facts['os_family'] == 'RedHat'

--- a/roles/hardware_tokens/molecule/default/prepare.yml
+++ b/roles/hardware_tokens/molecule/default/prepare.yml
@@ -9,20 +9,28 @@
       community.general.pacman:
         update_cache: true
         upgrade: true
+      retries: 3
+      delay: 5
       when: ansible_facts['os_family'] == 'Archlinux'
 
     - name: Prepare | Update package cache (Debian)
       ansible.builtin.apt:
         update_cache: true
+      retries: 3
+      delay: 5
       when: ansible_facts['os_family'] == 'Debian'
 
     - name: Prepare | Enable EPEL repository (RedHat)
       ansible.builtin.dnf:
         name: epel-release
         state: present
+      retries: 3
+      delay: 5
       when: ansible_facts['os_family'] == 'RedHat'
 
     - name: Prepare | Update package cache (RedHat)
       ansible.builtin.dnf:
         update_cache: true
+      retries: 3
+      delay: 5
       when: ansible_facts['os_family'] == 'RedHat'

--- a/roles/hardware_tokens/tasks/install.yml
+++ b/roles/hardware_tokens/tasks/install.yml
@@ -3,29 +3,39 @@
   ansible.builtin.package:
     name: '{{ __hardware_tokens_ccid_package }}'
     state: present
+  retries: 3
+  delay: 5
 
 - name: Install | FIDO2 packages
   ansible.builtin.package:
     name: '{{ __hardware_tokens_fido2_packages }}'
     state: present
+  retries: 3
+  delay: 5
   when: hardware_tokens_fido2_enabled | bool
 
 - name: Install | Smartcard packages
   ansible.builtin.package:
     name: '{{ __hardware_tokens_smartcard_packages }}'
     state: present
+  retries: 3
+  delay: 5
   when: hardware_tokens_smartcard_enabled | bool
 
 - name: Install | OpenSC
   ansible.builtin.package:
     name: '{{ __hardware_tokens_opensc_package }}'
     state: present
+  retries: 3
+  delay: 5
   when: hardware_tokens_opensc_enabled | bool
 
 - name: Install | NitroKey packages
   ansible.builtin.package:
     name: '{{ __hardware_tokens_nitrokey_packages }}'
     state: present
+  retries: 3
+  delay: 5
   when:
     - hardware_tokens_nitrokey_enabled | bool
     - __hardware_tokens_nitrokey_packages | length > 0
@@ -34,6 +44,8 @@
   ansible.builtin.package:
     name: '{{ __hardware_tokens_nitrokey_app_package }}'
     state: present
+  retries: 3
+  delay: 5
   when:
     - hardware_tokens_nitrokey_enabled | bool
     - hardware_tokens_nitrokey_app_enabled | bool
@@ -43,12 +55,16 @@
   ansible.builtin.package:
     name: '{{ __hardware_tokens_yubikey_packages }}'
     state: present
+  retries: 3
+  delay: 5
   when: hardware_tokens_yubikey_enabled | bool
 
 - name: Install | YubiKey Manager
   ansible.builtin.package:
     name: '{{ __hardware_tokens_yubikey_manager_package }}'
     state: present
+  retries: 3
+  delay: 5
   when:
     - hardware_tokens_yubikey_enabled | bool
     - hardware_tokens_yubikey_manager_enabled | bool
@@ -58,4 +74,6 @@
   ansible.builtin.package:
     name: '{{ __hardware_tokens_pam_u2f_package }}'
     state: present
+  retries: 3
+  delay: 5
   when: hardware_tokens_pam_u2f_enabled | bool

--- a/roles/logrotate/molecule/default/prepare.yml
+++ b/roles/logrotate/molecule/default/prepare.yml
@@ -19,20 +19,28 @@
       community.general.pacman:
         update_cache: true
         upgrade: true
+      retries: 3
+      delay: 5
       when: ansible_facts['os_family'] == 'Archlinux'
 
     - name: Prepare | Update package cache (Debian)
       ansible.builtin.apt:
         update_cache: true
+      retries: 3
+      delay: 5
       when: ansible_facts['os_family'] == 'Debian'
 
     - name: Prepare | Update package cache (RedHat)
       ansible.builtin.dnf:
         update_cache: true
+      retries: 3
+      delay: 5
       when: ansible_facts['os_family'] == 'RedHat'
 
     - name: Prepare | Install container dependencies
       ansible.builtin.package:
         name: '{{ __prepare_packages[ansible_facts["os_family"]] }}'
         state: present
+      retries: 3
+      delay: 5
       when: __prepare_packages[ansible_facts['os_family']] | length > 0

--- a/roles/logrotate/tasks/install.yml
+++ b/roles/logrotate/tasks/install.yml
@@ -3,6 +3,8 @@
   ansible.builtin.package:
     name: '{{ __logrotate_packages }}'
     state: present
+  retries: 3
+  delay: 5
 
 - name: Install | Ensure logrotate.d directory exists
   ansible.builtin.file:

--- a/roles/lynis/molecule/default/prepare.yml
+++ b/roles/lynis/molecule/default/prepare.yml
@@ -9,17 +9,23 @@
       community.general.pacman:
         update_cache: true
         upgrade: true
+      retries: 3
+      delay: 5
       when: ansible_facts['os_family'] == 'Archlinux'
 
     - name: Prepare | Update package cache (Debian)
       ansible.builtin.apt:
         update_cache: true
+      retries: 3
+      delay: 5
       when: ansible_facts['os_family'] == 'Debian'
 
     - name: Prepare | Enable EPEL repository (EL 9)
       ansible.builtin.dnf:
         name: epel-release
         state: present
+      retries: 3
+      delay: 5
       when:
         - ansible_facts['os_family'] == 'RedHat'
         - ansible_facts['distribution_major_version'] == '9'
@@ -27,12 +33,16 @@
     - name: Prepare | Update package cache (RedHat)
       ansible.builtin.dnf:
         update_cache: true
+      retries: 3
+      delay: 5
       when: ansible_facts['os_family'] == 'RedHat'
 
     - name: Prepare | Install git for EL 10 (git install method)
       ansible.builtin.package:
         name: git
         state: present
+      retries: 3
+      delay: 5
       when:
         - ansible_facts['os_family'] == 'RedHat'
         - ansible_facts['distribution_major_version'] == '10'

--- a/roles/lynis/tasks/install.yml
+++ b/roles/lynis/tasks/install.yml
@@ -3,6 +3,8 @@
   ansible.builtin.package:
     name: '{{ __lynis_packages }}'
     state: present
+  retries: 3
+  delay: 5
   when:
     - lynis_install_method == 'package'
     - __lynis_packages | length > 0
@@ -11,6 +13,8 @@
   ansible.builtin.package:
     name: git
     state: present
+  retries: 3
+  delay: 5
   when: lynis_install_method == 'git'
 
 - name: Install | Clone lynis from GitHub
@@ -19,6 +23,8 @@
     dest: '{{ lynis_install_dir }}'
     version: '{{ lynis_version }}'
     update: true
+  retries: 5
+  delay: 10
   when: lynis_install_method == 'git'
 
 - name: Install | Create lynis symlink

--- a/roles/networkmanager/molecule/default/prepare.yml
+++ b/roles/networkmanager/molecule/default/prepare.yml
@@ -14,22 +14,30 @@
       community.general.pacman:
         update_cache: true
         upgrade: true
+      retries: 3
+      delay: 5
       when: ansible_facts['os_family'] == 'Archlinux'
 
     - name: Prepare | Update package cache (Debian)
       ansible.builtin.apt:
         update_cache: true
+      retries: 3
+      delay: 5
       when: ansible_facts['os_family'] == 'Debian'
 
     - name: Prepare | Update package cache (RedHat)
       ansible.builtin.dnf:
         update_cache: true
+      retries: 3
+      delay: 5
       when: ansible_facts['os_family'] == 'RedHat'
 
     - name: Prepare | Install VM dependencies
       ansible.builtin.package:
         name: '{{ __prepare_packages[ansible_facts["os_family"]] }}'
         state: present
+      retries: 3
+      delay: 5
       when: ansible_facts['os_family'] in __prepare_packages
 
     # WiFi simulation (Arch only)
@@ -39,6 +47,8 @@
           - iw
           - hostapd
         state: present
+      retries: 3
+      delay: 5
       when: ansible_facts['os_family'] == 'Archlinux'
 
     - name: Prepare | Unload mac80211_hwsim module if loaded

--- a/roles/networkmanager/tasks/install.yml
+++ b/roles/networkmanager/tasks/install.yml
@@ -3,24 +3,32 @@
   ansible.builtin.package:
     name: '{{ __networkmanager_packages }}'
     state: present
+  retries: 3
+  delay: 5
   when: __networkmanager_packages | length > 0
 
 - name: Install | NetworkManager applet
   ansible.builtin.package:
     name: '{{ __networkmanager_applet_packages }}'
     state: present
+  retries: 3
+  delay: 5
   when: networkmanager_applet_enabled | bool
 
 - name: Install | VPN plugins
   ansible.builtin.package:
     name: '{{ networkmanager_vpn_plugins }}'
     state: present
+  retries: 3
+  delay: 5
   when: networkmanager_vpn_plugins | length > 0
 
 - name: Install | Optional dependencies
   ansible.builtin.package:
     name: '{{ item.name }}'
     state: present
+  retries: 3
+  delay: 5
   loop:
     - { name: curl, needed: "{{ networkmanager_timezone_enabled }}" }
     - { name: cifs-utils, needed: "{{ networkmanager_smb_shares | length > 0 }}" }

--- a/roles/nodejs/molecule/default/prepare.yml
+++ b/roles/nodejs/molecule/default/prepare.yml
@@ -20,20 +20,28 @@
       community.general.pacman:
         update_cache: true
         upgrade: true
+      retries: 3
+      delay: 5
       when: ansible_facts['os_family'] == 'Archlinux'
 
     - name: Prepare | Update package cache (Debian)
       ansible.builtin.apt:
         update_cache: true
+      retries: 3
+      delay: 5
       when: ansible_facts['os_family'] == 'Debian'
 
     - name: Prepare | Update package cache (RedHat)
       ansible.builtin.dnf:
         update_cache: true
+      retries: 3
+      delay: 5
       when: ansible_facts['os_family'] == 'RedHat'
 
     - name: Prepare | Install container dependencies
       ansible.builtin.package:
         name: '{{ __prepare_packages[ansible_facts["os_family"]] }}'
         state: present
+      retries: 3
+      delay: 5
       when: __prepare_packages[ansible_facts["os_family"]] | length > 0

--- a/roles/nodejs/tasks/install_nodesource.yml
+++ b/roles/nodejs/tasks/install_nodesource.yml
@@ -8,12 +8,16 @@
     name: '{{ __nodejs_prerequisite_packages }}'
     state: present
     update_cache: true
+  retries: 3
+  delay: 5
   when: ansible_facts['os_family'] == 'Debian'
 
 - name: Install NodeSource | Prerequisite packages (RedHat)
   ansible.builtin.package:
     name: '{{ __nodejs_prerequisite_packages }}'
     state: present
+  retries: 3
+  delay: 5
   when: ansible_facts['os_family'] == 'RedHat'
 
 #
@@ -27,6 +31,8 @@
     owner: root
     group: root
     mode: '0644'
+  retries: 5
+  delay: 10
   when: ansible_facts['os_family'] == 'Debian'
 
 - name: Install NodeSource | Add repository (Debian)
@@ -34,6 +40,8 @@
     repo: '{{ __nodejs_nodesource_repo }}'
     state: present
     filename: nodesource
+  retries: 5
+  delay: 10
   when: ansible_facts['os_family'] == 'Debian'
 
 - name: Install NodeSource | Node.js packages (Debian)
@@ -41,6 +49,8 @@
     name: '{{ __nodejs_packages }}'
     state: present
     update_cache: true
+  retries: 3
+  delay: 5
   when: ansible_facts['os_family'] == 'Debian'
 
 #
@@ -133,6 +143,8 @@
           ansible.builtin.package:
             name: nodejs
             state: present
+          retries: 3
+          delay: 5
 
     # --- Path B: AppStream doesn't have it, use NodeSource ---
 
@@ -155,11 +167,15 @@
             gpgcheck: true
             module_hotfixes: true
             priority: '9'
+          retries: 5
+          delay: 10
 
         - name: Install NodeSource | Node.js from NodeSource (RedHat < 10)
           ansible.builtin.package:
             name: '{{ __nodejs_packages }}'
             state: present
+          retries: 3
+          delay: 5
 
 # --- Rocky 10+: No modularity, use NodeSource directly ---
 
@@ -179,15 +195,21 @@
         gpgkey: '{{ __nodejs_nodesource_key_url }}'
         gpgcheck: true
         priority: '9'
+      retries: 5
+      delay: 10
 
     - name: Install NodeSource | Node.js from NodeSource (RedHat >= 10)
       ansible.builtin.package:
         name: '{{ __nodejs_packages }}'
         state: present
+      retries: 3
+      delay: 5
 
 # Ensure npm is always present (separate package on RedHat)
 - name: Install NodeSource | Ensure npm is installed (RedHat)
   ansible.builtin.package:
     name: npm
     state: present
+  retries: 3
+  delay: 5
   when: ansible_facts['os_family'] == 'RedHat'

--- a/roles/nodejs/tasks/install_nvm.yml
+++ b/roles/nodejs/tasks/install_nvm.yml
@@ -9,6 +9,8 @@
   ansible.builtin.package:
     name: '{{ __nodejs_nvm_packages }}'
     state: present
+  retries: 3
+  delay: 5
   when: ansible_facts['os_family'] == 'Archlinux'
 
 - name: Install NVM | Per-user install

--- a/roles/nodejs/tasks/install_nvm_user.yml
+++ b/roles/nodejs/tasks/install_nvm_user.yml
@@ -38,6 +38,8 @@
         mode: '0700'
         owner: '{{ __nodejs_nvm_user }}'
         group: '{{ __nodejs_nvm_user }}'
+      retries: 5
+      delay: 10
       register: __nodejs_nvm_script
 
     - name: Install NVM User | Run nvm install script

--- a/roles/nodejs/tasks/install_package.yml
+++ b/roles/nodejs/tasks/install_package.yml
@@ -3,3 +3,5 @@
   ansible.builtin.package:
     name: '{{ __nodejs_packages }}'
     state: present
+  retries: 3
+  delay: 5

--- a/roles/nodejs/tasks/package_managers.yml
+++ b/roles/nodejs/tasks/package_managers.yml
@@ -4,6 +4,8 @@
     name: pnpm
     global: true
     state: present
+  retries: 3
+  delay: 5
   environment: >-
     {{
       {'HTTP_PROXY': nodejs_npm_proxy, 'HTTPS_PROXY': nodejs_npm_proxy}
@@ -17,6 +19,8 @@
     name: yarn
     global: true
     state: present
+  retries: 3
+  delay: 5
   environment: >-
     {{
       {'HTTP_PROXY': nodejs_npm_proxy, 'HTTPS_PROXY': nodejs_npm_proxy}

--- a/roles/openssh/molecule/default/prepare.yml
+++ b/roles/openssh/molecule/default/prepare.yml
@@ -9,16 +9,22 @@
       community.general.pacman:
         update_cache: true
         upgrade: true
+      retries: 3
+      delay: 5
       when: ansible_facts['os_family'] == 'Archlinux'
 
     - name: Prepare | Update package cache (Debian)
       ansible.builtin.apt:
         update_cache: true
+      retries: 3
+      delay: 5
       when: ansible_facts['os_family'] == 'Debian'
 
     - name: Prepare | Update package cache (RedHat)
       ansible.builtin.dnf:
         update_cache: true
+      retries: 3
+      delay: 5
       when: ansible_facts['os_family'] == 'RedHat'
 
     - name: Prepare | Create sshd privilege separation directory

--- a/roles/openssh/tasks/install.yml
+++ b/roles/openssh/tasks/install.yml
@@ -3,11 +3,15 @@
   ansible.builtin.package:
     name: '{{ __openssh_packages }}'
     state: present
+  retries: 3
+  delay: 5
 
 - name: Install | ssh-audit
   ansible.builtin.package:
     name: '{{ __openssh_ssh_audit_package }}'
     state: present
+  retries: 3
+  delay: 5
   when: openssh_ssh_audit_enabled | bool
   # Package may not be available in all repositories
   failed_when: false
@@ -16,4 +20,6 @@
   ansible.builtin.package:
     name: '{{ openssh_askpass_package | default(__openssh_askpass_package) }}'
     state: present
+  retries: 3
+  delay: 5
   when: openssh_askpass_enabled | bool

--- a/roles/package_management/molecule/default/prepare.yml
+++ b/roles/package_management/molecule/default/prepare.yml
@@ -9,14 +9,20 @@
       community.general.pacman:
         update_cache: true
         upgrade: true
+      retries: 3
+      delay: 5
       when: ansible_facts['os_family'] == 'Archlinux'
 
     - name: Prepare | Update package cache (Debian)
       ansible.builtin.apt:
         update_cache: true
+      retries: 3
+      delay: 5
       when: ansible_facts['os_family'] == 'Debian'
 
     - name: Prepare | Update package cache (RedHat)
       ansible.builtin.dnf:
         update_cache: true
+      retries: 3
+      delay: 5
       when: ansible_facts['os_family'] == 'RedHat'

--- a/roles/package_management/tasks/archlinux/aur.yml
+++ b/roles/package_management/tasks/archlinux/aur.yml
@@ -5,6 +5,8 @@
       - git
       - base-devel
     state: present
+  retries: 3
+  delay: 5
 
 - name: AUR | Create builder group
   ansible.builtin.group:

--- a/roles/package_management/tasks/archlinux/makepkg.yml
+++ b/roles/package_management/tasks/archlinux/makepkg.yml
@@ -3,6 +3,8 @@
   ansible.builtin.package:
     name: 'base-devel'
     state: present
+  retries: 3
+  delay: 5
 
 - name: Makepkg | Deploy makepkg.conf
   ansible.builtin.template:
@@ -17,18 +19,24 @@
   ansible.builtin.package:
     name: 'ccache'
     state: present
+  retries: 3
+  delay: 5
   when: makepkg_ccache_enabled | bool
 
 - name: Makepkg | Install sccache
   ansible.builtin.package:
     name: 'sccache'
     state: present
+  retries: 3
+  delay: 5
   when: makepkg_sccache_enabled | bool
 
 - name: Makepkg | Install distcc
   ansible.builtin.package:
     name: 'distcc'
     state: present
+  retries: 3
+  delay: 5
   when: makepkg_distcc_enabled | bool
 
 #

--- a/roles/package_management/tasks/archlinux/pacman.yml
+++ b/roles/package_management/tasks/archlinux/pacman.yml
@@ -18,6 +18,8 @@
   when: item.key_id is defined
   register: __package_management_gpg_import
   changed_when: "'imported' in __package_management_gpg_import.stdout"
+  retries: 5
+  delay: 10
   failed_when:
     - __package_management_gpg_import.rc != 0
     - "'already in keyring' not in __package_management_gpg_import.stderr"
@@ -62,6 +64,8 @@
   ansible.builtin.package:
     name: 'pacman-contrib'
     state: present
+  retries: 3
+  delay: 5
 
 - name: Pacman | Configure paccache
   ansible.builtin.lineinfile:

--- a/roles/package_management/tasks/archlinux/reflector.yml
+++ b/roles/package_management/tasks/archlinux/reflector.yml
@@ -3,6 +3,8 @@
   ansible.builtin.package:
     name: 'reflector'
     state: present
+  retries: 3
+  delay: 5
 
 - name: Reflector | Deploy reflector.conf
   ansible.builtin.template:

--- a/roles/package_management/tasks/archlinux/tools.yml
+++ b/roles/package_management/tasks/archlinux/tools.yml
@@ -3,12 +3,16 @@
   ansible.builtin.package:
     name: 'rebuild-detector'
     state: present
+  retries: 3
+  delay: 5
   when: pacman_rebuild_detector_enabled | bool
 
 - name: Tools | Install pkgfile
   ansible.builtin.package:
     name: 'pkgfile'
     state: present
+  retries: 3
+  delay: 5
   when: pacman_pkgfile_enabled | bool
   notify: 'pkgfile installed'
 
@@ -25,6 +29,8 @@
     name: 'informant'
     use: '{{ aur_helper }}'
     state: present
+  retries: 3
+  delay: 5
   when:
     - pacman_informant_enabled | bool
     - aur_helper | length > 0

--- a/roles/package_management/tasks/debian/apt.yml
+++ b/roles/package_management/tasks/debian/apt.yml
@@ -40,3 +40,5 @@
       - gnupg
       - curl
     state: present
+  retries: 3
+  delay: 5

--- a/roles/package_management/tasks/debian/repos.yml
+++ b/roles/package_management/tasks/debian/repos.yml
@@ -8,6 +8,8 @@
     repo: "deb http://deb.debian.org/debian {{ ansible_facts['distribution_release'] }}-backports main contrib non-free"
     state: present
     filename: 'backports'
+  retries: 5
+  delay: 10
   when:
     - apt_backports_enabled | bool
     - ansible_facts['distribution'] == 'Debian'
@@ -21,6 +23,8 @@
   ansible.builtin.apt_repository:
     repo: '{{ item }}'
     state: present
+  retries: 5
+  delay: 10
   loop: '{{ apt_ppas }}'
   when:
     - apt_ppas | length > 0
@@ -41,6 +45,8 @@
         owner: root
         group: root
         mode: '0644'
+      retries: 5
+      delay: 10
 
     - name: Repos | Add PostgreSQL repository
       ansible.builtin.apt_repository:
@@ -50,6 +56,8 @@
           {{ ansible_facts['distribution_release'] }}-pgdg main
         state: present
         filename: 'postgresql'
+      retries: 5
+      delay: 10
       notify: 'apt configuration changed'
 
 #
@@ -66,6 +74,8 @@
         owner: root
         group: root
         mode: '0644'
+      retries: 5
+      delay: 10
       when: ansible_facts['distribution'] == 'Debian'
 
     - name: Repos | Add PHP Sury repository (Debian)
@@ -75,6 +85,8 @@
           https://packages.sury.org/php/ {{ ansible_facts['distribution_release'] }} main
         state: present
         filename: 'php-sury'
+      retries: 5
+      delay: 10
       when: ansible_facts['distribution'] == 'Debian'
       notify: 'apt configuration changed'
 
@@ -82,6 +94,8 @@
       ansible.builtin.apt_repository:
         repo: 'ppa:ondrej/php'
         state: present
+      retries: 5
+      delay: 10
       when: ansible_facts['distribution'] == 'Ubuntu'
       notify: 'apt configuration changed'
 
@@ -99,6 +113,8 @@
         owner: root
         group: root
         mode: '0644'
+      retries: 5
+      delay: 10
 
     - name: Repos | Add Grafana repository
       ansible.builtin.apt_repository:
@@ -107,6 +123,8 @@
           https://apt.grafana.com stable main
         state: present
         filename: 'grafana'
+      retries: 5
+      delay: 10
       notify: 'apt configuration changed'
 
 #
@@ -123,6 +141,8 @@
         owner: root
         group: root
         mode: '0644'
+      retries: 5
+      delay: 10
 
     - name: Repos | Add Kubernetes repository
       ansible.builtin.apt_repository:
@@ -131,6 +151,8 @@
           https://pkgs.k8s.io/core:/stable:/v{{ apt_kubernetes_version }}/deb/ /
         state: present
         filename: 'kubernetes'
+      retries: 5
+      delay: 10
       notify: 'apt configuration changed'
 
 #
@@ -144,6 +166,8 @@
     owner: root
     group: root
     mode: '0644'
+  retries: 5
+  delay: 10
   loop: '{{ apt_custom_repos }}'
   loop_control:
     label: '{{ item.name }}'
@@ -156,6 +180,8 @@
     repo: '{{ item.repo }}'
     state: present
     filename: '{{ item.name }}'
+  retries: 5
+  delay: 10
   loop: '{{ apt_custom_repos }}'
   loop_control:
     label: '{{ item.name }}'

--- a/roles/package_management/tasks/debian/tools.yml
+++ b/roles/package_management/tasks/debian/tools.yml
@@ -3,6 +3,8 @@
   ansible.builtin.package:
     name: 'apt-file'
     state: present
+  retries: 3
+  delay: 5
   when: apt_apt_file_enabled | bool
   notify: 'apt-file installed'
 
@@ -10,6 +12,8 @@
   ansible.builtin.package:
     name: 'needrestart'
     state: present
+  retries: 3
+  delay: 5
   when: apt_needrestart_enabled | bool
 
 - name: Tools | Configure needrestart mode
@@ -26,10 +30,14 @@
   ansible.builtin.package:
     name: 'debsums'
     state: present
+  retries: 3
+  delay: 5
   when: apt_debsums_enabled | bool
 
 - name: Tools | Install debian-goodies
   ansible.builtin.package:
     name: 'debian-goodies'
     state: present
+  retries: 3
+  delay: 5
   when: apt_debian_goodies_enabled | bool

--- a/roles/package_management/tasks/debian/unattended.yml
+++ b/roles/package_management/tasks/debian/unattended.yml
@@ -5,6 +5,8 @@
       - unattended-upgrades
       - apt-listchanges
     state: present
+  retries: 3
+  delay: 5
 
 - name: Unattended | Deploy unattended-upgrades config
   ansible.builtin.template:

--- a/roles/package_management/tasks/redhat/automatic.yml
+++ b/roles/package_management/tasks/redhat/automatic.yml
@@ -3,6 +3,8 @@
   ansible.builtin.package:
     name: 'dnf-automatic'
     state: present
+  retries: 3
+  delay: 5
 
 - name: Automatic | Deploy dnf-automatic config
   ansible.builtin.template:

--- a/roles/package_management/tasks/redhat/dnf.yml
+++ b/roles/package_management/tasks/redhat/dnf.yml
@@ -13,12 +13,16 @@
   ansible.builtin.package:
     name: 'dnf-plugins-core'
     state: present
+  retries: 3
+  delay: 5
   when: ansible_facts['distribution_major_version'] | int < 10
 
 - name: DNF | Install fastest mirror plugin (EL8 only)
   ansible.builtin.package:
     name: 'dnf-plugin-fastestmirror'
     state: "{{ 'present' if dnf_fastestmirror | bool else 'absent' }}"
+  retries: 3
+  delay: 5
   when:
     - ansible_facts['distribution'] != 'Fedora'
     - ansible_facts['distribution_major_version'] | int < 9

--- a/roles/package_management/tasks/redhat/repos.yml
+++ b/roles/package_management/tasks/redhat/repos.yml
@@ -70,6 +70,8 @@
   ansible.builtin.rpm_key:
     key: "/etc/pki/rpm-gpg/RPM-GPG-KEY-{{ __distro }}-{{ __distro_ver }}"
     state: present
+  retries: 5
+  delay: 10
   when:
     - dnf_epel_enabled | bool
     - ansible_facts['distribution'] in ['Rocky', 'AlmaLinux']
@@ -78,6 +80,8 @@
   ansible.builtin.package:
     name: 'epel-release'
     state: present
+  retries: 3
+  delay: 5
   when:
     - dnf_epel_enabled | bool
     - ansible_facts['distribution'] != 'Fedora'
@@ -97,6 +101,8 @@
         name: "https://rpms.remirepo.net/enterprise/remi-release-{{ ansible_facts['distribution_major_version'] }}.rpm"
         state: present
         disable_gpg_check: true
+      retries: 5
+      delay: 10
       notify: 'dnf configuration changed'
 
     - name: Repos | Check current PHP module stream
@@ -132,6 +138,8 @@
       https://mirrors.rpmfusion.org/free/{{ __rpmfusion_distro }}/rpmfusion-free-release-{{ __distro_ver }}.noarch.rpm
     state: present
     disable_gpg_check: true
+  retries: 5
+  delay: 10
   when: dnf_rpmfusion_free_enabled | bool
   notify: 'dnf configuration changed'
 
@@ -150,6 +158,8 @@
       __distro_ver }}.noarch.rpm
     state: present
     disable_gpg_check: true
+  retries: 5
+  delay: 10
   when: dnf_rpmfusion_nonfree_enabled | bool
   notify: 'dnf configuration changed'
 
@@ -165,6 +175,8 @@
       https://www.elrepo.org/elrepo-release-{{ __distro_ver }}.el{{ __distro_ver }}.elrepo.noarch.rpm
     state: present
     disable_gpg_check: true
+  retries: 5
+  delay: 10
   when:
     - dnf_elrepo_enabled | bool
     - ansible_facts['distribution'] != 'Fedora'
@@ -183,6 +195,8 @@
       __distro_ver }}-x86_64/pgdg-redhat-repo-latest.noarch.rpm
     state: present
     disable_gpg_check: true
+  retries: 5
+  delay: 10
   when:
     - dnf_postgresql_repo_enabled | bool
     - ansible_facts['distribution'] != 'Fedora'
@@ -203,6 +217,8 @@
         gpgkey: 'https://rpm.grafana.com/gpg.key'
         gpgcheck: true
         enabled: true
+      retries: 5
+      delay: 10
       notify: 'dnf configuration changed'
 
 #
@@ -221,6 +237,8 @@
         gpgcheck: true
         enabled: true
         exclude: 'kubelet kubeadm kubectl cri-tools kubernetes-cni'
+      retries: 5
+      delay: 10
       notify: 'dnf configuration changed'
 
 #
@@ -257,6 +275,8 @@
     gpgkey: '{{ item.gpgkey | default(omit) }}'
     gpgcheck: '{{ item.gpgcheck | default(true) }}'
     enabled: '{{ item.enabled | default(true) }}'
+  retries: 5
+  delay: 10
   loop: '{{ dnf_custom_repos }}'
   loop_control:
     label: '{{ item.name }}'

--- a/roles/package_management/tasks/redhat/tools.yml
+++ b/roles/package_management/tasks/redhat/tools.yml
@@ -3,6 +3,8 @@
   ansible.builtin.package:
     name: 'dnf-utils'
     state: present
+  retries: 3
+  delay: 5
   when:
     - dnf_utils_enabled | bool
     - ansible_facts['distribution_major_version'] | int < 10
@@ -11,6 +13,8 @@
   ansible.builtin.package:
     name: 'yum-utils'
     state: present
+  retries: 3
+  delay: 5
   when:
     - dnf_needs_restarting_enabled | bool
     - ansible_facts['distribution_major_version'] | int < 10
@@ -21,12 +25,16 @@
       - rpm-build
       - rpmdevtools
     state: present
+  retries: 3
+  delay: 5
   when: dnf_rpmbuild_enabled | bool
 
 - name: Tools | Install mock for chroot building
   ansible.builtin.package:
     name: 'mock'
     state: present
+  retries: 3
+  delay: 5
   when: dnf_mock_enabled | bool
 
 - name: Tools | Add users to mock group

--- a/roles/pam_hardening/molecule/default/prepare.yml
+++ b/roles/pam_hardening/molecule/default/prepare.yml
@@ -9,14 +9,20 @@
       community.general.pacman:
         update_cache: true
         upgrade: true
+      retries: 3
+      delay: 5
       when: ansible_facts['os_family'] == 'Archlinux'
 
     - name: Prepare | Update package cache (Debian)
       ansible.builtin.apt:
         update_cache: true
+      retries: 3
+      delay: 5
       when: ansible_facts['os_family'] == 'Debian'
 
     - name: Prepare | Update package cache (RedHat)
       ansible.builtin.dnf:
         update_cache: true
+      retries: 3
+      delay: 5
       when: ansible_facts['os_family'] == 'RedHat'

--- a/roles/pam_hardening/tasks/install.yml
+++ b/roles/pam_hardening/tasks/install.yml
@@ -3,15 +3,21 @@
   ansible.builtin.package:
     name: '{{ __pam_hardening_packages }}'
     state: present
+  retries: 3
+  delay: 5
 
 - name: Install | libpwquality
   ansible.builtin.package:
     name: '{{ __pam_hardening_pwquality_package }}'
     state: present
+  retries: 3
+  delay: 5
   when: pam_pwquality_enabled | bool
 
 - name: Install | Google Authenticator PAM module
   ansible.builtin.package:
     name: '{{ __pam_hardening_google_authenticator_package }}'
     state: present
+  retries: 3
+  delay: 5
   when: pam_2fa_enabled | bool

--- a/roles/php/molecule/default/prepare.yml
+++ b/roles/php/molecule/default/prepare.yml
@@ -9,11 +9,15 @@
       community.general.pacman:
         update_cache: true
         upgrade: true
+      retries: 3
+      delay: 5
       when: ansible_facts['os_family'] == 'Archlinux'
 
     - name: Prepare | Update package cache (Debian)
       ansible.builtin.apt:
         update_cache: true
+      retries: 3
+      delay: 5
       when: ansible_facts['os_family'] == 'Debian'
 
     - name: Prepare | Install Debian prerequisites
@@ -22,6 +26,8 @@
           - gnupg
           - ca-certificates
         state: present
+      retries: 3
+      delay: 5
       when: ansible_facts['os_family'] == 'Debian'
 
     - name: Prepare | Add Sury GPG key (Debian)
@@ -31,6 +37,8 @@
         owner: root
         group: root
         mode: '0644'
+      retries: 5
+      delay: 10
       when: ansible_facts['distribution'] == 'Debian'
 
     - name: Prepare | Add Sury repository (Debian)
@@ -40,22 +48,30 @@
           https://packages.sury.org/php/ {{ ansible_facts['distribution_release'] }} main
         state: present
         filename: 'php-sury'
+      retries: 5
+      delay: 10
       when: ansible_facts['distribution'] == 'Debian'
 
     - name: Prepare | Update apt cache after Sury (Debian)
       ansible.builtin.apt:
         update_cache: true
+      retries: 3
+      delay: 5
       when: ansible_facts['os_family'] == 'Debian'
 
     - name: Prepare | Update package cache (RedHat)
       ansible.builtin.dnf:
         update_cache: true
+      retries: 3
+      delay: 5
       when: ansible_facts['os_family'] == 'RedHat'
 
     - name: Prepare | Install EPEL (RedHat)
       ansible.builtin.dnf:
         name: epel-release
         state: present
+      retries: 3
+      delay: 5
       when: ansible_facts['os_family'] == 'RedHat'
 
     - name: Prepare | Install Remi repository (RedHat)
@@ -63,9 +79,13 @@
         name: "https://rpms.remirepo.net/enterprise/remi-release-{{ ansible_facts['distribution_major_version'] }}.rpm"
         state: present
         disable_gpg_check: true
+      retries: 3
+      delay: 5
       when: ansible_facts['os_family'] == 'RedHat'
 
     - name: Prepare | Update cache after repos (RedHat)
       ansible.builtin.dnf:
         update_cache: true
+      retries: 3
+      delay: 5
       when: ansible_facts['os_family'] == 'RedHat'

--- a/roles/php/tasks/composer.yml
+++ b/roles/php/tasks/composer.yml
@@ -3,3 +3,5 @@
   ansible.builtin.package:
     name: '{{ __php_composer_package }}'
     state: present
+  retries: 3
+  delay: 5

--- a/roles/php/tasks/install_version.yml
+++ b/roles/php/tasks/install_version.yml
@@ -40,6 +40,8 @@
   ansible.builtin.package:
     name: '{{ __php_version_packages }}'
     state: present
+  retries: 3
+  delay: 5
   when: not (__php_use_aur | bool)
 
 - name: Install Version | PHP packages from AUR (Arch)
@@ -48,6 +50,8 @@
   kewlfft.aur.aur:
     name: '{{ __php_version_packages }}'
     state: present
+  retries: 3
+  delay: 5
   when:
     - ansible_facts['os_family'] == 'Archlinux'
     - __php_use_aur | bool

--- a/roles/pki/molecule/default/prepare.yml
+++ b/roles/pki/molecule/default/prepare.yml
@@ -18,19 +18,27 @@
       community.general.pacman:
         update_cache: true
         upgrade: true
+      retries: 3
+      delay: 5
       when: ansible_facts['os_family'] == 'Archlinux'
 
     - name: Prepare | Update package cache (Debian)
       ansible.builtin.apt:
         update_cache: true
+      retries: 3
+      delay: 5
       when: ansible_facts['os_family'] == 'Debian'
 
     - name: Prepare | Update package cache (RedHat)
       ansible.builtin.dnf:
         update_cache: true
+      retries: 3
+      delay: 5
       when: ansible_facts['os_family'] == 'RedHat'
 
     - name: Prepare | Install container dependencies
       ansible.builtin.package:
         name: '{{ __prepare_packages[ansible_facts["os_family"]] }}'
         state: present
+      retries: 3
+      delay: 5

--- a/roles/pki/tasks/install.yml
+++ b/roles/pki/tasks/install.yml
@@ -3,3 +3,5 @@
   ansible.builtin.package:
     name: '{{ __pki_packages }}'
     state: present
+  retries: 3
+  delay: 5

--- a/roles/podman/molecule/default/prepare.yml
+++ b/roles/podman/molecule/default/prepare.yml
@@ -9,14 +9,20 @@
       community.general.pacman:
         update_cache: true
         upgrade: true
+      retries: 3
+      delay: 5
       when: ansible_facts['os_family'] == 'Archlinux'
 
     - name: Prepare | Update package cache (Debian)
       ansible.builtin.apt:
         update_cache: true
+      retries: 3
+      delay: 5
       when: ansible_facts['os_family'] == 'Debian'
 
     - name: Prepare | Update package cache (RedHat)
       ansible.builtin.dnf:
         update_cache: true
+      retries: 3
+      delay: 5
       when: ansible_facts['os_family'] == 'RedHat'

--- a/roles/podman/tasks/install.yml
+++ b/roles/podman/tasks/install.yml
@@ -3,29 +3,39 @@
   ansible.builtin.package:
     name: '{{ __podman_packages }}'
     state: present
+  retries: 3
+  delay: 5
 
 - name: Install | Additional tools
   ansible.builtin.package:
     name: '{{ podman_tools }}'
     state: present
+  retries: 3
+  delay: 5
   when: podman_tools | length > 0
 
 - name: Install | Podman-compose
   ansible.builtin.package:
     name: '{{ __podman_compose_package }}'
     state: present
+  retries: 3
+  delay: 5
   when: podman_compose_enabled | bool
 
 - name: Install | Podman-docker compatibility
   ansible.builtin.package:
     name: '{{ __podman_docker_package }}'
     state: present
+  retries: 3
+  delay: 5
   when: podman_docker_enabled | bool
 
 - name: Install | Podlet
   ansible.builtin.package:
     name: '{{ __podman_podlet_package }}'
     state: present
+  retries: 3
+  delay: 5
   when:
     - podman_podlet_enabled | bool
     - __podman_podlet_package | length > 0
@@ -36,6 +46,8 @@
   kewlfft.aur.aur:
     name: '{{ __podman_aur_packages.desktop }}'
     state: present
+  retries: 3
+  delay: 5
   when:
     - podman_desktop_enabled | bool
     - ansible_facts['os_family'] == 'Archlinux'

--- a/roles/python/molecule/default/prepare.yml
+++ b/roles/python/molecule/default/prepare.yml
@@ -9,20 +9,28 @@
       community.general.pacman:
         update_cache: true
         upgrade: true
+      retries: 3
+      delay: 5
       when: ansible_facts['os_family'] == 'Archlinux'
 
     - name: Prepare | Update package cache (Debian)
       ansible.builtin.apt:
         update_cache: true
+      retries: 3
+      delay: 5
       when: ansible_facts['os_family'] == 'Debian'
 
     - name: Prepare | Enable EPEL repository (RedHat)
       ansible.builtin.dnf:
         name: epel-release
         state: present
+      retries: 3
+      delay: 5
       when: ansible_facts['os_family'] == 'RedHat'
 
     - name: Prepare | Update package cache (RedHat)
       ansible.builtin.dnf:
         update_cache: true
+      retries: 3
+      delay: 5
       when: ansible_facts['os_family'] == 'RedHat'

--- a/roles/python/tasks/install.yml
+++ b/roles/python/tasks/install.yml
@@ -3,11 +3,15 @@
   ansible.builtin.package:
     name: '{{ __python_packages + __python_pip_packages }}'
     state: present
+  retries: 3
+  delay: 5
 
 - name: Install | pipx
   ansible.builtin.package:
     name: '{{ __python_pipx_packages }}'
     state: present
+  retries: 3
+  delay: 5
   when:
     - python_pipx_enabled | bool
     - __python_pipx_packages | length > 0
@@ -29,6 +33,8 @@
     name: pipx
     state: present
     virtualenv: /opt/pipx-bootstrap
+  retries: 3
+  delay: 5
   when:
     - python_pipx_enabled | bool
     - __python_bootstrap_pipx | default(false) | bool
@@ -43,6 +49,8 @@
   kewlfft.aur.aur:
     name: '{{ __python_aur_packages.extra }}'
     state: present
+  retries: 3
+  delay: 5
   when:
     - ansible_facts['os_family'] == 'Archlinux'
     - __python_aur_packages.extra | default([]) | length > 0
@@ -51,6 +59,8 @@
   ansible.builtin.package:
     name: '{{ python_extra_packages }}'
     state: present
+  retries: 3
+  delay: 5
   when:
     - ansible_facts['os_family'] != 'Archlinux'
     - python_extra_packages | length > 0

--- a/roles/restic/molecule/default/prepare.yml
+++ b/roles/restic/molecule/default/prepare.yml
@@ -9,20 +9,28 @@
       community.general.pacman:
         update_cache: true
         upgrade: true
+      retries: 3
+      delay: 5
       when: ansible_facts['os_family'] == 'Archlinux'
 
     - name: Prepare | Update package cache (Debian)
       ansible.builtin.apt:
         update_cache: true
+      retries: 3
+      delay: 5
       when: ansible_facts['os_family'] == 'Debian'
 
     - name: Prepare | Enable EPEL repository (RedHat)
       ansible.builtin.dnf:
         name: epel-release
         state: present
+      retries: 3
+      delay: 5
       when: ansible_facts['os_family'] == 'RedHat'
 
     - name: Prepare | Update package cache (RedHat)
       ansible.builtin.dnf:
         update_cache: true
+      retries: 3
+      delay: 5
       when: ansible_facts['os_family'] == 'RedHat'

--- a/roles/restic/tasks/install.yml
+++ b/roles/restic/tasks/install.yml
@@ -3,6 +3,8 @@
   ansible.builtin.package:
     name: '{{ __restic_packages }}'
     state: present
+  retries: 3
+  delay: 5
   when: restic_install_from_package | bool
 
 - name: Install | Download restic binary
@@ -12,6 +14,8 @@
       ansible.builtin.package:
         name: '{{ __restic_binary_packages }}'
         state: present
+      retries: 3
+      delay: 5
 
     - name: Install | Download restic archive
       ansible.builtin.get_url:
@@ -20,6 +24,8 @@
         owner: root
         group: root
         mode: '0644'
+      retries: 5
+      delay: 10
 
     - name: Install | Extract restic binary
       ansible.builtin.command:
@@ -44,4 +50,6 @@
   ansible.builtin.package:
     name: '{{ __restic_mail_package }}'
     state: present
+  retries: 3
+  delay: 5
   when: restic_email_on_failure | bool

--- a/roles/rkhunter/molecule/default/prepare.yml
+++ b/roles/rkhunter/molecule/default/prepare.yml
@@ -9,20 +9,28 @@
       community.general.pacman:
         update_cache: true
         upgrade: true
+      retries: 3
+      delay: 5
       when: ansible_facts['os_family'] == 'Archlinux'
 
     - name: Prepare | Update package cache (Debian)
       ansible.builtin.apt:
         update_cache: true
+      retries: 3
+      delay: 5
       when: ansible_facts['os_family'] == 'Debian'
 
     - name: Prepare | Enable EPEL repository (RedHat)
       ansible.builtin.dnf:
         name: epel-release
         state: present
+      retries: 3
+      delay: 5
       when: ansible_facts['os_family'] == 'RedHat'
 
     - name: Prepare | Update package cache (RedHat)
       ansible.builtin.dnf:
         update_cache: true
+      retries: 3
+      delay: 5
       when: ansible_facts['os_family'] == 'RedHat'

--- a/roles/rkhunter/tasks/install.yml
+++ b/roles/rkhunter/tasks/install.yml
@@ -3,6 +3,8 @@
   ansible.builtin.package:
     name: '{{ __rkhunter_packages }}'
     state: present
+  retries: 3
+  delay: 5
 
 - name: Install | Ensure rkhunter directories exist
   ansible.builtin.file:

--- a/roles/snmp/molecule/default/prepare.yml
+++ b/roles/snmp/molecule/default/prepare.yml
@@ -18,20 +18,28 @@
       community.general.pacman:
         update_cache: true
         upgrade: true
+      retries: 3
+      delay: 5
       when: ansible_facts['os_family'] == 'Archlinux'
 
     - name: Prepare | Update package cache (Debian)
       ansible.builtin.apt:
         update_cache: true
+      retries: 3
+      delay: 5
       when: ansible_facts['os_family'] == 'Debian'
 
     - name: Prepare | Update package cache (RedHat)
       ansible.builtin.dnf:
         update_cache: true
+      retries: 3
+      delay: 5
       when: ansible_facts['os_family'] == 'RedHat'
 
     - name: Prepare | Install container dependencies
       ansible.builtin.package:
         name: '{{ __prepare_packages[ansible_facts["os_family"]] }}'
         state: present
+      retries: 3
+      delay: 5
       when: ansible_facts['os_family'] in __prepare_packages

--- a/roles/snmp/tasks/install.yml
+++ b/roles/snmp/tasks/install.yml
@@ -3,4 +3,6 @@
   ansible.builtin.package:
     name: '{{ __snmp_packages }}'
     state: present
+  retries: 3
+  delay: 5
   register: __snmp_install

--- a/roles/sudo/molecule/default/prepare.yml
+++ b/roles/sudo/molecule/default/prepare.yml
@@ -9,14 +9,20 @@
       community.general.pacman:
         update_cache: true
         upgrade: true
+      retries: 3
+      delay: 5
       when: ansible_facts['os_family'] == 'Archlinux'
 
     - name: Prepare | Update package cache (Debian)
       ansible.builtin.apt:
         update_cache: true
+      retries: 3
+      delay: 5
       when: ansible_facts['os_family'] == 'Debian'
 
     - name: Prepare | Update package cache (RedHat)
       ansible.builtin.dnf:
         update_cache: true
+      retries: 3
+      delay: 5
       when: ansible_facts['os_family'] == 'RedHat'

--- a/roles/sudo/tasks/install.yml
+++ b/roles/sudo/tasks/install.yml
@@ -3,3 +3,5 @@
   ansible.builtin.package:
     name: '{{ __sudo_packages }}'
     state: present
+  retries: 3
+  delay: 5

--- a/roles/sysctl/molecule/default/prepare.yml
+++ b/roles/sysctl/molecule/default/prepare.yml
@@ -9,14 +9,20 @@
       community.general.pacman:
         update_cache: true
         upgrade: true
+      retries: 3
+      delay: 5
       when: ansible_facts['os_family'] == 'Archlinux'
 
     - name: Prepare | Update package cache (Debian)
       ansible.builtin.apt:
         update_cache: true
+      retries: 3
+      delay: 5
       when: ansible_facts['os_family'] == 'Debian'
 
     - name: Prepare | Update package cache (RedHat)
       ansible.builtin.dnf:
         update_cache: true
+      retries: 3
+      delay: 5
       when: ansible_facts['os_family'] == 'RedHat'

--- a/roles/sysctl/tasks/install.yml
+++ b/roles/sysctl/tasks/install.yml
@@ -3,6 +3,8 @@
   ansible.builtin.package:
     name: '{{ __sysctl_packages }}'
     state: present
+  retries: 3
+  delay: 5
 
 - name: Install | Load br_netfilter module for Docker profile
   community.general.modprobe:

--- a/roles/unbound/molecule/default/prepare.yml
+++ b/roles/unbound/molecule/default/prepare.yml
@@ -18,22 +18,30 @@
       community.general.pacman:
         update_cache: true
         upgrade: true
+      retries: 3
+      delay: 5
       when: ansible_facts['os_family'] == 'Archlinux'
 
     - name: Prepare | Update package cache (Debian)
       ansible.builtin.apt:
         update_cache: true
+      retries: 3
+      delay: 5
       when: ansible_facts['os_family'] == 'Debian'
 
     - name: Prepare | Update package cache (RedHat)
       ansible.builtin.dnf:
         update_cache: true
+      retries: 3
+      delay: 5
       when: ansible_facts['os_family'] == 'RedHat'
 
     - name: Prepare | Install container dependencies
       ansible.builtin.package:
         name: '{{ __prepare_packages[ansible_facts["os_family"]] }}'
         state: present
+      retries: 3
+      delay: 5
 
     - name: Prepare | Detect unbound binary path
       ansible.builtin.command:

--- a/roles/unbound/tasks/install.yml
+++ b/roles/unbound/tasks/install.yml
@@ -3,6 +3,8 @@
   ansible.builtin.package:
     name: '{{ __unbound_packages }}'
     state: present
+  retries: 3
+  delay: 5
 
 - name: Install | Ensure config directory exists
   ansible.builtin.file:
@@ -27,6 +29,8 @@
     owner: '{{ __unbound_user }}'
     group: '{{ __unbound_group }}'
     mode: '0644'
+  retries: 5
+  delay: 10
   when: unbound_root_hints_update_enabled | bool
 
 - name: Install | Deploy root hints update systemd service

--- a/roles/users/molecule/default/prepare.yml
+++ b/roles/users/molecule/default/prepare.yml
@@ -18,22 +18,30 @@
       community.general.pacman:
         update_cache: true
         upgrade: true
+      retries: 3
+      delay: 5
       when: ansible_facts['os_family'] == 'Archlinux'
 
     - name: Prepare | Update package cache (Debian)
       ansible.builtin.apt:
         update_cache: true
+      retries: 3
+      delay: 5
       when: ansible_facts['os_family'] == 'Debian'
 
     - name: Prepare | Update package cache (RedHat)
       ansible.builtin.dnf:
         update_cache: true
+      retries: 3
+      delay: 5
       when: ansible_facts['os_family'] == 'RedHat'
 
     - name: Prepare | Install container dependencies
       ansible.builtin.package:
         name: '{{ __prepare_packages[ansible_facts["os_family"]] }}'
         state: present
+      retries: 3
+      delay: 5
 
     # Create orphan user for exclusive mode test
     - name: Prepare | Create orphan user for exclusive mode test

--- a/roles/utils/molecule/default/prepare.yml
+++ b/roles/utils/molecule/default/prepare.yml
@@ -9,22 +9,30 @@
       community.general.pacman:
         update_cache: true
         upgrade: true
+      retries: 3
+      delay: 5
       when: ansible_facts['os_family'] == 'Archlinux'
 
     - name: Prepare | Update package cache (Debian)
       ansible.builtin.apt:
         update_cache: true
+      retries: 3
+      delay: 5
       when: ansible_facts['os_family'] == 'Debian'
 
     - name: Prepare | Enable EPEL repository (RedHat)
       ansible.builtin.dnf:
         name: epel-release
         state: present
+      retries: 3
+      delay: 5
       when: ansible_facts['os_family'] == 'RedHat'
 
     - name: Prepare | Update package cache (RedHat)
       ansible.builtin.dnf:
         update_cache: true
+      retries: 3
+      delay: 5
       when: ansible_facts['os_family'] == 'RedHat'
 
     - name: Prepare | Create aur_builder user for AUR packages (Arch)

--- a/roles/utils/tasks/install.yml
+++ b/roles/utils/tasks/install.yml
@@ -50,6 +50,8 @@
   ansible.builtin.package:
     name: '{{ __utils_packages }}'
     state: present
+  retries: 3
+  delay: 5
   when: __utils_packages | length > 0
 
 #
@@ -85,6 +87,8 @@
   kewlfft.aur.aur:
     name: '{{ __utils_aur_install_list }}'
     state: present
+  retries: 3
+  delay: 5
   when:
     - ansible_facts['os_family'] == 'Archlinux'
     - __utils_aur_install_list | default([]) | length > 0

--- a/roles/wireguard/molecule/default/prepare.yml
+++ b/roles/wireguard/molecule/default/prepare.yml
@@ -12,20 +12,28 @@
     - name: Prepare | Update package cache (Arch)
       community.general.pacman:
         update_cache: true
+      retries: 3
+      delay: 5
       when: ansible_facts['os_family'] == 'Archlinux'
 
     - name: Prepare | Update package cache (Debian)
       ansible.builtin.apt:
         update_cache: true
+      retries: 3
+      delay: 5
       when: ansible_facts['os_family'] == 'Debian'
 
     - name: Prepare | Enable EPEL repository (RedHat)
       ansible.builtin.dnf:
         name: epel-release
         state: present
+      retries: 3
+      delay: 5
       when: ansible_facts['os_family'] == 'RedHat'
 
     - name: Prepare | Update package cache (RedHat)
       ansible.builtin.dnf:
         update_cache: true
+      retries: 3
+      delay: 5
       when: ansible_facts['os_family'] == 'RedHat'

--- a/roles/wireguard/tasks/install.yml
+++ b/roles/wireguard/tasks/install.yml
@@ -3,6 +3,8 @@
   ansible.builtin.package:
     name: '{{ __wireguard_packages }}'
     state: present
+  retries: 3
+  delay: 5
 
 - name: Install | Load WireGuard kernel module
   community.general.modprobe:


### PR DESCRIPTION
## Summary

- Add `retries`/`delay` to all network-dependent tasks across all 39 roles and their molecule `prepare.yml` files
- Package installs (`package`, `apt`, `dnf`, `pacman`, `aur`, `pipx`, `npm`, `pip`): `retries: 3, delay: 5`
- Downloads/keys/repos (`get_url`, `git`, `rpm_key`, `apt_repository`, `yum_repository`, `deb822_repository`, keyserver commands): `retries: 5, delay: 10`
- 104 files changed, 662 insertions (retries/delay only, no other changes)

Closes #28

## Test plan

- [ ] `ansible-lint` passes (verified locally)
- [ ] `yamllint` passes (verified locally)
- [ ] CI pipeline passes
- [ ] Spot-check molecule test on one role to verify retries don't break idempotence

🤖 Generated with [Claude Code](https://claude.com/claude-code)