### PR TITLE
chore: Exclude CHANGELOG.md from markdownlint pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,6 +36,7 @@ repos:
         name: Markdown Lint
         language_version: '22.22.0'
         args: [--config=.markdownlint.yml]
+        exclude: '^CHANGELOG\.md$'
 
   # =============================================================================
   # GENERAL


### PR DESCRIPTION
## Summary

- Add `exclude: '^CHANGELOG\.md$'` to markdownlint pre-commit hook
- Release-please generates CHANGELOG with formatting that conflicts with markdownlint rules
- Matches desktop collection pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)