### PR TITLE
docs: Update README role count and fix pre-commit performance

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,9 @@ repos:
     hooks:
       - id: ansible-lint
         name: Ansible Lint
-        files: \.(yaml|yml)$
+        always_run: false
+        pass_filenames: true
+        types: [yaml]
         args:
           - --profile=production
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 ## Description
 
 Shared Ansible roles for multi-OS infrastructure management.
-37 roles covering base system, security, networking, package management,
+39 roles covering base system, security, networking, package management,
 user management, editors, and more.
 
 ## Supported Platforms
@@ -42,6 +42,7 @@ user management, editors, and more.
 | ---------------------- | ---------------------------------------------- |
 | **package_management** | pacman, APT, DNF, AUR helper (paru), reflector |
 | **nodejs**             | Node.js and NVM                                |
+| **php**                | PHP interpreter and extensions                 |
 | **python**             | Python interpreter and tools                   |
 | **ansible**            | Ansible, Molecule and linting tools            |
 
@@ -86,7 +87,8 @@ user management, editors, and more.
 | ------------- | ------------------------ |
 | **chrony**    | NTP time synchronization |
 | **logrotate** | Log rotation             |
-| **podman**    | Container runtime        |
+| **docker**    | Docker container runtime |
+| **podman**    | Podman container runtime |
 | **snmp**      | SNMP monitoring agent    |
 | **restic**    | Backup with restic       |
 


### PR DESCRIPTION
## Summary
- Add missing **docker** and **php** roles to README table, correct total count from 37 to 39
- Override ansible-lint `always_run` and enable `pass_filenames` so pre-commit only lints changed YAML files — full project scan happens in CI

## Test plan
- [x] `pre-commit run ansible-lint --files README.md` → Skipped
- [x] `pre-commit run ansible-lint --files roles/base/tasks/main.yml` → Passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)