### PR TITLE
refactor(php): Move Sury repo setup from package_management to php role

### DIFF
--- a/roles/package_management/defaults/main.yml
+++ b/roles/package_management/defaults/main.yml
@@ -551,7 +551,7 @@ apt_docker_repo_enabled: false
 # PostgreSQL PGDG repository
 apt_postgresql_repo_enabled: false
 
-# Sury repository (PHP, Apache2, nginx — deb.sury.org for Debian, PPA for Ubuntu)
+# DEPRECATED: Use marcstraube.common.php role instead (removed in v2.0.0)
 apt_sury_enabled: false
 
 # Grafana repository

--- a/roles/package_management/tasks/main.yml
+++ b/roles/package_management/tasks/main.yml
@@ -99,6 +99,17 @@
   tags:
     - package-management
 
+- name: Main | Warn about deprecated apt_sury_enabled
+  ansible.builtin.debug:
+    msg: >-
+      WARNING: apt_sury_enabled is deprecated and will be removed in v2.0.0.
+      Use the marcstraube.common.php role for Sury PHP repository management.
+  when:
+    - package_management_enabled | bool
+    - apt_sury_enabled | bool
+  tags:
+    - package-management
+
 - name: Main | Warn about deprecated dnf_remi_php_version
   ansible.builtin.debug:
     msg: >-

--- a/roles/php/README.md
+++ b/roles/php/README.md
@@ -17,12 +17,9 @@ and full FPM pool templates.
 
 - ansible-core >= 2.17
 - Collections: `community.general`, `kewlfft.aur` (Arch only)
-- **Debian/Ubuntu**: Sury repository enabled via `package_management`
-  (`apt_sury_enabled: true`)
-- **RHEL/Rocky**: Remi repository enabled via `package_management`
-  (`dnf_remi_enabled: true`)
-- **RHEL/Rocky**: EPEL repository enabled for Composer
-  (`dnf_epel_enabled: true`)
+- **Debian/Ubuntu**: Sury PHP repository is set up automatically by this role
+- **RHEL/Rocky**: Remi + EPEL repository via `package_management`
+  (`dnf_remi_enabled: true`, `dnf_epel_enabled: true`)
 
 ## Supported Platforms
 

--- a/roles/php/molecule/default/prepare.yml
+++ b/roles/php/molecule/default/prepare.yml
@@ -30,35 +30,6 @@
       delay: 5
       when: ansible_facts['os_family'] == 'Debian'
 
-    - name: Prepare | Add Sury GPG key (Debian)
-      ansible.builtin.get_url:
-        url: 'https://packages.sury.org/php/apt.gpg'
-        dest: '/etc/apt/keyrings/php-sury.gpg'
-        owner: root
-        group: root
-        mode: '0644'
-      retries: 5
-      delay: 10
-      when: ansible_facts['distribution'] == 'Debian'
-
-    - name: Prepare | Add Sury repository (Debian)
-      ansible.builtin.apt_repository:
-        repo: >-
-          deb [signed-by=/etc/apt/keyrings/php-sury.gpg]
-          https://packages.sury.org/php/ {{ ansible_facts['distribution_release'] }} main
-        state: present
-        filename: 'php-sury'
-      retries: 5
-      delay: 10
-      when: ansible_facts['distribution'] == 'Debian'
-
-    - name: Prepare | Update apt cache after Sury (Debian)
-      ansible.builtin.apt:
-        update_cache: true
-      retries: 3
-      delay: 5
-      when: ansible_facts['os_family'] == 'Debian'
-
     - name: Prepare | Update package cache (RedHat)
       ansible.builtin.dnf:
         update_cache: true

--- a/roles/php/tasks/main.yml
+++ b/roles/php/tasks/main.yml
@@ -24,6 +24,14 @@
   tags:
     - php
 
+- name: Main | Import repository tasks
+  ansible.builtin.import_tasks:
+    file: repos.yml
+  when: php_enabled | bool
+  tags:
+    - php
+    - php:install
+
 - name: Main | Import install tasks
   ansible.builtin.import_tasks:
     file: install.yml

--- a/roles/php/tasks/repos.yml
+++ b/roles/php/tasks/repos.yml
@@ -1,0 +1,62 @@
+---
+#
+# Sury PHP Repository (Debian)
+#
+
+- name: Repos | Ensure apt prerequisites
+  ansible.builtin.package:
+    name:
+      - 'ca-certificates'
+      - 'python3-debian'
+    state: present
+  retries: 3
+  delay: 5
+  when: ansible_facts['os_family'] == 'Debian'
+
+- name: Repos | Add Sury PHP repository (Debian)
+  ansible.builtin.deb822_repository:
+    name: php-sury
+    types: deb
+    uris: '{{ __php_sury_repo_uris }}'
+    suites: '{{ __php_sury_repo_suites }}'
+    components: '{{ __php_sury_repo_components }}'
+    signed_by: '{{ __php_sury_gpg_url }}'
+    state: present
+  retries: 5
+  delay: 10
+  register: __php_sury_repo
+  when: ansible_facts['distribution'] == 'Debian'
+
+- name: Repos | Add Sury PHP PPA (Ubuntu)
+  ansible.builtin.apt_repository:
+    repo: 'ppa:ondrej/php'
+    state: present
+  retries: 5
+  delay: 10
+  register: __php_sury_ppa
+  when: ansible_facts['distribution'] == 'Ubuntu'
+
+- name: Repos | Update apt cache after repo change
+  ansible.builtin.apt:
+    update_cache: true
+  retries: 3
+  delay: 5
+  when:
+    - ansible_facts['os_family'] == 'Debian'
+    - (__php_sury_repo is changed) or (__php_sury_ppa is changed)
+
+#
+# Cleanup legacy repo format
+#
+
+- name: Repos | Remove legacy Sury sources list file
+  ansible.builtin.file:
+    path: '/etc/apt/sources.list.d/php-sury.list'
+    state: absent
+  when: ansible_facts['distribution'] == 'Debian'
+
+- name: Repos | Remove legacy Sury GPG keyring
+  ansible.builtin.file:
+    path: '/etc/apt/keyrings/php-sury.gpg'
+    state: absent
+  when: ansible_facts['distribution'] == 'Debian'

--- a/roles/php/vars/Debian.yml
+++ b/roles/php/vars/Debian.yml
@@ -18,3 +18,9 @@ __php_fpm_listen_default: '/run/php/php{{ __php_ver }}-fpm.sock'
 # FPM pool defaults
 __php_fpm_default_user: 'www-data'
 __php_fpm_default_group: 'www-data'
+
+# Sury repository
+__php_sury_gpg_url: 'https://packages.sury.org/php/apt.gpg'
+__php_sury_repo_uris: 'https://packages.sury.org/php/'
+__php_sury_repo_suites: '{{ ansible_facts["distribution_release"] }}'
+__php_sury_repo_components: 'main'


### PR DESCRIPTION
## Summary
- php role now manages Sury PHP repository (deb822 format) unconditionally on Debian/Ubuntu
- Follows docker role pattern — no toggle, repo is always set up
- Legacy `.list` file and GPG keyring cleanup included
- Deprecation warning added to `package_management` for `apt_sury_enabled`

Closes #43

## Test plan
- [ ] `molecule test` on php role (Debian container gets Sury via role)
- [ ] Verify legacy file cleanup works
- [ ] Verify deprecation warning fires when `apt_sury_enabled: true` in package_management

🤖 Generated with [Claude Code](https://claude.com/claude-code)