### PR TITLE
fix: Correct README titles to collection FQCN format

### DIFF
--- a/roles/aide/README.md
+++ b/roles/aide/README.md
@@ -1,4 +1,4 @@
-# Ansible Role: marcstraube.common.aide
+# marcstraube.common.aide
 
 ## Description
 

--- a/roles/apparmor/README.md
+++ b/roles/apparmor/README.md
@@ -1,4 +1,4 @@
-# Ansible Role: marcstraube.common.apparmor
+# marcstraube.common.apparmor
 
 ## Description
 

--- a/roles/auditd/README.md
+++ b/roles/auditd/README.md
@@ -1,4 +1,4 @@
-# Ansible Role: marcstraube.common.auditd
+# marcstraube.common.auditd
 
 ## Description
 


### PR DESCRIPTION
## Summary

- Remove `Ansible Role: ` prefix from README titles in aide, apparmor, and auditd
- Consistent with all other roles in the collection

Closes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)