### PR TITLE
refactor: Update backup.yml to default(true)

### DIFF
--- a/playbooks/backup.yml
+++ b/playbooks/backup.yml
@@ -23,4 +23,4 @@
       tags:
         - backup
         - restic
-      when: restic_enabled | default(false) | bool
+      when: restic_enabled | default(true) | bool


### PR DESCRIPTION
## Summary

Closes #49

- Change `restic_enabled | default(false)` to `default(true)`
- Play-level `tags: [backup, never]` already prevents accidental execution

## BREAKING CHANGE

restic role now `default(true)` — inventory controls whether restic is enabled per host.

## Test plan

- [ ] `ansible-playbook marcstraube.common.backup -i inventory/ --list-tasks` shows restic role

🤖 Generated with [Claude Code](https://claude.com/claude-code)