### PR TITLE
refactor!: Change user_config_mode defaults to initial

### DIFF
--- a/roles/editors/README.md
+++ b/roles/editors/README.md
@@ -78,7 +78,7 @@ the full list of options:
 | Variable                    | Default     | Description                                |
 |-----------------------------|-------------|--------------------------------------------|
 | `editors_users`             | `[]`        | Per-user editor config entries             |
-| `editors_user_config_mode`  | `'managed'` | Default mode when user entry has no 'mode' |
+| `editors_user_config_mode`  | `'initial'` | Default mode when user entry has no 'mode' |
 | `editors_user_config_merge` | `true`      | Default config_merge behavior              |
 
 ## Tags

--- a/roles/editors/defaults/main.yml
+++ b/roles/editors/defaults/main.yml
@@ -135,7 +135,7 @@ editors_vim_config:
 editors_users: []
 
 # Default mode when user entry has no 'mode' key
-editors_user_config_mode: 'managed'
+editors_user_config_mode: 'initial'
 
 # Default config_merge: true = global | combine(user), false = user only
 editors_user_config_merge: true

--- a/roles/gnupg/README.md
+++ b/roles/gnupg/README.md
@@ -124,7 +124,7 @@ overrides if needed.
 | Variable                 | Default     | Description                                         |
 |--------------------------|-------------|-----------------------------------------------------|
 | `gnupg_users`            | `[]`        | Users to configure GnuPG for (username, mode, etc.) |
-| `gnupg_user_config_mode` | `'managed'` | Default config mode (managed, initial, disabled)    |
+| `gnupg_user_config_mode` | `'initial'` | Default config mode (managed, initial, disabled)    |
 
 ## Tags
 

--- a/roles/gnupg/defaults/main.yml
+++ b/roles/gnupg/defaults/main.yml
@@ -216,4 +216,4 @@ gnupg_users: []
 
 # Default config mode when user entry has no 'mode' key
 # Options: managed, initial, disabled
-gnupg_user_config_mode: 'managed'
+gnupg_user_config_mode: 'initial'

--- a/roles/package_management/defaults/main.yml
+++ b/roles/package_management/defaults/main.yml
@@ -184,7 +184,7 @@ makepkg_users: []
 #     packager: 'John Doe <john@example.com>'
 
 # Default mode when user entry has no 'mode' key
-makepkg_user_config_mode: 'managed'
+makepkg_user_config_mode: 'initial'
 
 #
 # Makepkg - Compiler Flags


### PR DESCRIPTION
## Summary

Closes #55

- `editors_user_config_mode`: `managed` → `initial`
- `gnupg_user_config_mode`: `managed` → `initial`
- `makepkg_user_config_mode`: `managed` → `initial`
- `multiplexer_user_config_mode`: already `initial` (no change)

## BREAKING CHANGE

Per-user configs now deployed once and then owned by the user. Set to `managed` in inventory to restore previous behavior.

## Test plan

- [ ] All `user_config_mode` variables default to `'initial'`
- [ ] READMEs match defaults

🤖 Generated with [Claude Code](https://claude.com/claude-code)