### PR TITLE
docs: Add References sections to all role READMEs

### DIFF
--- a/roles/aide/README.md
+++ b/roles/aide/README.md
@@ -157,6 +157,11 @@ AIDE 0.16 (EL 9) and 0.18+ (everything else) differ in configuration directives:
 The role handles this automatically via `vars/RedHat-9.yml` (0.16 overrides) and
 `vars/RedHat.yml` (0.18 defaults for all other RHEL-family distros).
 
+## References
+
+- [AIDE](https://aide.github.io/) — Advanced Intrusion Detection Environment project page
+- [AIDE on GitHub](https://github.com/aide/aide) — Source code and issue tracker
+
 ## License
 
 MIT

--- a/roles/ansible/README.md
+++ b/roles/ansible/README.md
@@ -77,6 +77,12 @@ molecule test
 
 Driver: `podman` | Platforms: Arch Linux, Debian Trixie, Rocky 9, Rocky 10
 
+## References
+
+- [Ansible Documentation](https://docs.ansible.com/) — Official Ansible documentation
+- [Molecule](https://ansible.readthedocs.io/projects/molecule/) — Ansible testing framework documentation
+- [ansible-lint](https://ansible.readthedocs.io/projects/lint/) — Ansible linting tool documentation
+
 ## License
 
 MIT

--- a/roles/apparmor/README.md
+++ b/roles/apparmor/README.md
@@ -153,6 +153,11 @@ The service role knows its own binary path (OS-specific) and runs `aa-enforce`
 internally. This avoids centralizing OS-specific binary paths in the AppArmor
 role.
 
+## References
+
+- [AppArmor](https://apparmor.net/) — Application security framework for Linux
+- [AppArmor Wiki](https://gitlab.com/apparmor/apparmor/-/wikis/home) — Documentation and community wiki
+
 ## License
 
 MIT

--- a/roles/auditd/README.md
+++ b/roles/auditd/README.md
@@ -216,6 +216,11 @@ Driver: `vagrant` | Platforms: Arch Linux, Debian Trixie, Rocky 9, Rocky 10
 - **`max_log_file_action: exec`**: Only available in audit >= 4.0.3.
 - **`space_left_action: halt`**: Deprecated in latest 4.x releases.
 
+## References
+
+- [audit-userspace](https://github.com/linux-audit/audit-userspace) — Linux Audit userspace tools source code
+- [auditd(8)](https://man7.org/linux/man-pages/man8/auditd.8.html) — Linux Audit daemon man page
+
 ## License
 
 MIT

--- a/roles/avahi/README.md
+++ b/roles/avahi/README.md
@@ -174,6 +174,11 @@ Driver: `podman` | Platforms: Arch Linux, Debian Trixie, Rocky 9, Rocky 10
 - **`rlimit-nproc`**: Intentionally omitted from the config template. Upstream removed
   the default due to container UID namespace sharing issues.
 
+## References
+
+- [Avahi](https://avahi.org/) — mDNS/DNS-SD service discovery suite
+- [Avahi on GitHub](https://github.com/avahi/avahi) — Source code and issue tracker
+
 ## License
 
 MIT

--- a/roles/base/README.md
+++ b/roles/base/README.md
@@ -188,6 +188,11 @@ Driver: `podman` | Platforms: Arch Linux, Debian Trixie, Rocky 9, Rocky 10
 - Other roles (apparmor, plymouth) append their own kernel parameters using the
   same `lineinfile` pattern on `GRUB_CMDLINE_LINUX_DEFAULT`.
 
+## References
+
+- [systemd](https://www.freedesktop.org/wiki/Software/systemd/) — System and service manager
+- [locale.conf(5)](https://man7.org/linux/man-pages/man5/locale.conf.5.html) — Locale configuration man page
+
 ## License
 
 MIT

--- a/roles/chrony/README.md
+++ b/roles/chrony/README.md
@@ -178,6 +178,11 @@ molecule test
 
 Driver: `podman` | Platforms: Arch Linux, Debian Trixie, Rocky 9, Rocky 10
 
+## References
+
+- [chrony](https://chrony-project.org/) — Versatile NTP implementation
+- [chrony.conf(5)](https://chrony-project.org/doc/4.6/chrony.conf.html) — chrony configuration file reference
+
 ## License
 
 MIT

--- a/roles/clamav/README.md
+++ b/roles/clamav/README.md
@@ -178,6 +178,11 @@ Driver: `podman` | Platforms: Arch Linux, Debian Trixie, Rocky 9, Rocky 10
 The role sets NoCOW (`chattr +C`) on the database directory (`/var/lib/clamav`)
 when running on BTRFS to reduce copy-on-write overhead from frequent database updates.
 
+## References
+
+- [ClamAV](https://www.clamav.net/) — Open source antivirus engine
+- [ClamAV Documentation](https://docs.clamav.net/) — Official documentation and configuration guides
+
 ## License
 
 MIT

--- a/roles/editors/README.md
+++ b/roles/editors/README.md
@@ -128,6 +128,12 @@ editors_neovim_binary_enabled: true
 editors_neovim_version: 'v0.10.4'
 ```
 
+## References
+
+- [nano](https://www.nano-editor.org/) — GNU nano text editor
+- [Vim](https://www.vim.org/) — Vi IMproved text editor
+- [Neovim](https://neovim.io/) — Hyperextensible Vim-based text editor
+
 ## License
 
 MIT

--- a/roles/energy_management/README.md
+++ b/roles/energy_management/README.md
@@ -171,6 +171,11 @@ removes the other. This role does NOT use the standard ternary service manage
 pattern for PPD/TLP because the switch actively removes the competing service
 and its packages, rather than simply toggling a single service.
 
+## References
+
+- [TLP](https://linrunner.de/tlp/) — Advanced power management for Linux
+- [power-profiles-daemon](https://gitlab.freedesktop.org/upower/power-profiles-daemon) — System-wide power profile management
+
 ## License
 
 MIT

--- a/roles/fail2ban/README.md
+++ b/roles/fail2ban/README.md
@@ -199,6 +199,11 @@ molecule test
 
 Driver: `podman` | Platforms: Arch Linux, Debian Trixie, Rocky 9, Rocky 10
 
+## References
+
+- [Fail2ban](https://www.fail2ban.org/) — Intrusion prevention framework
+- [Fail2ban on GitHub](https://github.com/fail2ban/fail2ban) — Source code and issue tracker
+
 ## License
 
 MIT

--- a/roles/firejail/README.md
+++ b/roles/firejail/README.md
@@ -88,6 +88,11 @@ molecule test
 
 Driver: `podman` | Platforms: Arch Linux, Debian Trixie, Rocky 9, Rocky 10
 
+## References
+
+- [Firejail](https://firejail.wordpress.com/) — SUID sandbox program
+- [Firejail on GitHub](https://github.com/netblue30/firejail) — Source code and issue tracker
+
 ## License
 
 MIT

--- a/roles/firewalld/README.md
+++ b/roles/firewalld/README.md
@@ -178,6 +178,11 @@ molecule test
 
 Driver: `podman` | Platforms: Arch Linux, Debian Trixie, Rocky 9, Rocky 10
 
+## References
+
+- [firewalld](https://firewalld.org/) — Dynamically managed firewall with network zones
+- [firewalld Documentation](https://firewalld.org/documentation/) — Official documentation
+
 ## License
 
 MIT

--- a/roles/fonts/README.md
+++ b/roles/fonts/README.md
@@ -143,6 +143,11 @@ molecule test
 
 Driver: `podman` | Platforms: Arch Linux, Debian Trixie, Rocky 9, Rocky 10
 
+## References
+
+- [fontconfig](https://www.freedesktop.org/wiki/Software/fontconfig/) — Font configuration and customization library
+- [Nerd Fonts](https://www.nerdfonts.com/) — Developer-targeted patched fonts with icon glyphs
+
 ## License
 
 MIT

--- a/roles/gnupg/README.md
+++ b/roles/gnupg/README.md
@@ -174,6 +174,11 @@ molecule test
 
 Driver: `podman` | Platforms: Arch Linux, Debian Trixie, Rocky 9, Rocky 10
 
+## References
+
+- [GnuPG](https://gnupg.org/) — The GNU Privacy Guard
+- [GnuPG Manual](https://gnupg.org/documentation/manuals/gnupg/) — Official documentation
+
 ## License
 
 MIT

--- a/roles/graphics/README.md
+++ b/roles/graphics/README.md
@@ -142,6 +142,12 @@ Driver: `podman` | Platforms: Arch Linux, Debian Trixie, Rocky 9, Rocky 10
 - **Debian Trixie**: Legacy 470xx driver has been dropped.
 - **RHEL/Rocky**: Requires RPM Fusion repositories for proprietary NVIDIA drivers.
 
+## References
+
+- [Intel graphics - ArchWiki](https://wiki.archlinux.org/title/Intel_graphics) — Intel GPU driver setup and configuration
+- [AMDGPU - ArchWiki](https://wiki.archlinux.org/title/AMDGPU) — AMD GPU driver setup and configuration
+- [NVIDIA - ArchWiki](https://wiki.archlinux.org/title/NVIDIA) — NVIDIA GPU driver setup and configuration
+
 ## License
 
 MIT

--- a/roles/hardening/README.md
+++ b/roles/hardening/README.md
@@ -145,6 +145,11 @@ Configure them via the base role's bootloader variables:
 | `page_alloc.shuffle=1`     | Randomize page allocator free lists                           |
 | `iommu=force`              | Force IOMMU isolation (5-15% I/O cost, skip in VMs)           |
 
+## References
+
+- [CIS Benchmark](https://www.cisecurity.org/benchmark/distribution_independent_linux) — hardening guidelines
+- [DISA STIGs](https://www.stig.dod.mil/) — Security Technical Implementation Guides
+
 ## License
 
 MIT

--- a/roles/hardware_tokens/README.md
+++ b/roles/hardware_tokens/README.md
@@ -132,6 +132,12 @@ Driver: `vagrant` | Platforms: Arch Linux, Debian Trixie, Rocky 9
 - **Rocky 9/10**: YubiKey Manager (ykman) not in repos, use pipx if needed. NitroKey
   App not available. Uses `plugdev` group.
 
+## References
+
+- [Yubico Developers](https://developers.yubico.com/) — YubiKey developer documentation and tools
+- [Nitrokey Documentation](https://www.nitrokey.com/documentation) — Nitrokey setup and usage guides
+- [FIDO2 - FIDO Alliance](https://fidoalliance.org/fido2/) — FIDO2 authentication standard specification
+
 ## License
 
 MIT

--- a/roles/logrotate/README.md
+++ b/roles/logrotate/README.md
@@ -140,6 +140,11 @@ Driver: `podman` | Platforms: Arch Linux, Debian Trixie, Rocky 9, Rocky 10
 - Arch Linux adds `.pacorig`, `.pacnew`, `.pacsave` to tabooext automatically via OS vars.
 - journald log management is handled by the `marcstraube.common.base` role, not here.
 
+## References
+
+- [logrotate on GitHub](https://github.com/logrotate/logrotate) — Source code and issue tracker
+- [logrotate(8) man page](https://man7.org/linux/man-pages/man8/logrotate.8.html) — command reference
+
 ## License
 
 MIT

--- a/roles/lynis/README.md
+++ b/roles/lynis/README.md
@@ -133,6 +133,11 @@ Driver: `podman` | Platforms: Arch Linux, Debian Trixie, Rocky 9, Rocky 10
 - Lynis is not a daemon — no AppArmor, fail2ban, or firewall integration needed
 - EL 10: lynis is not available in EPEL 10; the role uses git install (`lynis_install_method: 'git'`)
 
+## References
+
+- [Lynis](https://cisofy.com/lynis/) — Security auditing tool for Linux systems
+- [Lynis on GitHub](https://github.com/CISOfy/lynis) — Source code and issue tracker
+
 ## License
 
 MIT

--- a/roles/networkmanager/README.md
+++ b/roles/networkmanager/README.md
@@ -319,6 +319,11 @@ Driver: `vagrant` | Platforms: Arch Linux, Debian Trixie, Rocky 9, Rocky 10
 | `pre-down.d/30-umount-smb.sh`   | `pre-down`  | Graceful SMB unmount                         |
 | `pre-down.d/30-umount-sshfs.sh` | `pre-down`  | Graceful SSHFS unmount                       |
 
+## References
+
+- [NetworkManager](https://networkmanager.dev/) — network configuration daemon
+- [NetworkManager API Reference](https://networkmanager.dev/docs/api/latest/) — D-Bus API and configuration documentation
+
 ## License
 
 MIT

--- a/roles/nodejs/README.md
+++ b/roles/nodejs/README.md
@@ -123,6 +123,11 @@ On RedHat-family systems with `nodesource` method, the role:
 3. If AppStream has it: enables the stream and installs from AppStream
 4. If not: disables the module, adds the NodeSource repository, and installs
 
+## References
+
+- [Node.js](https://nodejs.org/) — JavaScript runtime
+- [NodeSource Distributions](https://github.com/nodesource/distributions) — Node.js binary distribution repositories
+
 ## License
 
 MIT

--- a/roles/openssh/README.md
+++ b/roles/openssh/README.md
@@ -209,6 +209,11 @@ SSH uses a built-in fail2ban filter. The `marcstraube.common.fail2ban` role
 manages the sshd jail centrally via `fail2ban_sshd_enabled`. No fail2ban
 configuration is needed in this role.
 
+## References
+
+- [OpenSSH](https://www.openssh.com/) — secure shell connectivity tools
+- [sshd_config(5)](https://man.openbsd.org/sshd_config) — OpenSSH daemon configuration reference
+
 ## License
 
 MIT

--- a/roles/package_management/README.md
+++ b/roles/package_management/README.md
@@ -202,6 +202,13 @@ Driver: `podman` | Platforms: Arch Linux, Debian Trixie, Rocky 9, Rocky 10
 - `dnf-plugins-core`, `dnf-utils`, `yum-utils` are automatically skipped (removed in dnf5)
 - `fastestmirror` is built into dnf5 (no plugin needed, config option still works)
 
+## References
+
+- [Pacman](https://wiki.archlinux.org/title/Pacman) — Arch Linux package manager
+- [Makepkg](https://wiki.archlinux.org/title/Makepkg) — Arch Linux package build utility
+- [APT Configuration](https://wiki.debian.org/AptConfiguration) — Debian package manager configuration
+- [DNF Documentation](https://dnf.readthedocs.io/) — Red Hat package manager
+
 ## License
 
 MIT

--- a/roles/pam_hardening/README.md
+++ b/roles/pam_hardening/README.md
@@ -109,6 +109,11 @@ Rocky uses `authselect` for PAM stack management. This role enables features
 via `authselect enable-feature` and deploys configuration files in
 `/etc/security/` which are not managed by authselect.
 
+## References
+
+- [Linux-PAM](https://github.com/linux-pam/linux-pam) — Pluggable Authentication Modules project
+- [pam.conf(5)](https://man7.org/linux/man-pages/man5/pam.conf.5.html) — PAM configuration file reference
+
 ## License
 
 MIT

--- a/roles/pki/README.md
+++ b/roles/pki/README.md
@@ -235,6 +235,11 @@ molecule test
 
 Driver: `podman` | Platforms: Arch Linux, Debian Trixie, Rocky 9, Rocky 10
 
+## References
+
+- [OpenSSL Documentation](https://www.openssl.org/docs/) — cryptography and TLS toolkit
+- [Transport Layer Security (ArchWiki)](https://wiki.archlinux.org/title/Transport_Layer_Security)
+
 ## License
 
 MIT

--- a/roles/podman/README.md
+++ b/roles/podman/README.md
@@ -98,12 +98,12 @@ overrides if needed.
 Controls UID/GID mapping between host and containers via `userns` in
 `containers.conf`. Available modes:
 
-| Mode      | Description                                                        |
-|-----------|--------------------------------------------------------------------|
-| `auto`    | Automatic UID remapping per container — best isolation (default)   |
-| `host`    | No remapping — container root = host root (or host user for rootless) |
-| `keep-id` | Map host UID into container (rootless only)                        |
-| `nomap`   | Do not map additional UIDs into the user namespace                 |
+| Mode      | Description                                                     |
+|-----------|-----------------------------------------------------------------|
+| `auto`    | Automatic UID remapping per container, best isolation (default) |
+| `host`    | No remapping, container root = host root (or host user)         |
+| `keep-id` | Map host UID into container (rootless only)                     |
+| `nomap`   | Do not map additional UIDs into the user namespace              |
 
 **When to override per container:** Some images (e.g., Uptime Kuma) run `chown`
 in their entrypoint, which fails under `auto` because container root is mapped
@@ -153,6 +153,11 @@ molecule test
 ```
 
 Driver: `podman` | Platforms: Arch Linux, Debian Trixie, Rocky 9, Rocky 10
+
+## References
+
+- [Podman](https://podman.io/) — daemonless container engine
+- [Podman Documentation](https://docs.podman.io/) — official documentation and tutorials
 
 ## License
 

--- a/roles/python/README.md
+++ b/roles/python/README.md
@@ -78,6 +78,11 @@ On Rocky 9, the system pipx from EPEL (1.2.1) is too old for
 venv at `/opt/pipx-bootstrap/`. Downstream roles should use the bootstrap
 path on EL 9.
 
+## References
+
+- [Python](https://www.python.org/) — programming language
+- [pipx](https://pipx.pypa.io/) — install and run Python applications in isolated environments
+
 ## License
 
 MIT

--- a/roles/restic/README.md
+++ b/roles/restic/README.md
@@ -164,6 +164,11 @@ molecule test
 
 Driver: `podman` | Platforms: Arch Linux, Debian Trixie, Rocky 9, Rocky 10
 
+## References
+
+- [restic](https://restic.net/) — fast, secure, efficient backup program
+- [restic Documentation](https://restic.readthedocs.io/) — official documentation and usage guide
+
 ## License
 
 MIT

--- a/roles/rkhunter/README.md
+++ b/roles/rkhunter/README.md
@@ -156,6 +156,11 @@ Driver: `podman` | Platforms: Arch Linux, Debian Trixie, Rocky 9
 - BTRFS: NoCOW attribute is set on `/var/lib/rkhunter/db` when on BTRFS filesystem
 - Rocky Linux 10 / EL 10 is not supported (rkhunter not available in EPEL 10)
 
+## References
+
+- [rkhunter](https://rkhunter.sourceforge.net/) — rootkit, backdoor, and local exploit scanner
+- [rkhunter Project](https://sourceforge.net/projects/rkhunter/) — SourceForge project page and downloads
+
 ## License
 
 MIT

--- a/roles/snmp/README.md
+++ b/roles/snmp/README.md
@@ -163,6 +163,11 @@ in `ExecStart`. This role deploys a systemd override to remove that, allowing
 AppArmor enforcement is available on Arch Linux and Debian (not RedHat/Rocky
 which uses SELinux). Enable with `snmp_apparmor_enabled: true`.
 
+## References
+
+- [Net-SNMP](https://www.net-snmp.org/) — SNMP protocol suite for network monitoring
+- [snmpd.conf(5)](https://www.net-snmp.org/docs/man/snmpd.conf.5.html) — Net-SNMP agent configuration reference
+
 ## License
 
 MIT

--- a/roles/sudo/README.md
+++ b/roles/sudo/README.md
@@ -113,6 +113,11 @@ molecule test
 
 Driver: `podman` | Platforms: Arch Linux, Debian Trixie, Rocky 9, Rocky 10
 
+## References
+
+- [sudo](https://www.sudo.ws/) — official sudo project site
+- [sudoers(5)](https://www.sudo.ws/docs/man/sudoers.man/) — sudoers file format and configuration reference
+
 ## License
 
 MIT

--- a/roles/sysctl/README.md
+++ b/roles/sysctl/README.md
@@ -114,6 +114,11 @@ molecule test
 
 Driver: `podman` | Platforms: Arch Linux, Debian Trixie, Rocky 9, Rocky 10
 
+## References
+
+- [Linux sysctl documentation](https://www.kernel.org/doc/html/latest/admin-guide/sysctl/) — kernel parameter reference
+- [sysctl(8)](https://man7.org/linux/man-pages/man8/sysctl.8.html) — sysctl command man page
+
 ## License
 
 MIT

--- a/roles/unbound/README.md
+++ b/roles/unbound/README.md
@@ -131,6 +131,11 @@ Driver: `podman` | Platforms: Arch Linux, Debian Trixie, Rocky 9, Rocky 10
 - The blocklist feature downloads hosts-format blocklists and converts them to unbound
   `local-zone` entries.
 
+## References
+
+- [Unbound](https://nlnetlabs.nl/projects/unbound/about/) — validating, recursive, and caching DNS resolver
+- [Unbound documentation](https://unbound.docs.nlnetlabs.nl/) — official Unbound documentation
+
 ## License
 
 MIT

--- a/roles/users/README.md
+++ b/roles/users/README.md
@@ -182,6 +182,11 @@ Driver: `podman` | Platforms: Arch Linux, Debian Trixie, Rocky 9, Rocky 10
 - Profile images use AccountsService and optionally `~/.face` symlinks for DM compatibility
 - Exclusive mode only affects regular users (UID 1000-59999), never system accounts
 
+## References
+
+- [useradd(8)](https://man7.org/linux/man-pages/man8/useradd.8.html) — user account creation man page
+- [login.defs(5)](https://man7.org/linux/man-pages/man5/login.defs.5.html) — shadow password suite configuration
+
 ## License
 
 MIT

--- a/roles/utils/README.md
+++ b/roles/utils/README.md
@@ -141,6 +141,12 @@ molecule test
 
 Driver: `podman` | Platforms: Arch Linux, Debian Trixie, Rocky 9, Rocky 10
 
+## References
+
+- [btop](https://github.com/aristocratos/btop) — modern resource monitor for the terminal
+- [ripgrep](https://github.com/BurntSushi/ripgrep) — fast recursive grep alternative
+- [fd](https://github.com/sharkdp/fd) — fast find alternative
+
 ## License
 
 MIT

--- a/roles/wireguard/README.md
+++ b/roles/wireguard/README.md
@@ -135,6 +135,11 @@ molecule test
 
 Driver: `vagrant` | Platforms: Arch Linux, Debian Trixie, Rocky 9, Rocky 10
 
+## References
+
+- [WireGuard](https://www.wireguard.com/) — fast, modern, secure VPN tunnel
+- [WireGuard Quickstart](https://www.wireguard.com/quickstart/) — installation and setup guide
+
 ## License
 
 MIT


### PR DESCRIPTION
## Summary

Closes #59

- Add upstream documentation links to 37 role READMEs
- 3 roles (docker, multiplexer, php) already had References
- Links point to official project pages, documentation, and man pages
- All 40 roles now have a `## References` section

## Test plan

- [ ] All 40 role READMEs have `## References` section
- [ ] Links are valid upstream sources
- [ ] markdownlint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)