### PR TITLE
fix: Remove _ansible_managed from JSON templates

### DIFF
--- a/roles/docker/molecule/default/verify.yml
+++ b/roles/docker/molecule/default/verify.yml
@@ -103,7 +103,6 @@
     - name: Verify | Assert daemon.json contains expected keys
       ansible.builtin.assert:
         that:
-          - "'_ansible_managed' in __daemon_decoded"
           - "'data-root' in __daemon_decoded"
           - "'storage-driver' in __daemon_decoded"
           - "'log-driver' in __daemon_decoded"

--- a/roles/docker/templates/daemon.json.j2
+++ b/roles/docker/templates/daemon.json.j2
@@ -1,5 +1,4 @@
 {% set daemon = {} %}
-{% set _ = daemon.update({"_ansible_managed": ansible_managed}) %}
 {% set _ = daemon.update({"data-root": docker_data_root}) %}
 {% set _ = daemon.update({"storage-driver": docker_storage_driver}) %}
 {% if docker_storage_opts | length > 0 %}

--- a/roles/podman/templates/auth.json.j2
+++ b/roles/podman/templates/auth.json.j2
@@ -1,5 +1,4 @@
 {
-  "_ansible_managed": "{{ ansible_managed }}",
   "auths": {
 {% for auth in podman_registries_auth %}
     "{{ auth.registry }}": {


### PR DESCRIPTION
## Summary

- Remove `_ansible_managed` key from `daemon.json.j2` (docker) and `auth.json.j2` (podman)
- JSON does not support comments, and Docker rejects unknown keys causing service startup failure

Closes #66

## Test plan

- [x] Docker service starts successfully after daemon.json deployment
- [x] Live-tested on Arch Linux workstation

🤖 Generated with [Claude Code](https://claude.com/claude-code)