### PR TITLE
fix: Use official repo for python-podman on Arch

### DIFF
--- a/roles/ansible/tasks/install.yml
+++ b/roles/ansible/tasks/install.yml
@@ -40,12 +40,9 @@
         - ansible_tools_molecule_enabled | bool
         - ansible_tools_container_driver in ['podman', 'docker']
 
-    - name: Install | Podman Python bindings from AUR (Arch)
-      become: true
-      become_user: 'aur_builder'
-      kewlfft.aur.aur:
-        name: '{{ __ansible_tools_aur_packages.podman }}'
-        use: 'makepkg'
+    - name: Install | Podman Python bindings (Arch)
+      ansible.builtin.package:
+        name: '{{ __ansible_tools_podman_packages }}'
         state: present
       retries: 3
       delay: 5

--- a/roles/ansible/vars/Archlinux.yml
+++ b/roles/ansible/vars/Archlinux.yml
@@ -9,8 +9,9 @@ __ansible_tools_aur_packages:
   # Requires --nocheck due to upstream test bug
   molecule:
     - molecule-plugins
-  podman:
-    - python-podman
+
+__ansible_tools_podman_packages:
+  - 'python-podman'
 
 __ansible_tools_docker_packages:
   - 'python-docker'


### PR DESCRIPTION
## Summary

- `python-podman` moved from AUR to official Arch repository
- Use `ansible.builtin.package` instead of `kewlfft.aur.aur`
- Move package name from `__ansible_tools_aur_packages.podman` to `__ansible_tools_podman_packages`

Closes #69

## Test plan

- [x] python-podman installs from official repo
- [x] Live-tested on Arch Linux workstation

🤖 Generated with [Claude Code](https://claude.com/claude-code)