### PR TITLE
ci: Move compat tests from PR to main-only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,10 +72,12 @@ jobs:
   # MOLECULE FORWARD-COMPATIBILITY (ansible-core 2.20, representative subset)
   # Tests a diverse subset of roles on latest ansible-core to catch
   # deprecations and breaking changes early.
+  # Only runs on push to main — not needed for every PR.
   # =============================================================================
   molecule-compat:
     name: Compat ${{ matrix.role }} (ansible-2.20)
     runs-on: ubuntu-latest
+    if: github.event_name == 'push'
     needs: [lint, markdown-lint, yaml-lint]
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Summary

- Compat tests (ansible-core 2.20) only run on push to main, not on PRs
- Speeds up PR feedback loop by ~5 minutes

PR pipeline: Lint + Molecule (changed roles)
Main pipeline: Lint + Molecule + Compat + Build

Closes #74

## Test plan

- [x] PR CI runs without compat jobs (this PR validates it)
- [x] Push to main runs full pipeline including compat

🤖 Generated with [Claude Code](https://claude.com/claude-code)