### PR TITLE
fix: Add --all argument to HSM sign script in apparmor

### DIFF
--- a/roles/apparmor/tasks/kernel.yml
+++ b/roles/apparmor/tasks/kernel.yml
@@ -114,7 +114,7 @@
 
 - name: Kernel | Re-sign boot files (HSM)
   ansible.builtin.command:
-    cmd: /usr/local/bin/secureboot-hsm-sign.sh
+    cmd: /usr/local/bin/secureboot-hsm-sign.sh --all
   changed_when: true
   when:
     - ansible_facts['os_family'] == 'Archlinux'


### PR DESCRIPTION
## Summary

- `secureboot-hsm-sign.sh` called without argument in apparmor kernel.yml
- Script requires `--all`, `--pending`, or a file path
- After GRUB regeneration, `--all` signs all boot files

Closes #70

## Test plan

- [x] AppArmor GRUB changes trigger successful HSM re-signing
- [x] Live-tested on Arch Linux workstation with HSM Secure Boot

🤖 Generated with [Claude Code](https://claude.com/claude-code)