### PR TITLE
fix: Skip podman-docker when real Docker is installed

### DIFF
--- a/roles/podman/tasks/install.yml
+++ b/roles/podman/tasks/install.yml
@@ -22,13 +22,21 @@
   delay: 5
   when: podman_compose_enabled | bool
 
+- name: Install | Check if real Docker binary exists
+  ansible.builtin.stat:
+    path: /usr/bin/docker
+  register: __podman_docker_bin
+
 - name: Install | Podman-docker compatibility
   ansible.builtin.package:
     name: '{{ __podman_docker_package }}'
     state: present
   retries: 3
   delay: 5
-  when: podman_docker_enabled | bool
+  when:
+    - podman_docker_enabled | bool
+    - not (docker_enabled | default(false) | bool)
+    - not (__podman_docker_bin.stat.exists and not __podman_docker_bin.stat.islnk)
 
 - name: Install | Podlet
   ansible.builtin.package:


### PR DESCRIPTION
## Summary

- `podman-docker` provides `/usr/bin/docker` as symlink to podman
- Conflicts with real Docker package when both are enabled
- Add stat check for existing Docker binary and `docker_enabled` variable check

Closes #68

## Test plan

- [x] Docker + Podman coexist without package conflict
- [x] Podman-docker installs when Docker is not present
- [x] Live-tested on Arch Linux workstation with both Docker and Podman

🤖 Generated with [Claude Code](https://claude.com/claude-code)