### PR TITLE
fix: BTRFS NoCOW tasks fail on missing directories

### DIFF
--- a/roles/aide/tasks/btrfs.yml
+++ b/roles/aide/tasks/btrfs.yml
@@ -58,8 +58,5 @@
 - name: BTRFS | Set NoCOW attribute on AIDE database directory
   ansible.builtin.command:
     cmd: chattr +C {{ aide_database | dirname }}
-  register: __aide_chattr
-  changed_when: __aide_chattr.rc == 0
-  # chattr +C may fail in containers or on non-BTRFS filesystems
-  failed_when: false
+  changed_when: true
   when: __aide_is_btrfs | bool

--- a/roles/auditd/tasks/btrfs.yml
+++ b/roles/auditd/tasks/btrfs.yml
@@ -55,11 +55,8 @@
         mode: '0700'
         state: directory
 
-# failed_when: false — chattr +C may fail on non-BTRFS or already-set directories
 - name: BTRFS | Set NoCOW attribute on audit log directory
   ansible.builtin.command:
     cmd: chattr +C {{ auditd_log_file | dirname }}
-  register: __auditd_chattr
-  changed_when: __auditd_chattr.rc == 0
-  failed_when: false
+  changed_when: true
   when: __auditd_is_btrfs | bool

--- a/roles/chrony/tasks/btrfs.yml
+++ b/roles/chrony/tasks/btrfs.yml
@@ -7,6 +7,14 @@
   changed_when: false
   failed_when: false
 
+- name: BTRFS | Ensure log directory exists for NoCOW
+  ansible.builtin.file:
+    path: '{{ chrony_log_dir }}'
+    state: directory
+    mode: '0750'
+  when:
+    - __chrony_log_fstype.stdout | default('') == 'btrfs'
+
 - name: BTRFS | Set NoCOW attribute on log directory
   ansible.builtin.command:
     cmd: chattr +C {{ chrony_log_dir }}

--- a/roles/clamav/tasks/btrfs.yml
+++ b/roles/clamav/tasks/btrfs.yml
@@ -56,7 +56,5 @@
 - name: BTRFS | Set NoCOW attribute on ClamAV database directory
   ansible.builtin.command:
     cmd: chattr +C {{ clamav_database_directory }}
-  register: __clamav_chattr
-  changed_when: __clamav_chattr.rc == 0
-  failed_when: false
+  changed_when: true
   when: __clamav_is_btrfs | bool

--- a/roles/docker/tasks/btrfs.yml
+++ b/roles/docker/tasks/btrfs.yml
@@ -68,8 +68,6 @@
   ansible.builtin.command:
     cmd: chattr +C {{ docker_data_root }}
   changed_when: true
-  # chattr may fail in containers without filesystem support
-  failed_when: false
   when:
     - __docker_is_btrfs | bool
     - "'C' not in (__docker_lsattr.stdout | default(''))"

--- a/roles/fail2ban/tasks/btrfs.yml
+++ b/roles/fail2ban/tasks/btrfs.yml
@@ -67,8 +67,6 @@
   ansible.builtin.command:
     cmd: chattr +C /var/lib/fail2ban
   changed_when: true
-  # chattr may fail in containers without filesystem support
-  failed_when: false
   when:
     - __fail2ban_db_is_btrfs | bool
     - "'C' not in (__fail2ban_db_lsattr.stdout | default(''))"
@@ -82,6 +80,18 @@
   # stat may fail if directory does not exist yet
   failed_when: false
   when: fail2ban_logtarget is not search('SYSLOG|SYSTEMD|STDOUT|STDERR')
+
+- name: BTRFS | Ensure fail2ban log file exists for NoCOW
+  ansible.builtin.copy:
+    content: ''
+    dest: '{{ fail2ban_logtarget }}'
+    force: false
+    owner: root
+    group: root
+    mode: '0640'
+  when:
+    - fail2ban_logtarget is not search('SYSLOG|SYSTEMD|STDOUT|STDERR')
+    - __fail2ban_log_fstype.stdout | default('') == 'btrfs'
 
 - name: BTRFS | Set NoCOW attribute on fail2ban log file
   ansible.builtin.command:

--- a/roles/podman/tasks/btrfs.yml
+++ b/roles/podman/tasks/btrfs.yml
@@ -68,8 +68,6 @@
   ansible.builtin.command:
     cmd: chattr +C {{ podman_storage_root }}
   changed_when: true
-  # chattr may fail in containers without filesystem support
-  failed_when: false
   when:
     - __podman_is_btrfs | bool
     - "'C' not in (__podman_lsattr.stdout | default(''))"

--- a/roles/restic/tasks/btrfs.yml
+++ b/roles/restic/tasks/btrfs.yml
@@ -10,6 +10,17 @@
   failed_when: false
   when: restic_log_to_file | bool
 
+- name: BTRFS | Ensure log directory exists for NoCOW
+  ansible.builtin.file:
+    path: '{{ restic_log_dir }}'
+    state: directory
+    owner: root
+    group: root
+    mode: '0750'
+  when:
+    - restic_log_to_file | bool
+    - __restic_log_fstype.stdout | default('') == 'btrfs'
+
 - name: BTRFS | Set NoCOW on log directory
   ansible.builtin.command:
     cmd: 'chattr +C {{ restic_log_dir }}'


### PR DESCRIPTION
## Summary

- chrony, restic: Create directory before `chattr +C`
- fail2ban: Create log file before `chattr +C`
- podman, docker, clamav, aide, auditd, fail2ban: Remove `failed_when: false`
  from chattr tasks — errors must not be silently swallowed. The `when: btrfs`
  condition already prevents execution on non-BTRFS systems and in containers.

Closes #65

## Test plan

- [x] All BTRFS roles work on fresh BTRFS system (chrony, fail2ban, clamav, auditd, aide, docker, podman)
- [x] No `failed_when: false` on chattr tasks
- [x] Molecule tests still pass (containers are not BTRFS, chattr is skipped)
- [x] Live-tested on Arch Linux BTRFS workstation

🤖 Generated with [Claude Code](https://claude.com/claude-code)