### PR TITLE
fix: Reset FPM service name for system PHP in configure phase

### DIFF
--- a/roles/php/tasks/configure_version.yml
+++ b/roles/php/tasks/configure_version.yml
@@ -19,6 +19,7 @@
       - '/etc/php/conf.d'
     __php_fpm_pool_dir: '/etc/php/php-fpm.d'
     __php_fpm_listen_default: '/run/php-fpm/php-fpm.sock'
+    __php_fpm_service: 'php-fpm'
   when:
     - ansible_facts['os_family'] == 'Archlinux'
     - __php_ver == __php_system_version


### PR DESCRIPTION
## Summary

- Reset `__php_fpm_service` to `php-fpm` in the Arch system-version reset block of `configure_version.yml`
- Without this fix, multi-version PHP setups reload the AUR service name twice instead of both `php-fpm` and `php<ver>-fpm`
- Aligns `configure_version.yml` with the existing correct pattern in `install_version.yml` and `service_version.yml`

Closes #79

## Test plan

- [x] Verified handler reloads both `php-fpm` and `php<ver>-fpm` on multi-version Arch host

🤖 Generated with [Claude Code](https://claude.com/claude-code)