### PR TITLE
fix: Auto-detect /tmp mount type in hardening role

### DIFF
--- a/roles/hardening/molecule/default/Vagrantfile
+++ b/roles/hardening/molecule/default/Vagrantfile
@@ -38,7 +38,7 @@ Vagrant.configure("2") do |config|
 
   if platform.empty? || platform == "hardening-rocky-9"
     config.vm.define "hardening-rocky-9" do |node|
-      node.vm.box = "rockylinux/9"
+      node.vm.box = "bento/rockylinux-9"
       node.vm.hostname = "hardening-rocky-9"
       node.vm.network "forwarded_port", guest: 22, host: 2224, id: "ssh", auto_correct: false
 

--- a/roles/hardening/tasks/filesystem.yml
+++ b/roles/hardening/tasks/filesystem.yml
@@ -3,6 +3,33 @@
 # chicken-and-egg problem where mounting /tmp destroys the Ansible
 # module payload that was extracted there.
 
+# Auto-detect /tmp mount type to avoid breaking non-tmpfs mounts
+# (e.g. BTRFS subvolumes with their own security options)
+- name: Filesystem | Detect current /tmp mount
+  ansible.builtin.command:
+    cmd: findmnt -n -o TARGET,FSTYPE /tmp
+  register: __hardening_tmp_findmnt
+  changed_when: false
+  failed_when: false
+  check_mode: false
+
+- name: Filesystem | Parse /tmp mount info
+  ansible.builtin.set_fact:
+    __hardening_tmp_is_separate: >-
+      {{ __hardening_tmp_findmnt.rc == 0 and
+         (__hardening_tmp_findmnt.stdout.split()[0] | default('')) == '/tmp' }}
+    __hardening_tmp_fstype: >-
+      {{ __hardening_tmp_findmnt.stdout.split()[1] | default('')
+         if __hardening_tmp_findmnt.rc == 0 else '' }}
+
+- name: Filesystem | Skip /tmp if already mounted as non-tmpfs
+  ansible.builtin.set_fact:
+    hardening_fs_mounts: >-
+      {{ hardening_fs_mounts | rejectattr('path', 'equalto', '/tmp') | list }}
+  when:
+    - __hardening_tmp_is_separate | bool
+    - __hardening_tmp_fstype not in ['tmpfs', '']
+
 - name: Filesystem | Configure mount entries in fstab
   ansible.posix.mount:
     path: '{{ item.path }}'


### PR DESCRIPTION
## Summary

- Auto-detect /tmp mount type before applying tmpfs mount
- Skip /tmp when already mounted as non-tmpfs (e.g. BTRFS subvolume), avoiding `Unknown parameter 'size'` errors
- Fix Rocky 9 Vagrant box name (rockylinux/9 → bento/rockylinux-9)

Closes #82

## Test plan

- [x] Molecule test passed on all 4 platforms (Arch, Debian Trixie, Rocky 9, Rocky 10)

🤖 Generated with [Claude Code](https://claude.com/claude-code)