### PR TITLE
refactor!: WireGuard role as standalone tunnel manager (#83)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -288,9 +288,9 @@
         "filename": "roles/wireguard/molecule/default/molecule.yml",
         "hashed_secret": "723646f6fe4303a5e36357b70264ef6dd251f153",
         "is_verified": false,
-        "line_number": 80
+        "line_number": 82
       }
     ]
   },
-  "generated_at": "2026-04-21T19:41:12Z"
+  "generated_at": "2026-04-23T09:54:26Z"
 }

--- a/roles/networkmanager/README.md
+++ b/roles/networkmanager/README.md
@@ -8,7 +8,7 @@ This role provides comprehensive NetworkManager management:
 
 - **Daemon configuration** via `/etc/NetworkManager/conf.d/00-ansible.conf` (DNS backend,
   logging, connectivity checking, WiFi power saving, MAC randomization, etc.)
-- **Connection profiles** (Ethernet, WiFi, WireGuard, VPN) via `community.general.nmcli`
+- **Connection profiles** (Ethernet, WiFi, VPN) via `community.general.nmcli`
 - **Dispatcher scripts** for automatic SMB/SSHFS mounting, VPN auto-connect, WiFi toggling,
   timezone detection
 - **Polkit rules** for unprivileged NetworkManager management
@@ -125,7 +125,6 @@ VPN plugin package names differ by OS:
 networkmanager_connections:
   ethernet: {}
   wifi: {}
-  wireguard: {}
   vpn: {}
 ```
 
@@ -162,23 +161,6 @@ networkmanager_connections:
       autoconnect: true
 ```
 
-#### WireGuard Connections
-
-```yaml
-networkmanager_connections:
-  wireguard:
-    "WG Tunnel":
-      ifname: "wg0"
-      addresses: ["10.0.0.2/24"]
-      dns: ["10.0.0.1"]
-      private_key: "{{ vault_wg_private_key }}"
-      peers:
-        - public_key: "PEER_PUBLIC_KEY"
-          endpoint: "vpn.example.com:51820"
-          allowed_ips: "0.0.0.0/0"
-          persistent_keepalive: 25
-```
-
 #### VPN Connections
 
 ```yaml
@@ -211,10 +193,10 @@ networkmanager_apply_global_dns: true    # enable global DNS application
 # Automatic timezone via ipapi.co
 networkmanager_timezone_enabled: false
 
-# VPN auto-connect on non-home networks
+# VPN auto-connect on non-home networks (via wg-quick/systemd)
 networkmanager_vpn_autoconnect:
   enabled: false
-  connection: ''           # WireGuard connection name
+  interface: ''            # WireGuard interface name (e.g., wg0)
   home_connections: []     # connections where VPN is not needed
 
 # SMB shares (per-user auto-mount)
@@ -308,7 +290,7 @@ Driver: `vagrant` | Platforms: Arch Linux, Debian Trixie, Rocky 9, Rocky 10
 | Script                          | Trigger     | Purpose                                      |
 |---------------------------------|-------------|----------------------------------------------|
 | `09-timezone.sh`                | `up`        | Set timezone via IP geolocation              |
-| `20-vpn-autoconnect.sh`         | `up`/`down` | Auto-activate WireGuard on non-home networks |
+| `20-vpn-autoconnect.sh`         | `up`/`down` | Auto-activate WireGuard tunnel via systemctl |
 | `30-mount-smb.sh`               | `up`        | Mount SMB shares on connection up            |
 | `40-umount-smb.sh`              | `down`      | Unmount SMB shares on connection down        |
 | `30-mount-sshfs.sh`             | `up`        | Mount SSHFS shares                           |

--- a/roles/networkmanager/defaults/main.yml
+++ b/roles/networkmanager/defaults/main.yml
@@ -153,7 +153,6 @@ networkmanager_vpn_plugins: []
 networkmanager_connections:
   ethernet: {}
   wifi: {}
-  wireguard: {}
   vpn: {}
 
 #
@@ -168,11 +167,12 @@ networkmanager_timezone_enabled: false
 
 # VPN Auto-Connect
 
-# Activate a WireGuard connection on non-home networks via dispatcher script.
-# Set enabled: true and configure connection + home_connections to use.
+# Activate a WireGuard tunnel on non-home networks via dispatcher script.
+# The tunnel is managed by the wireguard role (wg-quick/systemd), not NM.
+# Set enabled: true and configure interface + home_connections to use.
 networkmanager_vpn_autoconnect:
   enabled: false
-  connection: ''           # NM WireGuard connection name to activate
+  interface: ''            # WireGuard interface name (e.g., wg0)
   home_connections: []     # Connection names where VPN is NOT needed
 
 # SMB Shares

--- a/roles/networkmanager/handlers/main.yml
+++ b/roles/networkmanager/handlers/main.yml
@@ -11,6 +11,10 @@
     state: restarted
   when: networkmanager_service_enabled | bool
 
+- name: Reload systemd daemon
+  ansible.builtin.systemd_service:
+    daemon_reload: true
+
 - name: Restart polkitd
   ansible.builtin.systemd_service:
     name: '{{ __networkmanager_polkit_service }}'

--- a/roles/networkmanager/tasks/connections.yml
+++ b/roles/networkmanager/tasks/connections.yml
@@ -226,93 +226,6 @@
   changed_when: true
   notify: Reload NetworkManager connections
 
-- name: Connections | Create placeholder for WireGuard connections
-  community.general.nmcli:
-    type: wireguard
-    conn_name: "{{ item.key }}"
-    ifname: "{{ item.value.ifname | default('wg0') }}"
-    state: present
-    autoconnect: false
-  loop: "{{ networkmanager_connections.wireguard | dict2items | default([]) }}"
-  loop_control:
-    label: "{{ item.key }}"
-  when:
-    - item.value.state | default("present") == "present"
-    - item.key not in __nm_existing_connections.stdout_lines | default([])
-
-- name: Connections | Configure NetworkManager WireGuard connections
-  community.general.nmcli:
-    type: wireguard
-    conn_name: "{{ item.key }}"
-    ifname: "{{ item.value.ifname | default('wg0') }}"
-    ip4: "{{ item.value.addresses | first | default(omit) }}"
-    dns4: "{{ item.value.dns | default(omit) }}"
-    autoconnect: "{{ item.value.autoconnect | default(false) }}"
-    never_default4: "{{ item.value.never_default4 | default(omit) }}"
-    method6: "{{ item.value.method6 | default('disabled') }}"
-    wireguard:
-      private-key: "{{ item.value.private_key }}"
-      peer-routes: true
-    state: "{{ item.value.state | default('present') }}"
-  loop: "{{ networkmanager_connections.wireguard | dict2items | default([]) }}"
-  loop_control:
-    label: "{{ item.key }}"
-  no_log: true
-  register: wireguard_connections_result
-
-- name: Connections | Query current WireGuard peer public keys
-  ansible.builtin.shell: |
-    set -o pipefail
-    nmcli -g wireguard.peers connection show "{{ item.key }}" \
-      | grep -oP '(?<=public-key=)[^ ,]+' | sort
-  args:
-    executable: /bin/bash
-  loop: "{{ networkmanager_connections.wireguard | dict2items | default([]) }}"
-  loop_control:
-    label: "{{ item.key }}"
-  when:
-    - item.value.state | default("present") == "present"
-    - item.value.peers is defined
-    - item.value.peers | length > 0
-  register: __networkmanager_current_wg_peers
-  changed_when: false
-  # nmcli may fail if NetworkManager is not running or no connections exist
-  failed_when: false
-
-- name: Connections | Configure WireGuard peers
-  ansible.builtin.shell: |
-    set -euo pipefail
-    {% for peer in item.item.value.peers %}
-    {% set pa = [peer.public_key] %}
-    {% if peer.endpoint is defined %}
-    {% set _ = pa.append('endpoint=' + peer.endpoint) %}
-    {% endif %}
-    {% if peer.allowed_ips is defined %}
-    {% set _ = pa.append('allowed-ips=' + peer.allowed_ips | replace(',', ';')) %}
-    {% endif %}
-    {% if peer.persistent_keepalive is defined %}
-    {% set _ = pa.append('persistent-keepalive=' + peer.persistent_keepalive | string) %}
-    {% endif %}
-    {% if peer.preshared_key is defined %}
-    {% set _ = pa.append('preshared-key=' + peer.preshared_key) %}
-    {% endif %}
-    nmcli connection modify "{{ item.item.key }}" \
-      {{ '' if loop.first else '+' }}wireguard.peers \
-      "{{ pa | join(' ') }}"
-    {% endfor %}
-  args:
-    executable: /bin/bash
-  loop: "{{ __networkmanager_current_wg_peers.results | default([]) }}"
-  loop_control:
-    label: "{{ item.item.key }}"
-  when:
-    - not item.skipped | default(false)
-    - item.item.value.peers | map(attribute='public_key') | sort | list
-      != item.stdout_lines | default([]) | sort | list
-  changed_when: true
-  no_log: true
-  notify: Reload NetworkManager connections
-
 - name: Connections | Ensure NetworkManager VPN connections exist
   community.general.nmcli:
     type: vpn
@@ -329,7 +242,6 @@
     all_network_connections:
       ethernet: {}
       wifi: {}
-      wireguard: {}
       vpn: {}
 
 - name: Connections | Get UUIDs for connections
@@ -341,8 +253,7 @@
   loop: >-
     {{
       (ethernet_connections_result.results | default([])) +
-      (wifi_connections_result.results | default([])) +
-      (wireguard_connections_result.results | default([]))
+      (wifi_connections_result.results | default([]))
     }}
   loop_control:
     label: "{{ item.item.key }}"
@@ -359,8 +270,7 @@
       {{
         all_uuids_with_type | default([]) + [
           item | combine({
-            'type': 'wireguard' if item.item.item.value.peers is defined
-                    else ('wifi' if item.item.item.value.ssid is defined else 'ethernet')
+            'type': 'wifi' if item.item.item.value.ssid is defined else 'ethernet'
           })
         ]
       }}

--- a/roles/networkmanager/tasks/dispatcher.yml
+++ b/roles/networkmanager/tasks/dispatcher.yml
@@ -232,6 +232,62 @@
     path: /etc/NetworkManager/dispatcher.d/50-vpn-smb-mount.sh
     state: absent
 
+- name: Dispatcher | Build list of WireGuard interface dependencies from SMB shares
+  ansible.builtin.set_fact:
+    __networkmanager_smb_wg_deps: >-
+      {{ networkmanager_smb_shares
+         | selectattr('depends_on', 'defined')
+         | map(attribute='depends_on') | flatten
+         | difference(
+             (all_network_connections.ethernet.keys() | list) +
+             (all_network_connections.wifi.keys() | list) +
+             (all_network_connections.vpn.keys() | list))
+         | unique | list }}
+  when: networkmanager_smb_shares | length > 0
+
+- name: Dispatcher | Ensure wg-quick systemd drop-in directory exists
+  ansible.builtin.file:
+    path: /etc/systemd/system/wg-quick@.service.d
+    state: directory
+    owner: root
+    group: root
+    mode: '0755'
+  when: __networkmanager_smb_wg_deps | default([]) | length > 0
+
+- name: Dispatcher | Deploy wg-quick SMB mount systemd drop-in
+  ansible.builtin.template:
+    src: wg-quick-smb.conf.j2
+    dest: /etc/systemd/system/wg-quick@.service.d/smb-mount.conf
+    owner: root
+    group: root
+    mode: '0644'
+  when: __networkmanager_smb_wg_deps | default([]) | length > 0
+  notify: Reload systemd daemon
+
+- name: Dispatcher | Deploy WireGuard SMB mount script
+  ansible.builtin.template:
+    src: wireguard-smb-mount.sh.j2
+    dest: /usr/local/lib/wireguard-smb-mount.sh
+    owner: root
+    group: root
+    mode: '0755'
+  when: __networkmanager_smb_wg_deps | default([]) | length > 0
+  vars:
+    network_connections_data: "{{ all_network_connections }}"
+
+- name: Dispatcher | Remove wg-quick SMB mount systemd drop-in
+  ansible.builtin.file:
+    path: /etc/systemd/system/wg-quick@.service.d/smb-mount.conf
+    state: absent
+  when: __networkmanager_smb_wg_deps | default([]) | length == 0
+  notify: Reload systemd daemon
+
+- name: Dispatcher | Remove WireGuard SMB mount script
+  ansible.builtin.file:
+    path: /usr/local/lib/wireguard-smb-mount.sh
+    state: absent
+  when: __networkmanager_smb_wg_deps | default([]) | length == 0
+
 - name: Dispatcher | Ensure WiFi auto-toggle dispatcher script is installed
   ansible.builtin.template:
     src: dispatcher.d/99-wifi-auto-toggle.sh.j2

--- a/roles/networkmanager/templates/dispatcher.d/20-vpn-autoconnect.sh.j2
+++ b/roles/networkmanager/templates/dispatcher.d/20-vpn-autoconnect.sh.j2
@@ -2,16 +2,18 @@
 #!/bin/sh
 {{ ansible_managed | comment }}
 
-# This script automatically activates a WireGuard VPN connection when connecting
+# This script automatically activates a WireGuard VPN tunnel when connecting
 # to a non-home network, and deactivates it when the base connection drops.
+# The tunnel is managed by wg-quick/systemd, not NetworkManager.
 # This ensures laptops always have VPN connectivity when roaming.
 
 LOG_PREFIX="NM-VPN-Autoconnect"
-VPN_CONNECTION="{{ networkmanager_vpn_autoconnect.connection }}"
+WG_INTERFACE="{{ networkmanager_vpn_autoconnect.interface }}"
+WG_SERVICE="wg-quick@${WG_INTERFACE}.service"
 
 {% set uuid_map = {} %}
 {# Build UUID map for home connections that should NOT trigger VPN #}
-{% for conn_type in ['ethernet', 'wifi', 'wireguard'] %}
+{% for conn_type in ['ethernet', 'wifi'] %}
   {% if network_connections_data[conn_type] is defined %}
     {% for conn_name, conn_details in network_connections_data[conn_type].items() %}
       {% if conn_details.uuid is defined %}
@@ -28,20 +30,7 @@ VPN_CONNECTION="{{ networkmanager_vpn_autoconnect.connection }}"
   {% endif %}
 {% endfor %}
 
-{% set vpn_uuid = uuid_map.get(networkmanager_vpn_autoconnect.connection, '') %}
-
 if [ "$2" = "up" ]; then
-  # Skip if this IS the VPN connection itself
-{% if vpn_uuid %}
-  if [ "$NM_UUID" = "{{ vpn_uuid }}" ]; then
-    exit 0
-  fi
-{% else %}
-  if [ "$CONNECTION_ID" = "$VPN_CONNECTION" ]; then
-    exit 0
-  fi
-{% endif %}
-
 {% if home_uuids | length > 0 %}
 
   # Skip if on a home network connection (VPN not needed)
@@ -54,33 +43,22 @@ if [ "$2" = "up" ]; then
   # Wait briefly for connection to stabilize
   sleep 2
 
-  # Check if VPN is already active
-  if nmcli -t -f NAME connection show --active | grep -q "^${VPN_CONNECTION}$"; then
-    echo "$LOG_PREFIX: VPN ($VPN_CONNECTION) already active."
+  # Check if WireGuard tunnel is already active
+  if systemctl is-active --quiet "$WG_SERVICE"; then
+    echo "$LOG_PREFIX: WireGuard tunnel ($WG_INTERFACE) already active."
     exit 0
   fi
 
-  echo "$LOG_PREFIX: Non-home network detected ($CONNECTION_ID). Activating VPN ($VPN_CONNECTION)."
-  nmcli connection up "$VPN_CONNECTION" 2>&1 | while read -r line; do
+  echo "$LOG_PREFIX: Non-home network detected ($CONNECTION_ID). Activating WireGuard tunnel ($WG_INTERFACE)."
+  systemctl start "$WG_SERVICE" 2>&1 | while read -r line; do
     echo "$LOG_PREFIX: $line"
   done
 fi
 
 if [ "$2" = "down" ]; then
-  # Skip if this IS the VPN connection going down (avoid recursion)
-{% if vpn_uuid %}
-  if [ "$NM_UUID" = "{{ vpn_uuid }}" ]; then
-    exit 0
-  fi
-{% else %}
-  if [ "$CONNECTION_ID" = "$VPN_CONNECTION" ]; then
-    exit 0
-  fi
-{% endif %}
-
-  # Deactivate VPN when the base connection drops
-  if nmcli -t -f NAME connection show --active | grep -q "^${VPN_CONNECTION}$"; then
-    echo "$LOG_PREFIX: Base connection ($CONNECTION_ID) went down. Deactivating VPN ($VPN_CONNECTION)."
-    nmcli connection down "$VPN_CONNECTION" 2>/dev/null
+  # Deactivate WireGuard tunnel when the base connection drops
+  if systemctl is-active --quiet "$WG_SERVICE"; then
+    echo "$LOG_PREFIX: Base connection ($CONNECTION_ID) went down. Deactivating WireGuard tunnel ($WG_INTERFACE)."
+    systemctl stop "$WG_SERVICE" 2>/dev/null
   fi
 fi

--- a/roles/networkmanager/templates/dispatcher.d/30-mount-smb.sh.j2
+++ b/roles/networkmanager/templates/dispatcher.d/30-mount-smb.sh.j2
@@ -3,9 +3,9 @@
 {{ ansible_managed | comment }}
 
 # This script automatically mounts SMB shares based on the active NetworkManager connection.
-# It checks if the current active network connection (Ethernet, Wi-Fi, or WireGuard) is a
-# dependency for any defined SMB share.
-# Shares that depend on legacy VPN connections are excluded and handled by the VPN-specific mount script.
+# It checks if the current active network connection (Ethernet or Wi-Fi) is a dependency
+# for any defined SMB share. WireGuard interface dependencies are checked via systemctl.
+# Shares that depend on VPN connections are excluded and handled by the VPN-specific mount script.
 # Each share is mounted per user into their home directory.
 
 # NM_UUID is provided by NetworkManager dispatcher.
@@ -13,7 +13,7 @@ LOG_PREFIX="NM-SMB-Mount"
 
 {% set uuid_map = {} -%}
 {% set vpn_connection_names = [] -%}
-{% for conn_type in ['ethernet', 'wifi', 'wireguard'] -%}
+{% for conn_type in ['ethernet', 'wifi'] -%}
   {% if network_connections_data[conn_type] is defined -%}
     {% for conn_name, conn_details in network_connections_data[conn_type].items() -%}
       {% if conn_details.uuid is defined -%}
@@ -36,6 +36,7 @@ if [ "$2" = "up" ]; then
   {% for share in networkmanager_smb_shares %}
     {% if share.depends_on is defined and share.depends_on | length > 0 %}
       {% set dependency_uuids_for_this_share = [] %}
+      {% set dependency_wg_interfaces = [] %}
       {% set ns = namespace(has_vpn_dependency=false) %}
 
       {% for dependency_name in share.depends_on %}
@@ -43,12 +44,27 @@ if [ "$2" = "up" ]; then
           {% set ns.has_vpn_dependency = true %}
         {% elif uuid_map[dependency_name] is defined %}
           {% set _ = dependency_uuids_for_this_share.append(uuid_map[dependency_name]) %}
+        {% else %}
+          {% set _ = dependency_wg_interfaces.append(dependency_name) %}
         {% endif %}
       {% endfor %}
 
-      {% if not ns.has_vpn_dependency and dependency_uuids_for_this_share | length > 0 %}
-  # Check if the current NM_UUID matches any of the share's network connection dependencies
+      {% if not ns.has_vpn_dependency and (dependency_uuids_for_this_share | length > 0 or dependency_wg_interfaces | length > 0) %}
+  # Check if any dependency is satisfied for share '{{ share.name }}'
+  SHOULD_MOUNT="false"
+        {% if dependency_uuids_for_this_share | length > 0 %}
+  # NM connection dependencies
   if {% for uuid in dependency_uuids_for_this_share %}[ "$NM_UUID" = "{{ uuid }}" ]{% if not loop.last %} || {% endif %}{% endfor %}; then
+    SHOULD_MOUNT="true"
+  fi
+        {% endif %}
+        {% if dependency_wg_interfaces | length > 0 %}
+  # WireGuard interface dependencies (managed by wg-quick/systemd)
+  if {% for iface in dependency_wg_interfaces %}systemctl is-active --quiet "wg-quick@{{ iface }}.service"{% if not loop.last %} || {% endif %}{% endfor %}; then
+    SHOULD_MOUNT="true"
+  fi
+        {% endif %}
+  if [ "$SHOULD_MOUNT" = "true" ]; then
         {% for smb_user in share.users %}
           {% set user_home = user_homes[smb_user.name] | default('/home/' + smb_user.name) %}
           {% set mount_point = user_home + '/' + share.mount_subpath %}
@@ -59,7 +75,7 @@ if [ "$2" = "up" ]; then
           {% endfor %}
     # Mount for user {{ smb_user.name }}
     if ! mountpoint -q "{{ mount_point }}"; then
-      echo "$LOG_PREFIX: Current connection (UUID: $NM_UUID) is a dependency for share '{{ share.name }}'. Mounting {{ mount_point }} for {{ smb_user.name }}"
+      echo "$LOG_PREFIX: Dependency satisfied for share '{{ share.name }}'. Mounting {{ mount_point }} for {{ smb_user.name }}"
       mkdir -p "{{ mount_point }}"
       mount -t cifs -o {{ opts | join(',') }} {{ share.src }} "{{ mount_point }}"
     else

--- a/roles/networkmanager/templates/dispatcher.d/40-umount-smb.sh.j2
+++ b/roles/networkmanager/templates/dispatcher.d/40-umount-smb.sh.j2
@@ -4,7 +4,8 @@
 
 # This script attempts to unmount SMB shares when a network connection goes down (e.g., unexpected disconnect).
 # It ensures a share is only unmounted if none of its dependencies are active anymore.
-# Shares that depend on legacy VPN connections are excluded and handled by the VPN-specific umount script.
+# WireGuard interface dependencies are checked via systemctl.
+# Shares that depend on VPN connections are excluded and handled by the VPN-specific umount script.
 # Each share is unmounted per user from their home directory.
 
 # NM_UUID is provided by NetworkManager dispatcher.
@@ -12,7 +13,7 @@ LOG_PREFIX="NM-SMB-Unmount-Down"
 
 {% set id_map = {} -%}
 {% if network_connections_data is defined -%}
-  {% for conn_type in ['ethernet', 'wifi', 'wireguard'] -%}
+  {% for conn_type in ['ethernet', 'wifi'] -%}
     {% if network_connections_data[conn_type] is defined -%}
       {% for conn_name, conn_details in network_connections_data[conn_type].items() -%}
         {% if conn_details.uuid is defined -%}
@@ -31,7 +32,7 @@ LOG_PREFIX="NM-SMB-Unmount-Down"
 {% for user in users_list | default([]) -%}
   {% set _ = user_homes.update({user.name: user.home | default('/home/' + user.name)}) -%}
 {% endfor -%}
-# Function to get all currently active connection IDs (UUIDs for base, names for VPNs)
+# Function to get all currently active NM connection IDs (UUIDs for base, names for VPNs)
 get_active_connection_ids() {
   nmcli -t -f UUID,TYPE,NAME connection show --active | while IFS=':' read -r uuid type name; do
     if [ "$type" = "vpn" ]; then
@@ -47,25 +48,33 @@ if [ "$2" = "down" ]; then
 {% if networkmanager_smb_shares is defined and networkmanager_smb_shares is not none and networkmanager_smb_shares | length > 0 %}
 
   {% for share in networkmanager_smb_shares %}
-    {% set resolved_dependencies = [] %}
+    {% set resolved_nm_dependencies = [] %}
+    {% set wg_interface_dependencies = [] %}
     {% for dependency_name in share.depends_on %}
       {% if id_map[dependency_name] is defined %}
-        {% set _ = resolved_dependencies.append(id_map[dependency_name]) %}
+        {% set _ = resolved_nm_dependencies.append(id_map[dependency_name]) %}
+      {% else %}
+        {% set _ = wg_interface_dependencies.append(dependency_name) %}
       {% endif %}
     {% endfor %}
 
-    {% if resolved_dependencies | length > 0 %}
+    {% if resolved_nm_dependencies | length > 0 or wg_interface_dependencies | length > 0 %}
       {% for smb_user in share.users %}
         {% set user_home = user_homes[smb_user.name] | default('/home/' + smb_user.name) %}
         {% set mount_point = user_home + '/' + share.mount_subpath %}
   # Check if the share is currently mounted for {{ smb_user.name }}
   if mountpoint -q "{{ mount_point }}"; then
     SHARE_STILL_NEEDED="false"
-        {% for dep_id in resolved_dependencies %}
-    # Check if this dependency is still active
+        {% for dep_id in resolved_nm_dependencies %}
+    # Check if NM dependency is still active
     if echo "$ACTIVE_IDS" | grep -q "^{{ dep_id }}$"; then
       SHARE_STILL_NEEDED="true"
-      break
+    fi
+        {% endfor %}
+        {% for iface in wg_interface_dependencies %}
+    # Check if WireGuard interface dependency is still active
+    if systemctl is-active --quiet "wg-quick@{{ iface }}.service"; then
+      SHARE_STILL_NEEDED="true"
     fi
         {% endfor %}
 

--- a/roles/networkmanager/templates/dispatcher.d/50-vpn-mount-smb.sh.j2
+++ b/roles/networkmanager/templates/dispatcher.d/50-vpn-mount-smb.sh.j2
@@ -11,7 +11,7 @@ LOG_PREFIX="NM-VPN-SMB-Mount"
 
 {% set id_map = {} -%}
 {% if network_connections_data is defined -%}
-  {% for conn_type in ['ethernet', 'wifi', 'wireguard'] -%}
+  {% for conn_type in ['ethernet', 'wifi'] -%}
     {% if network_connections_data[conn_type] is defined -%}
       {% for conn_name, conn_details in network_connections_data[conn_type].items() -%}
         {% if conn_details.uuid is defined -%}

--- a/roles/networkmanager/templates/dispatcher.d/60-vpn-umount-smb.sh.j2
+++ b/roles/networkmanager/templates/dispatcher.d/60-vpn-umount-smb.sh.j2
@@ -12,7 +12,7 @@ LOG_PREFIX="NM-VPN-SMB-Umount"
 
 {% set id_map = {} -%}
 {% if network_connections_data is defined -%}
-  {% for conn_type in ['ethernet', 'wifi', 'wireguard'] -%}
+  {% for conn_type in ['ethernet', 'wifi'] -%}
     {% if network_connections_data[conn_type] is defined -%}
       {% for conn_name, conn_details in network_connections_data[conn_type].items() -%}
         {% if conn_details.uuid is defined -%}

--- a/roles/networkmanager/templates/dispatcher.d/pre-down.d/30-umount-smb.sh.j2
+++ b/roles/networkmanager/templates/dispatcher.d/pre-down.d/30-umount-smb.sh.j2
@@ -11,7 +11,7 @@ LOG_PREFIX="NM-SMB-Unmount-PreDown"
 
 {% set id_map = {} -%}
 {% if network_connections_data is defined -%}
-  {% for conn_type in ['ethernet', 'wifi', 'wireguard'] -%}
+  {% for conn_type in ['ethernet', 'wifi'] -%}
     {% if network_connections_data[conn_type] is defined -%}
       {% for conn_name, conn_details in network_connections_data[conn_type].items() -%}
         {% if conn_details.uuid is defined -%}

--- a/roles/networkmanager/templates/wg-quick-smb.conf.j2
+++ b/roles/networkmanager/templates/wg-quick-smb.conf.j2
@@ -1,0 +1,9 @@
+{{ ansible_managed | comment(decoration='# ') }}
+#
+# systemd drop-in for wg-quick@.service
+# Mounts/unmounts SMB shares when WireGuard tunnels start/stop.
+#
+
+[Service]
+ExecStartPost=/usr/local/lib/wireguard-smb-mount.sh %i up
+ExecStopPost=-/usr/local/lib/wireguard-smb-mount.sh %i down

--- a/roles/networkmanager/templates/wireguard-smb-mount.sh.j2
+++ b/roles/networkmanager/templates/wireguard-smb-mount.sh.j2
@@ -1,0 +1,90 @@
+#jinja2:lstrip_blocks: True
+#!/bin/sh
+{{ ansible_managed | comment }}
+
+# This script is called by wg-quick@.service via systemd drop-in.
+# It mounts/unmounts SMB shares that depend on WireGuard interfaces.
+# Arguments: <interface_name> up|down
+
+WG_INTERFACE="$1"
+ACTION="$2"
+LOG_PREFIX="WG-SMB-${ACTION}"
+
+{% set user_homes = {} -%}
+{% for user in users_list | default([]) -%}
+  {% set _ = user_homes.update({user.name: user.home | default('/home/' + user.name)}) -%}
+{% endfor -%}
+{% set nm_connection_names = [] -%}
+{% if network_connections_data is defined -%}
+  {% for conn_type in ['ethernet', 'wifi'] -%}
+    {% if network_connections_data[conn_type] is defined -%}
+      {% for conn_name in network_connections_data[conn_type].keys() -%}
+        {% set _ = nm_connection_names.append(conn_name) -%}
+      {% endfor -%}
+    {% endif -%}
+  {% endfor -%}
+  {% if network_connections_data.vpn is defined -%}
+    {% for vpn_name in network_connections_data.vpn.keys() -%}
+      {% set _ = nm_connection_names.append(vpn_name) -%}
+    {% endfor -%}
+  {% endif -%}
+{% endif -%}
+{% if networkmanager_smb_shares is defined and networkmanager_smb_shares is not none and networkmanager_smb_shares | length > 0 %}
+if [ "$ACTION" = "up" ]; then
+  {% for share in networkmanager_smb_shares %}
+    {% set wg_interface_deps = [] %}
+    {% for dep_name in share.depends_on | default([]) %}
+      {% if dep_name not in nm_connection_names %}
+        {% set _ = wg_interface_deps.append(dep_name) %}
+      {% endif %}
+    {% endfor %}
+    {% if wg_interface_deps | length > 0 %}
+  # Check if this interface is a dependency for share '{{ share.name }}'
+  if {% for iface in wg_interface_deps %}[ "$WG_INTERFACE" = "{{ iface }}" ]{% if not loop.last %} || {% endif %}{% endfor %}; then
+      {% for smb_user in share.users %}
+        {% set user_home = user_homes[smb_user.name] | default('/home/' + smb_user.name) %}
+        {% set mount_point = user_home + '/' + share.mount_subpath %}
+        {% set creds_path = user_home + '/' + networkmanager_smb_credentials_dir + '/' + share.credentials_name + '-credentials' %}
+        {% set opts = ['uid=$(id -u ' + smb_user.name + ')', 'gid=$(id -g ' + smb_user.name + ')', 'credentials=' + creds_path] %}
+        {% for key, value in (share.mount_options | default({})).items() %}
+          {% set _ = opts.append(key + '=' + value | string) %}
+        {% endfor %}
+    # Mount for user {{ smb_user.name }}
+    if ! mountpoint -q "{{ mount_point }}"; then
+      echo "$LOG_PREFIX: WireGuard interface ($WG_INTERFACE) is a dependency for share '{{ share.name }}'. Mounting {{ mount_point }} for {{ smb_user.name }}"
+      mkdir -p "{{ mount_point }}"
+      mount -t cifs -o {{ opts | join(',') }} {{ share.src }} "{{ mount_point }}"
+    else
+      echo "$LOG_PREFIX: Share '{{ share.name }}' ({{ mount_point }}) already mounted for {{ smb_user.name }}."
+    fi
+      {% endfor %}
+  fi
+    {% endif %}
+  {% endfor %}
+fi
+
+if [ "$ACTION" = "down" ]; then
+  {% for share in networkmanager_smb_shares %}
+    {% set wg_interface_deps = [] %}
+    {% for dep_name in share.depends_on | default([]) %}
+      {% if dep_name not in nm_connection_names %}
+        {% set _ = wg_interface_deps.append(dep_name) %}
+      {% endif %}
+    {% endfor %}
+    {% if wg_interface_deps | length > 0 %}
+  # Check if this interface is a dependency for share '{{ share.name }}'
+  if {% for iface in wg_interface_deps %}[ "$WG_INTERFACE" = "{{ iface }}" ]{% if not loop.last %} || {% endif %}{% endfor %}; then
+      {% for smb_user in share.users %}
+        {% set user_home = user_homes[smb_user.name] | default('/home/' + smb_user.name) %}
+        {% set mount_point = user_home + '/' + share.mount_subpath %}
+    # Unmount for user {{ smb_user.name }}
+    if mountpoint -q "{{ mount_point }}"; then
+      echo "$LOG_PREFIX: WireGuard interface ($WG_INTERFACE) went down. Unmounting share '{{ share.name }}' ({{ mount_point }}) for {{ smb_user.name }}."
+      umount -t cifs -l "{{ mount_point }}"
+    fi
+      {% endfor %}
+  fi
+    {% endif %}
+  {% endfor %}
+fi
+{% endif %}

--- a/roles/wireguard/README.md
+++ b/roles/wireguard/README.md
@@ -1,12 +1,16 @@
 # marcstraube.common.wireguard
 
-Configure WireGuard VPN tunnels in server or client mode.
+Configure WireGuard VPN tunnels with multi-interface support.
 
 ## Description
 
-Manages WireGuard VPN interface configuration in server or client mode with
-automatic key generation, peer management, lifecycle scripts (pre/post up/down),
-IP forwarding via sysctl, firewalld integration, and systemd service management.
+Manages one or more WireGuard VPN interfaces per host, each in server or client
+mode. Features automatic key generation, peer management, lifecycle scripts
+(pre/post up/down), IP forwarding via sysctl, firewalld integration, and systemd
+service management via wg-quick.
+
+Each interface is independently configured and managed as a
+`wg-quick@<name>.service` systemd unit.
 
 ## Requirements
 
@@ -31,78 +35,136 @@ overrides if needed.
 
 ### Role Control
 
-| Variable                    | Default | Description                            |
-|-----------------------------|---------|----------------------------------------|
-| `wireguard_enabled`         | `true`  | Enable the wireguard role              |
-| `wireguard_service_enabled` | `true`  | Enable and start the WireGuard service |
+| Variable                    | Default            | Description                             |
+|-----------------------------|--------------------|-----------------------------------------|
+| `wireguard_enabled`         | `true`             | Enable the wireguard role               |
+| `wireguard_service_enabled` | `true`             | Enable and start services per interface |
+| `wireguard_config_dir`      | `'/etc/wireguard'` | Key/config directory                    |
 
 ### Interface Configuration
 
-| Variable                 | Default           | Description                           |
-|--------------------------|-------------------|---------------------------------------|
-| `wireguard_interface`    | `'wg0'`           | Interface name                        |
-| `wireguard_address`      | `'10.100.0.1/24'` | IPv4 address (CIDR)                   |
-| `wireguard_address_ipv6` | `''`              | IPv6 address (CIDR, optional)         |
-| `wireguard_port`         | `51820`           | Listen port (UDP)                     |
-| `wireguard_private_key`  | `''`              | Private key (auto-generated if empty) |
-| `wireguard_dns`          | `['10.100.0.1']`  | DNS servers (client mode)             |
-| `wireguard_mtu`          | `0`               | Interface MTU (0 = auto)              |
-| `wireguard_table`        | `'auto'`          | Routing table (auto, off, or number)  |
-| `wireguard_fwmark`       | `''`              | Firewall mark for outgoing packets    |
-| `wireguard_saveconfig`   | `false`           | Save runtime config on shutdown       |
+All interface settings are defined as a list of dicts in `wireguard_interfaces`.
 
-### Server Mode
+```yaml
+wireguard_interfaces:
+  - name: wg0
+    address: '10.100.0.1/24'
+    port: 51820
+    mode: server
+    ip_forward: true
+    peers:
+      - name: laptop
+        public_key: '{{ vault_wireguard_keys.wg0.peer_laptop_pubkey }}'
+        allowed_ips: '10.100.0.2/32'
+        persistent_keepalive: 25
+```
 
-| Variable                | Default | Description                 |
-|-------------------------|---------|-----------------------------|
-| `wireguard_server_mode` | `true`  | Enable server mode          |
-| `wireguard_ip_forward`  | `true`  | Enable IPv4/IPv6 forwarding |
+#### Per-Interface Keys
 
-### Peers
+| Key                  | Default      | Description                                      |
+|----------------------|--------------|--------------------------------------------------|
+| `name`               | **required** | Interface name (wg0, wg1, ...)                   |
+| `address`            | **required** | IPv4 address (CIDR notation)                     |
+| `address_ipv6`       | `''`         | IPv6 address (CIDR, optional)                    |
+| `port`               | `51820`      | Listen port (UDP)                                |
+| `private_key`        | `''`         | Private key (auto-generated if empty)            |
+| `mode`               | `'server'`   | Interface mode: `server` or `client`             |
+| `ip_forward`         | `true`       | Enable IP forwarding (server mode)               |
+| `dns`                | `[]`         | DNS servers written to wg.conf (client mode)     |
+| `peers`              | `[]`         | List of peer definitions (see below)             |
+| `firewalld_enabled`  | `true`       | Enable firewalld integration                     |
+| `firewalld_zone`     | `'public'`   | Firewalld zone for WireGuard port                |
+| `preup`              | `[]`         | Commands run before interface up                 |
+| `postup`             | `[]`         | Commands run after interface up                  |
+| `predown`            | `[]`         | Commands run before interface down               |
+| `postdown`           | `[]`         | Commands run after interface down                |
+| `generate_keys`      | `true`       | Auto-generate keys if private_key is empty       |
+| `mtu`                | `0`          | Interface MTU (0 = auto)                         |
+| `table`              | `'auto'`     | Routing table (auto, off, or number)             |
+| `fwmark`             | `''`         | Firewall mark for outgoing packets               |
+| `saveconfig`         | `false`      | Save runtime config on shutdown                  |
+| `config_mode`        | `'0600'`     | Config file permissions                          |
 
-| Variable          | Default | Description              |
-|-------------------|---------|--------------------------|
-| `wireguard_peers` | `[]`    | List of peer definitions |
+Use `%i` as placeholder for the interface name in lifecycle scripts.
 
-Each peer dict supports: `name`, `public_key`, `allowed_ips`, `preshared_key`,
-`endpoint`, `persistent_keepalive`, `description`.
+#### Peer Definition
 
-### Client Mode
+| Key                    | Default | Description                               |
+|------------------------|---------|-------------------------------------------|
+| `name`                 |         | Peer name (used as comment in config)     |
+| `public_key`           |         | Peer's public key                         |
+| `allowed_ips`          |         | Allowed IPs for this peer                 |
+| `preshared_key`        | `''`    | Preshared key for additional security     |
+| `endpoint`             | `''`    | Endpoint address (IP:Port)                |
+| `persistent_keepalive` | `0`     | Keepalive interval (seconds, 0 = off)     |
+| `description`          | `''`    | Description/comment                       |
 
-| Variable                                | Default           | Description                  |
-|-----------------------------------------|-------------------|------------------------------|
-| `wireguard_client_mode`                 | `false`           | Enable client mode           |
-| `wireguard_client_endpoint`             | `''`              | Server endpoint (IP:Port)    |
-| `wireguard_client_server_pubkey`        | `''`              | Server public key            |
-| `wireguard_client_preshared_key`        | `''`              | Preshared key (optional)     |
-| `wireguard_client_allowed_ips`          | `'10.100.0.0/24'` | Allowed IPs to route         |
-| `wireguard_client_persistent_keepalive` | `25`              | Keepalive interval (seconds) |
+### Server Mode Example
 
-### Lifecycle Scripts
+```yaml
+wireguard_interfaces:
+  - name: wg0
+    address: '10.100.0.1/24'
+    port: 51820
+    private_key: '{{ vault_wireguard_keys.wg0.private_key }}'
+    mode: server
+    ip_forward: true
+    peers:
+      - name: laptop
+        public_key: '{{ vault_wireguard_keys.wg0.peer_laptop_pubkey }}'
+        allowed_ips: '10.100.0.2/32'
+        persistent_keepalive: 25
+      - name: phone
+        public_key: '{{ vault_wireguard_keys.wg0.peer_phone_pubkey }}'
+        allowed_ips: '10.100.0.3/32'
+```
 
-| Variable             | Default | Description                        |
-|----------------------|---------|------------------------------------|
-| `wireguard_preup`    | `[]`    | Commands run before interface up   |
-| `wireguard_postup`   | `[]`    | Commands run after interface up    |
-| `wireguard_predown`  | `[]`    | Commands run before interface down |
-| `wireguard_postdown` | `[]`    | Commands run after interface down  |
+### Client Mode Example
 
-Use `%i` as placeholder for the interface name.
+```yaml
+wireguard_interfaces:
+  - name: wg0
+    address: '10.100.0.2/32'
+    port: 51820
+    private_key: '{{ vault_wireguard_keys.wg0.private_key }}'
+    mode: client
+    dns:
+      - '10.100.0.1'
+    peers:
+      - name: server
+        public_key: '{{ vault_wireguard_keys.wg0.server_pubkey }}'
+        endpoint: '{{ vault_wireguard_keys.wg0.server_endpoint }}'
+        allowed_ips: '10.100.0.0/24'
+        persistent_keepalive: 25
+```
 
-### Firewall
+### Multi-Interface Example
 
-| Variable                      | Default    | Description                       |
-|-------------------------------|------------|-----------------------------------|
-| `wireguard_firewalld_enabled` | `true`     | Enable firewalld integration      |
-| `wireguard_firewalld_zone`    | `'public'` | Firewalld zone for WireGuard port |
-
-### Key Management
-
-| Variable                  | Default            | Description                  |
-|---------------------------|--------------------|------------------------------|
-| `wireguard_config_dir`    | `'/etc/wireguard'` | Key/config directory         |
-| `wireguard_generate_keys` | `true`             | Auto-generate WireGuard keys |
-| `wireguard_config_mode`   | `'0600'`           | Config file permissions      |
+```yaml
+wireguard_interfaces:
+  - name: wg0
+    address: '10.100.0.1/24'
+    port: 51820
+    mode: server
+    ip_forward: true
+    peers:
+      - name: road-warrior
+        public_key: '{{ vault_wireguard_keys.wg0.peer_rw_pubkey }}'
+        allowed_ips: '10.100.0.2/32'
+  - name: wg1
+    address: '10.200.0.2/32'
+    port: 51821
+    mode: client
+    dns:
+      - '10.200.0.1'
+    firewalld_enabled: false
+    peers:
+      - name: corporate-vpn
+        public_key: '{{ vault_wireguard_keys.wg1.server_pubkey }}'
+        endpoint: '{{ vault_wireguard_keys.wg1.server_endpoint }}'
+        allowed_ips: '10.200.0.0/16'
+        persistent_keepalive: 25
+```
 
 ## Tags
 

--- a/roles/wireguard/defaults/main.yml
+++ b/roles/wireguard/defaults/main.yml
@@ -6,162 +6,76 @@
 # Enable the wireguard role
 wireguard_enabled: true
 
-# Enable and start the WireGuard service
+# Enable and start WireGuard services (per interface)
 wireguard_service_enabled: true
 
 #
-# Interface Configuration
-#
-
-# Interface name (wg0, wg1, etc.)
-wireguard_interface: 'wg0'
-
-# Server's WireGuard IP address (CIDR notation)
-wireguard_address: '10.100.0.1/24'
-
-# IPv6 address (optional)
-wireguard_address_ipv6: ''
-
-# Listen port (UDP)
-wireguard_port: 51820
-
-# Private key (auto-generated if empty)
-wireguard_private_key: ''
-
-# DNS servers for clients
-wireguard_dns:
-  - '10.100.0.1'
-
-#
-# Server Mode
-#
-
-# Enable server mode (IP forwarding, firewalld masquerade)
-wireguard_server_mode_enabled: true
-
-# Enable IP forwarding
-wireguard_ip_forward_enabled: true
-
-#
-# Peers
-#
-
-# List of peer definitions
-wireguard_peers: []
-# Example:
-#   - name: 'laptop'
-#     public_key: 'abc123...'
-#     # Preshared key for additional security (optional)
-#     preshared_key: ''
-#     # Allowed IPs for this peer
-#     allowed_ips: '10.100.0.2/32'
-#     # Endpoint for site-to-site (optional)
-#     endpoint: ''
-#     # Persistent keepalive (seconds, 0 = disabled)
-#     persistent_keepalive: 25
-#     # Description/comment
-#     description: 'Work laptop'
-
-#
-# Client Mode
-#
-# When this host connects to another WireGuard server.
-
-# Enable client mode
-wireguard_client_mode_enabled: false
-
-# Server endpoint (IP:Port)
-wireguard_client_endpoint: ''
-
-# Server's public key
-wireguard_client_server_pubkey: ''
-
-# Preshared key (optional)
-wireguard_client_preshared_key: ''
-
-# Allowed IPs to route through VPN
-# Use '0.0.0.0/0, ::/0' for full tunnel
-wireguard_client_allowed_ips: '10.100.0.0/24'
-
-# Persistent keepalive (for NAT traversal)
-wireguard_client_persistent_keepalive: 25
-
-#
-# Firewall
-#
-
-# Enable firewalld integration
-wireguard_firewalld_enabled: true
-
-# Firewalld zone for WireGuard port
-wireguard_firewalld_zone: 'public'
-
-#
-# Key Management
+# Global Configuration
 #
 
 # Directory for storing keys and configuration
 wireguard_config_dir: '/etc/wireguard'
 
-# Auto-generate WireGuard keys if not provided
-wireguard_generate_keys_enabled: true
-
-# File permissions for configuration files
-wireguard_config_mode: '0600'
-
 #
-# Lifecycle Scripts
+# Interface Configuration
 #
-# Custom commands executed by wg-quick on tunnel up/down.
-# Use this for NAT/masquerade when not using firewalld, or any other
-# tunnel lifecycle hooks. %i expands to the interface name.
 
-# Commands run before interface up
-wireguard_preup: []
+# List of WireGuard interfaces to configure.
+# Each interface is a standalone tunnel managed by wg-quick/systemd.
+wireguard_interfaces: []
 # Example:
-#   - 'sysctl -w net.ipv4.conf.%i.rp_filter=2'
-
-# Commands run after interface up
-wireguard_postup: []
-# Example:
-#   - 'iptables -t nat -A POSTROUTING -s 10.100.0.0/24 -o eth0 -j MASQUERADE'
-#   - 'iptables -A FORWARD -i %i -j ACCEPT'
-
-# Commands run before interface down
-wireguard_predown: []
-# Example:
-#   - 'echo "Shutting down %i"'
-
-# Commands run after interface down
-wireguard_postdown: []
-# Example:
-#   - 'iptables -t nat -D POSTROUTING -s 10.100.0.0/24 -o eth0 -j MASQUERADE'
-#   - 'iptables -D FORWARD -i %i -j ACCEPT'
-
+#   - name: wg0
+#     # Server's WireGuard IP address (CIDR notation)
+#     address: '10.100.0.1/24'
+#     # IPv6 address (optional)
+#     address_ipv6: ''
+#     # Listen port (UDP)
+#     port: 51820
+#     # Private key (auto-generated if empty)
+#     private_key: ''
+#     # Interface mode: server (IP forwarding, masquerade) or client (DNS, keepalive)
+#     mode: server
 #
-# Save Config
+#     # Server mode: enable IP forwarding via sysctl
+#     ip_forward: true
 #
-
-# Save runtime config on shutdown (wg-quick SaveConfig directive)
-wireguard_saveconfig_enabled: false
-
+#     # Client mode: DNS servers written to wg.conf
+#     dns: []
 #
-# Firewall Mark
+#     # Peer definitions
+#     peers:
+#       - name: 'laptop'
+#         public_key: 'abc123...'
+#         # Allowed IPs for this peer
+#         allowed_ips: '10.100.0.2/32'
+#         # Preshared key for additional security (optional)
+#         preshared_key: ''
+#         # Endpoint for site-to-site or client mode (optional)
+#         endpoint: ''
+#         # Persistent keepalive (seconds, 0 = disabled)
+#         persistent_keepalive: 0
+#         # Description/comment
+#         description: 'Work laptop'
 #
-
-# Firewall mark for outgoing WireGuard packets (empty = disabled)
-wireguard_fwmark: ''
-
+#     # Firewalld integration (per interface)
+#     firewalld_enabled: true
+#     firewalld_zone: 'public'
 #
-# MTU
+#     # Lifecycle scripts (commands run by wg-quick, %i = interface name)
+#     preup: []
+#     postup: []
+#     predown: []
+#     postdown: []
 #
-
-# MTU for WireGuard interface (0 = auto)
-wireguard_mtu: 0
-
-#
-# Table
-#
-
-# Routing table (auto, off, or table number)
-wireguard_table: 'auto'
+#     # Auto-generate WireGuard keys if private_key is empty
+#     generate_keys: true
+#     # MTU (0 = auto)
+#     mtu: 0
+#     # Routing table (auto, off, or table number)
+#     table: 'auto'
+#     # Firewall mark for outgoing packets (empty = disabled)
+#     fwmark: ''
+#     # Save runtime config on shutdown
+#     saveconfig: false
+#     # File permissions for configuration file
+#     config_mode: '0600'

--- a/roles/wireguard/handlers/main.yml
+++ b/roles/wireguard/handlers/main.yml
@@ -5,17 +5,3 @@
   # Container-safety for molecule
   failed_when: false
   when: wireguard_enabled | bool
-
-- name: Restart WireGuard
-  ansible.builtin.systemd_service:
-    name: '{{ __wireguard_service_name }}'
-    state: restarted
-  when: wireguard_service_enabled | bool
-
-- name: Reload WireGuard
-  ansible.builtin.command:
-    cmd: 'wg syncconf {{ wireguard_interface }} <(wg-quick strip {{ wireguard_interface }})'
-  args:
-    executable: /bin/bash
-  changed_when: true
-  when: wireguard_service_enabled | bool

--- a/roles/wireguard/meta/main.yml
+++ b/roles/wireguard/meta/main.yml
@@ -1,7 +1,7 @@
 ---
 galaxy_info:
   author: Marc Straube
-  description: Configure WireGuard VPN server and client
+  description: Configure WireGuard VPN tunnels with multi-interface support
   license: MIT
   min_ansible_version: '2.17'
 

--- a/roles/wireguard/molecule/default/Vagrantfile
+++ b/roles/wireguard/molecule/default/Vagrantfile
@@ -38,7 +38,7 @@ Vagrant.configure("2") do |config|
 
   if platform.empty? || platform == "wireguard-rocky-9"
     config.vm.define "wireguard-rocky-9" do |node|
-      node.vm.box = "rockylinux/9"
+      node.vm.box = "bento/rockylinux-9"
       node.vm.hostname = "wireguard-rocky-9"
       node.vm.network "forwarded_port", guest: 22, host: 2224, id: "ssh", auto_correct: false
 

--- a/roles/wireguard/molecule/default/molecule.yml
+++ b/roles/wireguard/molecule/default/molecule.yml
@@ -69,17 +69,19 @@ provisioner:
         # Centralized test configuration variables
         wireguard_enabled: true
         wireguard_service_enabled: true
-        wireguard_interface: 'wg0'
-        wireguard_address: '10.100.0.1/24'
-        wireguard_port: 51820
-        wireguard_server_mode: true
-        wireguard_generate_keys: true
-        wireguard_firewalld_enabled: false
-        wireguard_peers:
-          - name: 'test-client'
-            public_key: 'DkI14ou7LuomS8yKwmPiBMslAt6g29+33GEA92doHXA='
-            allowed_ips: '10.100.0.2/32'
-            persistent_keepalive: 25
+        wireguard_interfaces:
+          - name: wg0
+            address: '10.100.0.1/24'
+            port: 51820
+            mode: server
+            ip_forward: true
+            generate_keys: true
+            firewalld_enabled: false
+            peers:
+              - name: 'test-client'
+                public_key: 'DkI14ou7LuomS8yKwmPiBMslAt6g29+33GEA92doHXA='
+                allowed_ips: '10.100.0.2/32'
+                persistent_keepalive: 25
 
   playbooks:
     create: create.yml

--- a/roles/wireguard/molecule/default/verify.yml
+++ b/roles/wireguard/molecule/default/verify.yml
@@ -130,7 +130,7 @@
 
     - name: Verify | Check WireGuard service status
       ansible.builtin.systemd_service:
-        name: '{{ __wireguard_service_name }}'
+        name: 'wg-quick@wg0'
       register: __wireguard_svc_check
 
     - name: Verify | Assert WireGuard service is active and enabled

--- a/roles/wireguard/tasks/configure.yml
+++ b/roles/wireguard/tasks/configure.yml
@@ -2,9 +2,17 @@
 - name: Configure | Deploy WireGuard configuration
   ansible.builtin.template:
     src: wg.conf.j2
-    dest: '{{ wireguard_config_dir }}/{{ wireguard_interface }}.conf'
+    dest: '{{ wireguard_config_dir }}/{{ __wireguard_iface.name }}.conf'
     owner: root
     group: root
-    mode: '{{ wireguard_config_mode }}'
-  notify: Restart WireGuard
+    mode: '{{ __wireguard_iface.config_mode | default("0600") }}'
+  register: __wireguard_config_changed
   no_log: true
+
+- name: Configure | Restart WireGuard service
+  ansible.builtin.systemd_service:
+    name: 'wg-quick@{{ __wireguard_iface.name }}'
+    state: restarted
+  when:
+    - __wireguard_config_changed is changed
+    - wireguard_service_enabled | bool

--- a/roles/wireguard/tasks/firewall.yml
+++ b/roles/wireguard/tasks/firewall.yml
@@ -7,29 +7,29 @@
 
 - name: Firewall | Manage WireGuard port rule
   ansible.posix.firewalld:
-    port: '{{ wireguard_port }}/udp'
-    zone: '{{ wireguard_firewalld_zone }}'
+    port: '{{ __wireguard_iface.port | default(51820) }}/udp'
+    zone: '{{ __wireguard_iface.firewalld_zone | default("public") }}'
     permanent: true
     immediate: true
-    state: "{{ wireguard_firewalld_enabled | bool | ternary('enabled', 'disabled') }}"
+    state: "{{ __wireguard_iface.firewalld_enabled | default(true) | bool | ternary('enabled', 'disabled') }}"
   when: __wireguard_firewalld_status.status.ActiveState | default('') == 'active'
 
 - name: Firewall | Manage WireGuard interface in trusted zone
   ansible.posix.firewalld:
-    interface: '{{ wireguard_interface }}'
+    interface: '{{ __wireguard_iface.name }}'
     zone: 'trusted'
     permanent: true
     immediate: true
-    state: "{{ wireguard_firewalld_enabled | bool | ternary('enabled', 'disabled') }}"
+    state: "{{ __wireguard_iface.firewalld_enabled | default(true) | bool | ternary('enabled', 'disabled') }}"
   when: __wireguard_firewalld_status.status.ActiveState | default('') == 'active'
 
-- name: Firewall | Manage masquerading for server mode
+- name: Firewall | Manage masquerading
   ansible.posix.firewalld:
     masquerade: true
-    zone: '{{ wireguard_firewalld_zone }}'
+    zone: '{{ __wireguard_iface.firewalld_zone | default("public") }}'
     permanent: true
     immediate: true
-    state: "{{ wireguard_firewalld_enabled | bool | ternary('enabled', 'disabled') }}"
+    state: "{{ __wireguard_iface.firewalld_enabled | default(true) | bool | ternary('enabled', 'disabled') }}"
   when:
     - __wireguard_firewalld_status.status.ActiveState | default('') == 'active'
-    - wireguard_server_mode_enabled | bool
+    - __wireguard_iface.mode | default('server') == 'server'

--- a/roles/wireguard/tasks/install.yml
+++ b/roles/wireguard/tasks/install.yml
@@ -27,7 +27,13 @@
     state: present
     sysctl_set: true
     reload: true
-  when: wireguard_ip_forward_enabled | bool
+  when: >-
+    wireguard_interfaces
+    | selectattr('mode', 'defined')
+    | selectattr('mode', 'equalto', 'server')
+    | selectattr('ip_forward', 'defined')
+    | selectattr('ip_forward')
+    | list | length > 0
 
 - name: Install | Enable IP forwarding (IPv6)
   ansible.posix.sysctl:
@@ -36,6 +42,10 @@
     state: present
     sysctl_set: true
     reload: true
-  when:
-    - wireguard_ip_forward_enabled | bool
-    - wireguard_address_ipv6 | length > 0
+  when: >-
+    wireguard_interfaces
+    | selectattr('mode', 'defined')
+    | selectattr('mode', 'equalto', 'server')
+    | selectattr('address_ipv6', 'defined')
+    | rejectattr('address_ipv6', 'equalto', '')
+    | list | length > 0

--- a/roles/wireguard/tasks/interface.yml
+++ b/roles/wireguard/tasks/interface.yml
@@ -1,0 +1,46 @@
+---
+- name: Interface | Include keys tasks
+  ansible.builtin.include_tasks:
+    file: keys.yml
+    apply:
+      tags:
+        - wireguard
+        - wireguard:keys
+  when: __wireguard_iface.generate_keys | default(true) | bool
+  tags:
+    - wireguard
+    - wireguard:keys
+
+- name: Interface | Include configure tasks
+  ansible.builtin.include_tasks:
+    file: configure.yml
+    apply:
+      tags:
+        - wireguard
+        - wireguard:configure
+  tags:
+    - wireguard
+    - wireguard:configure
+
+- name: Interface | Include service tasks
+  ansible.builtin.include_tasks:
+    file: service.yml
+    apply:
+      tags:
+        - wireguard
+        - wireguard:service
+  tags:
+    - wireguard
+    - wireguard:service
+
+- name: Interface | Include firewall tasks
+  ansible.builtin.include_tasks:
+    file: firewall.yml
+    apply:
+      tags:
+        - wireguard
+        - wireguard:firewall
+  when: __wireguard_iface.firewalld_enabled | default(true) | bool
+  tags:
+    - wireguard
+    - wireguard:firewall

--- a/roles/wireguard/tasks/keys.yml
+++ b/roles/wireguard/tasks/keys.yml
@@ -1,7 +1,7 @@
 ---
 - name: Keys | Check if private key exists
   ansible.builtin.stat:
-    path: '{{ wireguard_config_dir }}/{{ wireguard_interface }}_private.key'
+    path: '{{ wireguard_config_dir }}/{{ __wireguard_iface.name }}_private.key'
   register: __wireguard_privkey_file
 
 - name: Keys | Generate private key
@@ -11,25 +11,25 @@
   changed_when: true
   when:
     - not __wireguard_privkey_file.stat.exists
-    - wireguard_private_key | length == 0
+    - __wireguard_iface.private_key | default('') | length == 0
   no_log: true
 
 - name: Keys | Save private key to file
   ansible.builtin.copy:
     content: '{{ __wireguard_generated_privkey.stdout }}'
-    dest: '{{ wireguard_config_dir }}/{{ wireguard_interface }}_private.key'
+    dest: '{{ wireguard_config_dir }}/{{ __wireguard_iface.name }}_private.key'
     owner: root
     group: root
     mode: '0600'
   when:
     - not __wireguard_privkey_file.stat.exists
-    - wireguard_private_key | length == 0
+    - __wireguard_iface.private_key | default('') | length == 0
     - __wireguard_generated_privkey.stdout is defined
   no_log: true
 
 - name: Keys | Read existing private key
   ansible.builtin.slurp:
-    src: '{{ wireguard_config_dir }}/{{ wireguard_interface }}_private.key'
+    src: '{{ wireguard_config_dir }}/{{ __wireguard_iface.name }}_private.key'
   register: __wireguard_privkey_content
   when: __wireguard_privkey_file.stat.exists
   no_log: true
@@ -37,8 +37,10 @@
 - name: Keys | Set private key fact
   ansible.builtin.set_fact:
     __wireguard_private_key: >-
-      {{ wireguard_private_key if wireguard_private_key | length > 0
-         else (__wireguard_generated_privkey.stdout if __wireguard_generated_privkey is changed
+      {{ __wireguard_iface.private_key
+         if (__wireguard_iface.private_key | default('') | length > 0)
+         else (__wireguard_generated_privkey.stdout
+         if __wireguard_generated_privkey is changed
          else __wireguard_privkey_content.content | b64decode | trim) }}
   no_log: true
 
@@ -53,7 +55,7 @@
 - name: Keys | Save public key to file
   ansible.builtin.copy:
     content: '{{ __wireguard_generated_pubkey.stdout }}'
-    dest: '{{ wireguard_config_dir }}/{{ wireguard_interface }}_public.key'
+    dest: '{{ wireguard_config_dir }}/{{ __wireguard_iface.name }}_public.key'
     owner: root
     group: root
     mode: '0644'
@@ -64,4 +66,4 @@
 
 - name: Keys | Display public key
   ansible.builtin.debug:
-    msg: 'WireGuard public key: {{ __wireguard_public_key }}'
+    msg: 'WireGuard public key ({{ __wireguard_iface.name }}): {{ __wireguard_public_key }}'

--- a/roles/wireguard/tasks/main.yml
+++ b/roles/wireguard/tasks/main.yml
@@ -19,39 +19,16 @@
     - wireguard
     - wireguard:install
 
-- name: Main | Import keys tasks
-  ansible.builtin.import_tasks: keys.yml
-  when:
-    - wireguard_enabled | bool
-    - wireguard_generate_keys_enabled | bool
-  tags:
-    - wireguard
-    - wireguard:keys
-
-- name: Main | Import configure tasks
-  ansible.builtin.import_tasks: configure.yml
-  when: wireguard_enabled | bool
-  tags:
-    - wireguard
-    - wireguard:configure
-
-- name: Main | Import service tasks
-  ansible.builtin.import_tasks: service.yml
-  when: wireguard_enabled | bool
-  tags:
-    - wireguard
-    - wireguard:service
-
-- name: Main | Include firewall tasks
+- name: Main | Include per-interface tasks
   ansible.builtin.include_tasks:
-    file: firewall.yml
+    file: interface.yml
     apply:
       tags:
         - wireguard
-        - wireguard:firewall
-  when:
-    - wireguard_enabled | bool
-    - wireguard_firewalld_enabled | bool
+  loop: '{{ wireguard_interfaces }}'
+  loop_control:
+    loop_var: __wireguard_iface
+    label: '{{ __wireguard_iface.name }}'
+  when: wireguard_enabled | bool
   tags:
     - wireguard
-    - wireguard:firewall

--- a/roles/wireguard/tasks/service.yml
+++ b/roles/wireguard/tasks/service.yml
@@ -1,7 +1,7 @@
 ---
 - name: Service | Manage WireGuard service
   ansible.builtin.systemd_service:
-    name: '{{ __wireguard_service_name }}'
-    enabled: "{{ wireguard_service_enabled | bool }}"
+    name: 'wg-quick@{{ __wireguard_iface.name }}'
+    enabled: '{{ wireguard_service_enabled | bool }}'
     state: "{{ wireguard_service_enabled | bool | ternary('started', 'stopped') }}"
     daemon_reload: true

--- a/roles/wireguard/templates/wg.conf.j2
+++ b/roles/wireguard/templates/wg.conf.j2
@@ -1,57 +1,43 @@
 {{ ansible_managed | comment }}
 #
-# WireGuard Configuration: {{ wireguard_interface }}
+# WireGuard Configuration: {{ __wireguard_iface.name }}
 #
 
 [Interface]
-Address = {{ wireguard_address }}
-{% if wireguard_address_ipv6 | length > 0 %}
-Address = {{ wireguard_address_ipv6 }}
+Address = {{ __wireguard_iface.address }}
+{% if __wireguard_iface.address_ipv6 | default('') | length > 0 %}
+Address = {{ __wireguard_iface.address_ipv6 }}
 {% endif %}
 PrivateKey = {{ __wireguard_private_key }}
-ListenPort = {{ wireguard_port }}
-{% if wireguard_fwmark | length > 0 %}
-FwMark = {{ wireguard_fwmark }}
+ListenPort = {{ __wireguard_iface.port | default(51820) }}
+{% if __wireguard_iface.fwmark | default('') | length > 0 %}
+FwMark = {{ __wireguard_iface.fwmark }}
 {% endif %}
-{% if wireguard_mtu > 0 %}
-MTU = {{ wireguard_mtu }}
+{% if __wireguard_iface.mtu | default(0) | int > 0 %}
+MTU = {{ __wireguard_iface.mtu }}
 {% endif %}
-{% if wireguard_table != 'auto' %}
-Table = {{ wireguard_table }}
+{% if __wireguard_iface.table | default('auto') != 'auto' %}
+Table = {{ __wireguard_iface.table }}
 {% endif %}
-{% if wireguard_saveconfig_enabled | bool %}
+{% if __wireguard_iface.saveconfig | default(false) | bool %}
 SaveConfig = true
 {% endif %}
-{% if wireguard_dns | length > 0 and wireguard_client_mode_enabled | bool %}
-DNS = {{ wireguard_dns | join(', ') }}
+{% if __wireguard_iface.dns | default([]) | length > 0 and __wireguard_iface.mode | default('server') == 'client' %}
+DNS = {{ __wireguard_iface.dns | join(', ') }}
 {% endif %}
-{% for cmd in wireguard_preup %}
+{% for cmd in __wireguard_iface.preup | default([]) %}
 PreUp = {{ cmd }}
 {% endfor %}
-{% for cmd in wireguard_postup %}
+{% for cmd in __wireguard_iface.postup | default([]) %}
 PostUp = {{ cmd }}
 {% endfor %}
-{% for cmd in wireguard_predown %}
+{% for cmd in __wireguard_iface.predown | default([]) %}
 PreDown = {{ cmd }}
 {% endfor %}
-{% for cmd in wireguard_postdown %}
+{% for cmd in __wireguard_iface.postdown | default([]) %}
 PostDown = {{ cmd }}
 {% endfor %}
-{% if wireguard_client_mode_enabled | bool %}
-
-# Client configuration
-[Peer]
-PublicKey = {{ wireguard_client_server_pubkey }}
-{% if wireguard_client_preshared_key | length > 0 %}
-PresharedKey = {{ wireguard_client_preshared_key }}
-{% endif %}
-Endpoint = {{ wireguard_client_endpoint }}
-AllowedIPs = {{ wireguard_client_allowed_ips }}
-{% if wireguard_client_persistent_keepalive > 0 %}
-PersistentKeepalive = {{ wireguard_client_persistent_keepalive }}
-{% endif %}
-{% endif %}
-{% for peer in wireguard_peers %}
+{% for peer in __wireguard_iface.peers | default([]) %}
 
 # Peer: {{ peer.name }}{% if peer.description is defined %} - {{ peer.description }}{% endif %}
 
@@ -64,7 +50,7 @@ AllowedIPs = {{ peer.allowed_ips }}
 {% if peer.endpoint is defined and peer.endpoint | length > 0 %}
 Endpoint = {{ peer.endpoint }}
 {% endif %}
-{% if peer.persistent_keepalive is defined and peer.persistent_keepalive > 0 %}
+{% if peer.persistent_keepalive is defined and peer.persistent_keepalive | int > 0 %}
 PersistentKeepalive = {{ peer.persistent_keepalive }}
 {% endif %}
 {% endfor %}

--- a/roles/wireguard/vars/Archlinux.yml
+++ b/roles/wireguard/vars/Archlinux.yml
@@ -1,3 +1,4 @@
 ---
 __wireguard_packages:
   - 'wireguard-tools'
+  - 'systemd-resolvconf'

--- a/roles/wireguard/vars/RedHat.yml
+++ b/roles/wireguard/vars/RedHat.yml
@@ -1,3 +1,4 @@
 ---
 __wireguard_packages:
   - 'wireguard-tools'
+  - 'systemd-resolved'

--- a/roles/wireguard/vars/main.yml
+++ b/roles/wireguard/vars/main.yml
@@ -1,4 +1,2 @@
 ---
 __wireguard_kernel_module: 'wireguard'
-
-__wireguard_service_name: 'wg-quick@{{ wireguard_interface }}'


### PR DESCRIPTION
## Summary

- Redesign WireGuard role for multi-interface support via `wireguard_interfaces` list
- Remove WireGuard connection management from NetworkManager role
- NM dispatchers now use `systemctl` (wg-quick) instead of `nmcli` for WireGuard
- Add systemd drop-in for wg-quick to trigger SMB mount/unmount on tunnel events

## Breaking Changes

- All `wireguard_*` flat variables replaced by `wireguard_interfaces` list
- `networkmanager_connections.wireguard` removed
- `networkmanager_vpn_autoconnect.connection` renamed to `.interface`

## Test plan

- [x] Molecule test (Arch Linux) — converge, idempotence, verify
- [x] Live deployment on fresh Arch install — WireGuard + NetworkManager
- [x] Idempotent re-run (`changed=0`)
- [ ] Tunnel connectivity test (requires non-home network)
- [ ] Remaining Molecule platforms (Debian, Rocky 9, Rocky 10)

## Dependencies

- Requires `systemd-resolved` role for DNS in wg-quick (tracked separately)

🤖 Generated with [Claude Code](https://claude.com/claude-code)