### PR TITLE
fix: Add missing fontconfig variable to fonts RedHat-9.yml

### DIFF
--- a/roles/fonts/vars/RedHat-9.yml
+++ b/roles/fonts/vars/RedHat-9.yml
@@ -2,6 +2,8 @@
 # EL 9 uses old emoji package name and lacks some EPEL 10 coding fonts.
 # Overrides RedHat.yml defaults.
 
+__fonts_fontconfig_package: 'fontconfig'
+
 __fonts_dejavu_package: 'dejavu-sans-fonts'
 __fonts_liberation_package: 'liberation-fonts'
 __fonts_noto_package: 'google-noto-sans-fonts'


### PR DESCRIPTION
## Summary

Closes #93

Add missing `__fonts_fontconfig_package` to `vars/RedHat-9.yml`. The
`with_first_found` pattern only loads one file, so EL 9 never falls
through to `RedHat.yml` where the variable is defined.

## Test plan

- [x] `molecule test -p fonts-rocky-9` — passed
- [ ] CI pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)