### PR TITLE
fix: Add wait_for_connection after Docker service start

### DIFF
--- a/roles/docker/tasks/service.yml
+++ b/roles/docker/tasks/service.yml
@@ -10,6 +10,13 @@
     name: '{{ __docker_service_name }}'
     enabled: "{{ docker_service_enabled | bool }}"
     state: "{{ docker_service_enabled | bool | ternary('started', 'stopped') }}"
+  register: __docker_service_result
+
+- name: Service | Wait for connection after Docker start  # noqa: no-handler
+  ansible.builtin.wait_for_connection:
+    delay: 5
+    timeout: 60
+  when: __docker_service_result.changed
 
 - name: Service | Deploy system prune timer
   ansible.builtin.template:


### PR DESCRIPTION
## Summary

Closes #100

Add a `wait_for_connection` task after the Docker service start in
`service.yml`. Docker's first start injects nftables rules that briefly
disrupt host networking, causing SSH to drop during Ansible provisioning.

## Test plan

- [x] Full playbook run — Docker start no longer breaks SSH connection
- [ ] CI pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)