### PR TITLE
refactor!: Add NM-managed WireGuard mode for clients

### DIFF
--- a/roles/networkmanager/README.md
+++ b/roles/networkmanager/README.md
@@ -193,7 +193,7 @@ networkmanager_apply_global_dns: true    # enable global DNS application
 # Automatic timezone via ipapi.co
 networkmanager_timezone_enabled: false
 
-# VPN auto-connect on non-home networks (via wg-quick/systemd)
+# VPN auto-connect on non-home networks (NM-managed WireGuard connection)
 networkmanager_vpn_autoconnect:
   enabled: false
   interface: ''            # WireGuard interface name (e.g., wg0)
@@ -303,14 +303,14 @@ The resolved role must run before the networkmanager role in the playbook
 | Script                          | Trigger     | Purpose                                      |
 |---------------------------------|-------------|----------------------------------------------|
 | `09-timezone.sh`                | `up`        | Set timezone via IP geolocation              |
-| `20-vpn-autoconnect.sh`         | `up`/`down` | Auto-activate WireGuard tunnel via systemctl |
+| `20-vpn-autoconnect.sh`         | `up`/`down` | Auto-activate WireGuard NM connection        |
 | `30-mount-smb.sh`               | `up`        | Mount SMB shares on connection up            |
 | `40-umount-smb.sh`              | `down`      | Unmount SMB shares on connection down        |
 | `30-mount-sshfs.sh`             | `up`        | Mount SSHFS shares                           |
 | `40-umount-sshfs.sh`            | `down`      | Unmount SSHFS shares                         |
 | `50-vpn-mount-smb.sh`           | `vpn-up`    | Mount SMB shares on VPN connect              |
 | `60-vpn-umount-smb.sh`          | `vpn-down`  | Unmount SMB shares on VPN disconnect         |
-| `99-wifi-auto-toggle.sh`        | `up`/`down` | Disable WiFi when ethernet connected         |
+| `10-wifi-auto-toggle.sh`        | `up`/`down` | Disable WiFi when ethernet connected         |
 | `pre-down.d/30-umount-smb.sh`   | `pre-down`  | Graceful SMB unmount                         |
 | `pre-down.d/30-umount-sshfs.sh` | `pre-down`  | Graceful SSHFS unmount                       |
 

--- a/roles/networkmanager/TESTING.md
+++ b/roles/networkmanager/TESTING.md
@@ -181,7 +181,7 @@ ls -la /etc/NetworkManager/dispatcher.d/
 cat /etc/NetworkManager/dispatcher.d/30-mount-smb.sh
 
 # Check if WiFi toggle script is working
-cat /etc/NetworkManager/dispatcher.d/99-wifi-auto-toggle.sh
+cat /etc/NetworkManager/dispatcher.d/10-wifi-auto-toggle.sh
 
 # View Ansible-managed daemon configuration
 cat /etc/NetworkManager/conf.d/00-ansible.conf

--- a/roles/networkmanager/molecule/default/verify.yml
+++ b/roles/networkmanager/molecule/default/verify.yml
@@ -341,7 +341,7 @@
 
     - name: Verify | Check WiFi toggle dispatcher script exists
       ansible.builtin.stat:
-        path: /etc/NetworkManager/dispatcher.d/99-wifi-auto-toggle.sh
+        path: /etc/NetworkManager/dispatcher.d/10-wifi-auto-toggle.sh
       register: wifi_toggle_script
       when: wifi_toggle_configured | bool
 

--- a/roles/networkmanager/tasks/connections.yml
+++ b/roles/networkmanager/tasks/connections.yml
@@ -26,6 +26,7 @@
     type: ethernet
     conn_name: "{{ item.key }}"
     ifname: "{{ item.value.ifname | default(omit) }}"
+    mac: "{{ item.value.mac | default(omit) }}"
     ip4: "{{ item.value.ip4 | default(omit) }}"
     gw4: "{{ item.value.gw4 | default(omit) }}"
     gw4_ignore_auto: "{{ item.value.gw4_ignore_auto | default(omit) }}"
@@ -161,6 +162,37 @@
   loop_control:
     label: "{{ item.key }}"
   register: wifi_connections_result
+
+- name: Connections | Check current WiFi cloned-mac-address
+  ansible.builtin.shell: |
+    set -o pipefail
+    nmcli -t -f 802-11-wireless.cloned-mac-address connection show "{{ item.key }}" | cut -d: -f2
+  args:
+    executable: /bin/bash
+  loop: "{{ networkmanager_connections.wifi | dict2items }}"
+  loop_control:
+    label: "{{ item.key }}"
+  when:
+    - item.value.state | default("present") == "present"
+    - item.value.mac is defined
+  register: current_wifi_cloned_mac
+  changed_when: false
+  failed_when: false
+
+- name: Connections | Set WiFi cloned-mac-address
+  ansible.builtin.command:
+    cmd: >-
+      nmcli connection modify "{{ item.item.key }}"
+      802-11-wireless.cloned-mac-address
+      "{{ item.item.value.mac }}"
+  loop: "{{ current_wifi_cloned_mac.results | default([]) }}"
+  loop_control:
+    label: "{{ item.item.key }}"
+  when:
+    - not item.skipped | default(false)
+    - item.stdout | trim != item.item.value.mac
+  changed_when: true
+  notify: Reload NetworkManager connections
 
 - name: Connections | Check current ipv4.dhcp-send-hostname for connections
   ansible.builtin.shell: |

--- a/roles/networkmanager/tasks/dispatcher.yml
+++ b/roles/networkmanager/tasks/dispatcher.yml
@@ -290,8 +290,8 @@
 
 - name: Dispatcher | Ensure WiFi auto-toggle dispatcher script is installed
   ansible.builtin.template:
-    src: dispatcher.d/99-wifi-auto-toggle.sh.j2
-    dest: /etc/NetworkManager/dispatcher.d/99-wifi-auto-toggle.sh
+    src: dispatcher.d/10-wifi-auto-toggle.sh.j2
+    dest: /etc/NetworkManager/dispatcher.d/10-wifi-auto-toggle.sh
     owner: root
     group: root
     mode: '0755'
@@ -303,7 +303,7 @@
 
 - name: Dispatcher | Ensure WiFi auto-toggle dispatcher script is removed
   ansible.builtin.file:
-    path: /etc/NetworkManager/dispatcher.d/99-wifi-auto-toggle.sh
+    path: /etc/NetworkManager/dispatcher.d/10-wifi-auto-toggle.sh
     state: absent
   when: not ((networkmanager_connections.ethernet | dict2items |
     selectattr('value.toggle_wifi', 'defined') | selectattr('value.toggle_wifi')) |

--- a/roles/networkmanager/templates/dispatcher.d/10-wifi-auto-toggle.sh.j2
+++ b/roles/networkmanager/templates/dispatcher.d/10-wifi-auto-toggle.sh.j2
@@ -2,19 +2,19 @@
 #!/bin/sh
 {{ ansible_managed | comment }}
 
-# This script will automatically toggle wireless depending on an defined established ethernet connection
+# This script will automatically toggle wireless depending on an defined established ethernet connection.
 # Connection details are defined in Ansible variable 'networkmanager_connections'
 
 LOG_PREFIX="NM-WiFi-Toggle"
 
 {% if network_connections_data.ethernet is defined %}
 
-# NM_UUID is provided by NetworkManager dispatcher.
+# CONNECTION_UUID is provided by NetworkManager dispatcher.
 
-  {% for conn_name, conn_details in network_connections_data.ethernet.items() %}
-    {% if conn_details.toggle_wifi is defined and conn_details.toggle_wifi %}
+{% for conn_name, conn_details in network_connections_data.ethernet.items() %}
+{% if conn_details.toggle_wifi is defined and conn_details.toggle_wifi %}
 # Check if the current connection is {{ conn_name }} (UUID: {{ conn_details.uuid }})
-if [ "$NM_UUID" = "{{ conn_details.uuid }}" ]; then
+if [ "$CONNECTION_UUID" = "{{ conn_details.uuid }}" ]; then
   case "$2" in
     up)
       echo "$LOG_PREFIX for connection '{{ conn_name }}': ethernet up"
@@ -26,6 +26,6 @@ if [ "$NM_UUID" = "{{ conn_details.uuid }}" ]; then
       ;;
   esac
 fi
-    {% endif %}
-  {% endfor %}
+{% endif %}
+{% endfor %}
 {% endif %}

--- a/roles/networkmanager/templates/dispatcher.d/20-vpn-autoconnect.sh.j2
+++ b/roles/networkmanager/templates/dispatcher.d/20-vpn-autoconnect.sh.j2
@@ -4,12 +4,11 @@
 
 # This script automatically activates a WireGuard VPN tunnel when connecting
 # to a non-home network, and deactivates it when the base connection drops.
-# The tunnel is managed by wg-quick/systemd, not NetworkManager.
-# This ensures laptops always have VPN connectivity when roaming.
+# The tunnel is managed as a NetworkManager WireGuard connection.
 
 LOG_PREFIX="NM-VPN-Autoconnect"
 WG_INTERFACE="{{ networkmanager_vpn_autoconnect.interface }}"
-WG_SERVICE="wg-quick@${WG_INTERFACE}.service"
+WG_CONNECTION="WireGuard ${WG_INTERFACE}"
 
 {% set uuid_map = {} %}
 {# Build UUID map for home connections that should NOT trigger VPN #}
@@ -30,11 +29,18 @@ WG_SERVICE="wg-quick@${WG_INTERFACE}.service"
   {% endif %}
 {% endfor %}
 
+# Only react to ethernet and wifi interfaces, skip loopback/bridge/docker/wg/etc.
+case "$1" in
+  lo|docker*|br-*|veth*|wg*|p2p-*)
+    exit 0
+    ;;
+esac
+
 if [ "$2" = "up" ]; then
 {% if home_uuids | length > 0 %}
 
   # Skip if on a home network connection (VPN not needed)
-  if {% for uuid in home_uuids %}[ "$NM_UUID" = "{{ uuid }}" ]{% if not loop.last %} || {% endif %}{% endfor %}; then
+  if {% for uuid in home_uuids %}[ "$CONNECTION_UUID" = "{{ uuid }}" ]{% if not loop.last %} || {% endif %}{% endfor %}; then
     echo "$LOG_PREFIX: On home network ($CONNECTION_ID). VPN not needed."
     exit 0
   fi
@@ -43,22 +49,22 @@ if [ "$2" = "up" ]; then
   # Wait briefly for connection to stabilize
   sleep 2
 
-  # Check if WireGuard tunnel is already active
-  if systemctl is-active --quiet "$WG_SERVICE"; then
-    echo "$LOG_PREFIX: WireGuard tunnel ($WG_INTERFACE) already active."
+  # Check if WireGuard connection is already active
+  if nmcli -t -f NAME connection show --active | grep -q "^${WG_CONNECTION}$"; then
+    echo "$LOG_PREFIX: WireGuard connection ($WG_CONNECTION) already active."
     exit 0
   fi
 
-  echo "$LOG_PREFIX: Non-home network detected ($CONNECTION_ID). Activating WireGuard tunnel ($WG_INTERFACE)."
-  systemctl start "$WG_SERVICE" 2>&1 | while read -r line; do
+  echo "$LOG_PREFIX: Non-home network detected ($CONNECTION_ID). Activating $WG_CONNECTION."
+  nmcli connection up "$WG_CONNECTION" 2>&1 | while read -r line; do
     echo "$LOG_PREFIX: $line"
   done
 fi
 
 if [ "$2" = "down" ]; then
-  # Deactivate WireGuard tunnel when the base connection drops
-  if systemctl is-active --quiet "$WG_SERVICE"; then
-    echo "$LOG_PREFIX: Base connection ($CONNECTION_ID) went down. Deactivating WireGuard tunnel ($WG_INTERFACE)."
-    systemctl stop "$WG_SERVICE" 2>/dev/null
+  # Deactivate WireGuard connection when the base connection drops
+  if nmcli -t -f NAME connection show --active | grep -q "^${WG_CONNECTION}$"; then
+    echo "$LOG_PREFIX: Base connection ($CONNECTION_ID) went down. Deactivating $WG_CONNECTION."
+    nmcli connection down "$WG_CONNECTION" 2>/dev/null
   fi
 fi

--- a/roles/networkmanager/templates/dispatcher.d/30-mount-smb.sh.j2
+++ b/roles/networkmanager/templates/dispatcher.d/30-mount-smb.sh.j2
@@ -8,7 +8,7 @@
 # Shares that depend on VPN connections are excluded and handled by the VPN-specific mount script.
 # Each share is mounted per user into their home directory.
 
-# NM_UUID is provided by NetworkManager dispatcher.
+# CONNECTION_UUID is provided by NetworkManager dispatcher.
 LOG_PREFIX="NM-SMB-Mount"
 
 {% set uuid_map = {} -%}
@@ -54,7 +54,7 @@ if [ "$2" = "up" ]; then
   SHOULD_MOUNT="false"
         {% if dependency_uuids_for_this_share | length > 0 %}
   # NM connection dependencies
-  if {% for uuid in dependency_uuids_for_this_share %}[ "$NM_UUID" = "{{ uuid }}" ]{% if not loop.last %} || {% endif %}{% endfor %}; then
+  if {% for uuid in dependency_uuids_for_this_share %}[ "$CONNECTION_UUID" = "{{ uuid }}" ]{% if not loop.last %} || {% endif %}{% endfor %}; then
     SHOULD_MOUNT="true"
   fi
         {% endif %}

--- a/roles/networkmanager/templates/dispatcher.d/40-umount-smb.sh.j2
+++ b/roles/networkmanager/templates/dispatcher.d/40-umount-smb.sh.j2
@@ -8,7 +8,7 @@
 # Shares that depend on VPN connections are excluded and handled by the VPN-specific umount script.
 # Each share is unmounted per user from their home directory.
 
-# NM_UUID is provided by NetworkManager dispatcher.
+# CONNECTION_UUID is provided by NetworkManager dispatcher.
 LOG_PREFIX="NM-SMB-Unmount-Down"
 
 {% set id_map = {} -%}

--- a/roles/networkmanager/templates/dispatcher.d/pre-down.d/30-umount-smb.sh.j2
+++ b/roles/networkmanager/templates/dispatcher.d/pre-down.d/30-umount-smb.sh.j2
@@ -6,7 +6,7 @@
 # It ensures a share is only unmounted if none of its dependencies are active anymore.
 # Each share is unmounted per user from their home directory.
 
-# NM_UUID is provided by NetworkManager dispatcher.
+# CONNECTION_UUID is provided by NetworkManager dispatcher.
 LOG_PREFIX="NM-SMB-Unmount-PreDown"
 
 {% set id_map = {} -%}

--- a/roles/wireguard/README.md
+++ b/roles/wireguard/README.md
@@ -4,13 +4,18 @@ Configure WireGuard VPN tunnels with multi-interface support.
 
 ## Description
 
-Manages one or more WireGuard VPN interfaces per host, each in server or client
-mode. Features automatic key generation, peer management, lifecycle scripts
-(pre/post up/down), IP forwarding via sysctl, firewalld integration, and systemd
-service management via wg-quick.
+Manages one or more WireGuard VPN interfaces per host. Supports three modes:
 
-Each interface is independently configured and managed as a
-`wg-quick@<name>.service` systemd unit.
+- **server** — wg-quick/systemd, IP forwarding, masquerade (servers)
+- **client** — wg-quick/systemd, DNS, keepalive (legacy client mode)
+- **nm** — NetworkManager-managed connection (laptops/desktops)
+
+Features automatic key generation, peer management, firewalld integration,
+and lifecycle scripts (server/client modes).
+
+Server/client mode interfaces are managed as `wg-quick@<name>.service` systemd
+units. NM mode deploys a `.nmconnection` keyfile — NetworkManager handles routing,
+DNS, and connection lifecycle.
 
 ## Requirements
 
@@ -68,9 +73,13 @@ wireguard_interfaces:
 | `address_ipv6`       | `''`         | IPv6 address (CIDR, optional)                    |
 | `port`               | `51820`      | Listen port (UDP)                                |
 | `private_key`        | `''`         | Private key (auto-generated if empty)            |
-| `mode`               | `'server'`   | Interface mode: `server` or `client`             |
+| `mode`               | `'server'`   | Interface mode: `server`, `client`, or `nm`      |
 | `ip_forward`         | `true`       | Enable IP forwarding (server mode)               |
-| `dns`                | `[]`         | DNS servers written to wg.conf (client mode)     |
+| `dns`                | `[]`         | DNS servers (client/nm mode)                     |
+| `dns_search`         | `[]`         | DNS routing domains (nm mode, use `~` prefix)    |
+| `dns_priority`       |              | DNS priority for systemd-resolved (nm mode)      |
+| `never_default`      | `false`      | Prevent default route via tunnel (nm mode)       |
+| `nm_autoconnect`     | `false`      | Auto-activate NM connection at boot (nm mode)    |
 | `peers`              | `[]`         | List of peer definitions (see below)             |
 | `firewalld_enabled`  | `true`       | Enable firewalld integration                     |
 | `firewalld_zone`     | `'public'`   | Firewalld zone for WireGuard port                |
@@ -137,6 +146,40 @@ wireguard_interfaces:
         allowed_ips: '10.100.0.0/24'
         persistent_keepalive: 25
 ```
+
+### NM Mode Example (Laptops/Desktops)
+
+```yaml
+wireguard_interfaces:
+  - name: wg0
+    mode: nm
+    address: '10.100.0.2/24'
+    private_key: '{{ vault_wireguard_keys.wg0.private_key }}'
+    dns:
+      - '10.100.0.1'
+    dns_search:
+      - '~example.com'
+    never_default: true
+    firewalld_enabled: false
+    peers:
+      - name: server
+        public_key: '{{ vault_wireguard_keys.wg0.server_pubkey }}'
+        endpoint: 'vpn.example.com:51820'
+        allowed_ips: '10.100.0.0/24,192.168.1.0/24'
+        preshared_key: '{{ vault_wireguard_keys.wg0.preshared_key }}'
+        persistent_keepalive: 25
+```
+
+NM mode deploys a `.nmconnection` profile with `autoconnect=false`. Use the
+`networkmanager_vpn_autoconnect` dispatcher to activate the tunnel automatically
+on non-home networks (see the `networkmanager` role).
+
+Key differences from client mode:
+
+- No wg-quick service — NetworkManager manages the interface
+- DNS routing domains (`~` prefix) integrate with systemd-resolved
+- `never_default: true` prevents full-tunnel routing (split-tunnel)
+- `ip4-auto-default-route` handles policy routing for full-tunnel if needed
 
 ### Multi-Interface Example
 

--- a/roles/wireguard/defaults/main.yml
+++ b/roles/wireguard/defaults/main.yml
@@ -33,7 +33,10 @@ wireguard_interfaces: []
 #     port: 51820
 #     # Private key (auto-generated if empty)
 #     private_key: ''
-#     # Interface mode: server (IP forwarding, masquerade) or client (DNS, keepalive)
+#     # Interface mode:
+#     #   server  - wg-quick/systemd, IP forwarding, masquerade (servers)
+#     #   client  - wg-quick/systemd, DNS, keepalive (legacy)
+#     #   nm      - NetworkManager-managed connection (laptops/desktops)
 #     mode: server
 #
 #     # Server mode: enable IP forwarding via sysctl

--- a/roles/wireguard/handlers/main.yml
+++ b/roles/wireguard/handlers/main.yml
@@ -5,3 +5,9 @@
   # Container-safety for molecule
   failed_when: false
   when: wireguard_enabled | bool
+
+- name: Reload NetworkManager connections
+  ansible.builtin.command:
+    cmd: nmcli connection reload
+  changed_when: false
+  when: wireguard_enabled | bool

--- a/roles/wireguard/tasks/interface.yml
+++ b/roles/wireguard/tasks/interface.yml
@@ -11,6 +11,18 @@
     - wireguard
     - wireguard:keys
 
+- name: Interface | Include NM connection tasks
+  ansible.builtin.include_tasks:
+    file: nm.yml
+    apply:
+      tags:
+        - wireguard
+        - wireguard:configure
+  when: __wireguard_iface.mode | default('server') == 'nm'
+  tags:
+    - wireguard
+    - wireguard:configure
+
 - name: Interface | Include configure tasks
   ansible.builtin.include_tasks:
     file: configure.yml
@@ -18,6 +30,7 @@
       tags:
         - wireguard
         - wireguard:configure
+  when: __wireguard_iface.mode | default('server') != 'nm'
   tags:
     - wireguard
     - wireguard:configure
@@ -29,6 +42,7 @@
       tags:
         - wireguard
         - wireguard:service
+  when: __wireguard_iface.mode | default('server') != 'nm'
   tags:
     - wireguard
     - wireguard:service
@@ -40,7 +54,9 @@
       tags:
         - wireguard
         - wireguard:firewall
-  when: __wireguard_iface.firewalld_enabled | default(true) | bool
+  when:
+    - __wireguard_iface.mode | default('server') != 'nm'
+    - __wireguard_iface.firewalld_enabled | default(true) | bool
   tags:
     - wireguard
     - wireguard:firewall

--- a/roles/wireguard/tasks/nm.yml
+++ b/roles/wireguard/tasks/nm.yml
@@ -1,0 +1,20 @@
+---
+# Deploy WireGuard as a NetworkManager-managed connection (mode: nm).
+# The .nmconnection keyfile includes peers (not supported by community.general.nmcli).
+# NM handles routing, DNS, and connection lifecycle.
+
+- name: NM | Deploy connection profile
+  ansible.builtin.template:
+    src: wg-nm.nmconnection.j2
+    dest: '/etc/NetworkManager/system-connections/WireGuard {{ __wireguard_iface.name }}.nmconnection'
+    owner: root
+    group: root
+    mode: '0600'
+  notify: Reload NetworkManager connections
+
+- name: NM | Ensure wg-quick service is stopped and disabled
+  ansible.builtin.systemd_service:
+    name: 'wg-quick@{{ __wireguard_iface.name }}.service'
+    state: stopped
+    enabled: false
+  failed_when: false

--- a/roles/wireguard/templates/wg-nm.nmconnection.j2
+++ b/roles/wireguard/templates/wg-nm.nmconnection.j2
@@ -1,0 +1,65 @@
+#jinja2:lstrip_blocks: True
+# {{ ansible_managed }}
+#
+# NetworkManager WireGuard connection profile
+# Deployed by the wireguard role (mode: nm)
+
+[connection]
+id=WireGuard {{ __wireguard_iface.name }}
+type=wireguard
+interface-name={{ __wireguard_iface.name }}
+autoconnect={{ __wireguard_iface.nm_autoconnect | default(false) | string | lower }}
+
+[wireguard]
+private-key={{ __wireguard_private_key }}
+{% if __wireguard_iface.port | default(0) | int > 0 %}
+listen-port={{ __wireguard_iface.port }}
+{% endif %}
+peer-routes=true
+{% set all_allowed = __wireguard_iface.peers | map(attribute='allowed_ips') | join(',') %}
+{% if '0.0.0.0/0' in all_allowed %}
+ip4-auto-default-route=true
+{% endif %}
+{% if '::/0' in all_allowed %}
+ip6-auto-default-route=true
+{% endif %}
+
+{% for peer in __wireguard_iface.peers %}
+[wireguard-peer.{{ peer.public_key }}]
+{% if peer.endpoint is defined and peer.endpoint | length > 0 %}
+endpoint={{ peer.endpoint }}
+{% endif %}
+allowed-ips={{ peer.allowed_ips | replace(',', ';') }};
+{% if peer.persistent_keepalive | default(0) | int > 0 %}
+persistent-keepalive={{ peer.persistent_keepalive }}
+{% endif %}
+{% if peer.preshared_key is defined and peer.preshared_key | length > 0 %}
+preshared-key={{ peer.preshared_key }}
+preshared-key-flags=0
+{% endif %}
+
+{% endfor %}
+[ipv4]
+{% set addr = __wireguard_iface.address %}
+address1={{ addr }}
+method=manual
+{% if __wireguard_iface.dns is defined and __wireguard_iface.dns | length > 0 %}
+dns={{ __wireguard_iface.dns | first | replace(',', ';') }};
+{% endif %}
+{% if __wireguard_iface.dns_search is defined and __wireguard_iface.dns_search | length > 0 %}
+dns-search={{ __wireguard_iface.dns_search | join(';') }};
+{% endif %}
+{% if __wireguard_iface.dns_priority is defined %}
+dns-priority={{ __wireguard_iface.dns_priority }}
+{% endif %}
+{% if __wireguard_iface.never_default | default(false) | bool %}
+never-default=true
+{% endif %}
+
+[ipv6]
+{% if __wireguard_iface.address_ipv6 | default('') | length > 0 %}
+address1={{ __wireguard_iface.address_ipv6 }}
+method=manual
+{% else %}
+method=disabled
+{% endif %}


### PR DESCRIPTION
## Summary

Closes #99

Add `mode: nm` to the wireguard role, deploying a `.nmconnection` keyfile
instead of wg-quick/systemd. NetworkManager handles routing, DNS, and
connection lifecycle — fixing persistent networking issues on laptops where
wg-quick with full-tunnel AllowedIPs broke host connectivity.

### wireguard role
- New `mode: nm` — deploys `.nmconnection` keyfile with full peer support
- New task file `nm.yml`, new template `wg-nm.nmconnection.j2`
- Stops and disables wg-quick service when mode=nm
- New variables: `dns_search`, `dns_priority`, `never_default`, `nm_autoconnect`

### networkmanager role
- Fix `$NM_UUID` → `$CONNECTION_UUID` in all 5 dispatcher templates
- VPN autoconnect dispatcher uses `nmcli connection up/down`
- Interface filter skips loopback/bridge/docker/wg/p2p events
- WiFi toggle renamed from 99 to 10 (runs before SMB timeout scripts)
- WiFi `cloned-mac-address` support via per-connection `mac` parameter

## BREAKING CHANGE

VPN autoconnect dispatcher uses nmcli instead of systemctl.
Clients must use `mode: nm` for WireGuard interfaces.

## Test plan

- [x] NM connection profile deployed correctly
- [x] wg-quick service stopped and disabled
- [x] Dispatcher recognizes home network, does not start VPN
- [x] Loopback/bridge events filtered (no spurious VPN activation)
- [x] WiFi toggle works (Ethernet up → WiFi off, Ethernet down → WiFi on)
- [x] Reboot: VPN not started on home network
- [x] DNS works with all services active
- [ ] CI pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)