### PR TITLE
fix: Make BTRFS NoCOW tasks idempotent across 8 roles

### DIFF
--- a/roles/aide/tasks/btrfs.yml
+++ b/roles/aide/tasks/btrfs.yml
@@ -55,8 +55,18 @@
         mode: '0700'
         state: directory
 
+- name: BTRFS | Check NoCOW attribute on AIDE database directory
+  ansible.builtin.command:
+    cmd: lsattr -d {{ aide_database | dirname }}
+  register: __aide_lsattr
+  changed_when: false
+  failed_when: false
+  when: __aide_is_btrfs | bool
+
 - name: BTRFS | Set NoCOW attribute on AIDE database directory
   ansible.builtin.command:
     cmd: chattr +C {{ aide_database | dirname }}
   changed_when: true
-  when: __aide_is_btrfs | bool
+  when:
+    - __aide_is_btrfs | bool
+    - "'C' not in (__aide_lsattr.stdout | default(''))"

--- a/roles/auditd/tasks/btrfs.yml
+++ b/roles/auditd/tasks/btrfs.yml
@@ -55,8 +55,18 @@
         mode: '0700'
         state: directory
 
+- name: BTRFS | Check NoCOW attribute on audit log directory
+  ansible.builtin.command:
+    cmd: lsattr -d {{ auditd_log_file | dirname }}
+  register: __auditd_lsattr
+  changed_when: false
+  failed_when: false
+  when: __auditd_is_btrfs | bool
+
 - name: BTRFS | Set NoCOW attribute on audit log directory
   ansible.builtin.command:
     cmd: chattr +C {{ auditd_log_file | dirname }}
   changed_when: true
-  when: __auditd_is_btrfs | bool
+  when:
+    - __auditd_is_btrfs | bool
+    - "'C' not in (__auditd_lsattr.stdout | default(''))"

--- a/roles/chrony/tasks/btrfs.yml
+++ b/roles/chrony/tasks/btrfs.yml
@@ -15,9 +15,18 @@
   when:
     - __chrony_log_fstype.stdout | default('') == 'btrfs'
 
+- name: BTRFS | Check NoCOW attribute on log directory
+  ansible.builtin.command:
+    cmd: lsattr -d {{ chrony_log_dir }}
+  register: __chrony_lsattr
+  changed_when: false
+  failed_when: false
+  when: __chrony_log_fstype.stdout | default('') == 'btrfs'
+
 - name: BTRFS | Set NoCOW attribute on log directory
   ansible.builtin.command:
     cmd: chattr +C {{ chrony_log_dir }}
+  changed_when: true
   when:
     - __chrony_log_fstype.stdout | default('') == 'btrfs'
-  changed_when: false
+    - "'C' not in (__chrony_lsattr.stdout | default(''))"

--- a/roles/clamav/tasks/btrfs.yml
+++ b/roles/clamav/tasks/btrfs.yml
@@ -53,8 +53,18 @@
         mode: '0755'
         state: directory
 
+- name: BTRFS | Check NoCOW attribute on ClamAV database directory
+  ansible.builtin.command:
+    cmd: lsattr -d {{ clamav_database_directory }}
+  register: __clamav_lsattr
+  changed_when: false
+  failed_when: false
+  when: __clamav_is_btrfs | bool
+
 - name: BTRFS | Set NoCOW attribute on ClamAV database directory
   ansible.builtin.command:
     cmd: chattr +C {{ clamav_database_directory }}
   changed_when: true
-  when: __clamav_is_btrfs | bool
+  when:
+    - __clamav_is_btrfs | bool
+    - "'C' not in (__clamav_lsattr.stdout | default(''))"

--- a/roles/lynis/tasks/btrfs.yml
+++ b/roles/lynis/tasks/btrfs.yml
@@ -18,8 +18,18 @@
     mode: '0750'
   when: __lynis_report_fstype.stdout | default('') == 'btrfs'
 
+- name: BTRFS | Check NoCOW attribute on report directory
+  ansible.builtin.command:
+    cmd: lsattr -d {{ lynis_report_dir }}
+  register: __lynis_lsattr
+  changed_when: false
+  failed_when: false
+  when: __lynis_report_fstype.stdout | default('') == 'btrfs'
+
 - name: BTRFS | Set NoCOW attribute on report directory
   ansible.builtin.command:
     cmd: chattr +C {{ lynis_report_dir }}
-  when: __lynis_report_fstype.stdout | default('') == 'btrfs'
-  changed_when: false
+  changed_when: true
+  when:
+    - __lynis_report_fstype.stdout | default('') == 'btrfs'
+    - "'C' not in (__lynis_lsattr.stdout | default(''))"

--- a/roles/restic/tasks/btrfs.yml
+++ b/roles/restic/tasks/btrfs.yml
@@ -21,10 +21,21 @@
     - restic_log_to_file | bool
     - __restic_log_fstype.stdout | default('') == 'btrfs'
 
-- name: BTRFS | Set NoCOW on log directory
+- name: BTRFS | Check NoCOW attribute on log directory
   ansible.builtin.command:
-    cmd: 'chattr +C {{ restic_log_dir }}'
+    cmd: 'lsattr -d {{ restic_log_dir }}'
+  register: __restic_lsattr
+  changed_when: false
+  failed_when: false
   when:
     - restic_log_to_file | bool
     - __restic_log_fstype.stdout | default('') == 'btrfs'
-  changed_when: false
+
+- name: BTRFS | Set NoCOW on log directory
+  ansible.builtin.command:
+    cmd: 'chattr +C {{ restic_log_dir }}'
+  changed_when: true
+  when:
+    - restic_log_to_file | bool
+    - __restic_log_fstype.stdout | default('') == 'btrfs'
+    - "'C' not in (__restic_lsattr.stdout | default(''))"

--- a/roles/rkhunter/tasks/btrfs.yml
+++ b/roles/rkhunter/tasks/btrfs.yml
@@ -8,8 +8,18 @@
   changed_when: false
   failed_when: false
 
+- name: BTRFS | Check NoCOW attribute on rkhunter database directory
+  ansible.builtin.command:
+    cmd: lsattr -d /var/lib/rkhunter/db
+  register: __rkhunter_lsattr
+  changed_when: false
+  failed_when: false
+  when: __rkhunter_db_fstype.stdout | default('') == 'btrfs'
+
 - name: BTRFS | Set NoCOW attribute on rkhunter database directory
   ansible.builtin.command:
     cmd: chattr +C /var/lib/rkhunter/db
-  when: __rkhunter_db_fstype.stdout | default('') == 'btrfs'
-  changed_when: false
+  changed_when: true
+  when:
+    - __rkhunter_db_fstype.stdout | default('') == 'btrfs'
+    - "'C' not in (__rkhunter_lsattr.stdout | default(''))"

--- a/roles/unbound/tasks/btrfs.yml
+++ b/roles/unbound/tasks/btrfs.yml
@@ -9,8 +9,18 @@
   changed_when: false
   failed_when: false
 
+- name: BTRFS | Check NoCOW attribute on data directory
+  ansible.builtin.command:
+    cmd: lsattr -d /var/lib/unbound
+  register: __unbound_lsattr
+  changed_when: false
+  failed_when: false
+  when: __unbound_data_fstype.stdout | default('') == 'btrfs'
+
 - name: BTRFS | Set NoCOW attribute on data directory
   ansible.builtin.command:
     cmd: chattr +C /var/lib/unbound
-  when: __unbound_data_fstype.stdout | default('') == 'btrfs'
-  changed_when: false
+  changed_when: true
+  when:
+    - __unbound_data_fstype.stdout | default('') == 'btrfs'
+    - "'C' not in (__unbound_lsattr.stdout | default(''))"


### PR DESCRIPTION
## Summary

Closes #103

Add `lsattr -d` check before `chattr +C` in 8 roles to avoid false
`changed` reports on subsequent runs. Matches the existing docker role
pattern.

## Affected Roles

aide, auditd, chrony, clamav, lynis, restic, rkhunter, unbound

## Test plan

- [x] Linting passed
- [ ] CI pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)