### PR TITLE
fix: Install AppArmor extra profiles before enforcing

### DIFF
--- a/roles/apparmor/defaults/main.yml
+++ b/roles/apparmor/defaults/main.yml
@@ -25,7 +25,6 @@ apparmor_securityfs: '/sys/kernel/security'
 
 # Profiles to put in enforce mode (list of binary paths)
 apparmor_enforce_profiles:
-  - '/usr/sbin/tcpdump'
   - '/usr/bin/man'
 
 # Profiles to put in complain mode

--- a/roles/apparmor/tasks/profiles.yml
+++ b/roles/apparmor/tasks/profiles.yml
@@ -31,6 +31,23 @@
 # Enforce Profiles
 #
 
+# Install extra profiles from /usr/share/apparmor/extra-profiles/ if not
+# already present in /etc/apparmor.d/. Profile filenames use dots instead
+# of slashes (e.g., /usr/sbin/tcpdump → usr.sbin.tcpdump).
+- name: Profiles | Install extra profiles for enforce list
+  ansible.builtin.copy:
+    src: '/usr/share/apparmor/extra-profiles/{{ item | regex_replace("^/", "") | replace("/", ".") }}'
+    dest: '/etc/apparmor.d/{{ item | regex_replace("^/", "") | replace("/", ".") }}'
+    remote_src: true
+    owner: root
+    group: root
+    mode: '0644'
+    force: false
+  loop: '{{ apparmor_enforce_profiles }}'
+  register: __apparmor_extra_installed
+  failed_when: false
+  notify: Reload AppArmor
+
 # failed_when: false — profile may not exist on system (user-provided list)
 - name: Profiles | Set profiles to enforce mode
   ansible.builtin.command:


### PR DESCRIPTION
## Summary

Closes #105

Copy profiles from `/usr/share/apparmor/extra-profiles/` to `/etc/apparmor.d/`
before running `aa-enforce`. Remove tcpdump from defaults (not available on Arch).

## Test plan

- [x] First run: profile copied + enforced (changed)
- [x] Second run: idempotent (ok)
- [x] Linting passed
- [ ] CI pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)