### PR TITLE
fix: AIDE exclude BTRFS snapshots and disable /home monitoring by default

### DIFF
--- a/roles/aide/defaults/main.yml
+++ b/roles/aide/defaults/main.yml
@@ -49,7 +49,8 @@ aide_monitor_configs_enabled: true
 aide_monitor_system_dirs_enabled: true
 
 # Monitor user home directories (detect compromised accounts)
-aide_monitor_home_dirs_enabled: true
+# Disabled by default — /home can be very large on workstations
+aide_monitor_home_dirs_enabled: false
 
 # Monitor log files
 aide_monitor_logs_enabled: false

--- a/roles/aide/molecule/default/converge.yml
+++ b/roles/aide/molecule/default/converge.yml
@@ -11,7 +11,7 @@
     aide_monitor_libraries: true
     aide_monitor_configs: true
     aide_monitor_boot: true
-    aide_monitor_home_dirs: true
+    aide_monitor_home_dirs_enabled: false
     aide_custom_rules:
       - path: '/opt/test'
         rule: 'R+sha512'

--- a/roles/aide/molecule/default/verify.yml
+++ b/roles/aide/molecule/default/verify.yml
@@ -107,12 +107,12 @@
         fail_msg: "Custom monitoring rule not found in config"
         success_msg: "Custom monitoring rule configured correctly"
 
-    - name: Verify | Assert /home monitoring is configured
+    - name: Verify | Assert /home monitoring is not enabled by default
       ansible.builtin.assert:
         that:
-          - "'/home NORMAL' in aide_config_decoded"
-        fail_msg: "/home monitoring rule not found in config"
-        success_msg: "/home monitoring rule configured correctly"
+          - "'/home NORMAL' not in aide_config_decoded"
+        fail_msg: "/home monitoring should not be enabled by default"
+        success_msg: "/home monitoring correctly disabled by default"
 
     #
     # Database Verification

--- a/roles/aide/tasks/database.yml
+++ b/roles/aide/tasks/database.yml
@@ -18,9 +18,9 @@
     - aide_init_db_enabled | bool
     - not aide_db_check.stat.exists or aide_force_init_enabled | bool
   register: aide_init
-  changed_when: aide_init.rc == 0
-  async: 3600
-  poll: 10
+  changed_when: aide_init.rc | default(1) == 0
+  async: 7200
+  poll: 30
 
 - name: Database | Move new database to production  # noqa: no-handler
   ansible.builtin.command:

--- a/roles/aide/templates/aide.conf.j2
+++ b/roles/aide/templates/aide.conf.j2
@@ -71,6 +71,9 @@ LOG = >
 !/var/spool
 !/var/lib/aide
 
+# BTRFS snapshots (snapper)
+!/.snapshots
+
 # OS-specific exclusions
 {% for path in __aide_os_exclude_paths | default([]) %}
 !/{{ path | regex_replace('^/', '') }}


### PR DESCRIPTION
## Summary

Closes #107

- Add `/.snapshots` to hardcoded excludes in aide.conf template — prevents scanning all snapper snapshots
- Change `aide_monitor_home_dirs_enabled` default to `false` — `/home` can be very large on workstations
- Increase async timeout from 3600 to 7200 for `aide --init`
- Fix `changed_when` for async tasks (`default(1)` on timeout)

## Test plan

- [x] Full base-system run: `changed=0` on second run (idempotent)
- [x] AIDE init completes in minutes instead of hours
- [x] Linting passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)