### PR TITLE
feat(playbooks): Add system_update task file for Arch partial-upgrade safety

### DIFF
--- a/playbooks/base_system.yml
+++ b/playbooks/base_system.yml
@@ -18,6 +18,11 @@
   become: true
   gather_facts: true
 
+  pre_tasks:
+    - name: Base System | Import system update tasks
+      ansible.builtin.import_tasks:
+        file: tasks/system_update.yml
+
   tasks:
     - name: Base System | Import base system tasks
       ansible.builtin.import_tasks:

--- a/playbooks/tasks/system_update.yml
+++ b/playbooks/tasks/system_update.yml
@@ -1,0 +1,27 @@
+---
+# =============================================================================
+# System Update Tasks
+# =============================================================================
+# Pre-task file for full system upgrade before package operations.
+# Imported by collection standalone playbooks as pre_tasks.
+#
+# Scope: Arch Linux only.
+# Rolling release requires a full upgrade before any package install to
+# prevent partial-upgrade failures and missing packages on mirrors.
+#
+# EL/Debian are intentionally not handled here — those updates should be
+# performed deliberately, not as a side-effect of a configuration run.
+#
+# Tag scheme:
+#   system-update   This task file
+#   maintenance     Shared with other maintenance tasks
+# =============================================================================
+
+- name: System Update | Arch Linux full upgrade
+  community.general.pacman:
+    update_cache: true
+    upgrade: true
+  when: ansible_facts['os_family'] == 'Archlinux'
+  tags:
+    - system-update
+    - maintenance


### PR DESCRIPTION
## Summary

Add a self-contained `playbooks/tasks/system_update.yml` task file and
import it as `pre_tasks` in the standalone `base_system.yml` playbook.

Standalone runs of `marcstraube.common.base_system` previously did not
handle Arch's partial-upgrade problem — only the infra-layer wrapper
invoked `archlinux.system_update` beforehand. With this change, the
collection's own standalone playbook is safe to run directly on Arch.

## Scope

Arch only. Rolling release requires it. EL/Debian are typically server
systems where updates should be performed deliberately, not as a side
effect of a configuration run.

## Design choices

- **Task file, not inlined.** Mirrors the `tasks/base_system.yml` pattern
  and stays reusable for any future standalone playbook in this collection.
- **No cross-collection dependency.** The task file lives inside this
  collection. Same pattern will be replicated in `marcstraube.desktop` and
  `marcstraube.server` so each collection stays self-contained.

## Changes

- New: `playbooks/tasks/system_update.yml`
- `playbooks/base_system.yml`: add `pre_tasks` block importing the task file

## Test plan

- [ ] `ansible-playbook marcstraube.common.base_system` on a stale Arch host
      runs the full upgrade before package operations
- [ ] On Debian: pacman task is skipped (when condition)
- [ ] On Rocky: pacman task is skipped (when condition)
- [ ] `--tags system-update` runs only the upgrade
- [ ] `--tags maintenance` includes the upgrade
- [ ] `--skip-tags system-update` skips the upgrade

Closes #109

🤖 Generated with [Claude Code](https://claude.com/claude-code)