### PR TITLE
Omit ifname in placeholder task when inventory does not define it

### DIFF
--- a/roles/networkmanager/tasks/connections.yml
+++ b/roles/networkmanager/tasks/connections.yml
@@ -11,7 +11,7 @@
   community.general.nmcli:
     type: ethernet
     conn_name: "{{ item.key }}"
-    ifname: "{{ item.value.ifname }}"
+    ifname: "{{ item.value.ifname | default(omit) }}"
     state: present
     autoconnect: false
   loop: "{{ networkmanager_connections.ethernet | dict2items | default([]) }}"


### PR DESCRIPTION
## Summary

Add `| default(omit)` to `item.value.ifname` in the ethernet placeholder task so its behavior matches the configure task (which already uses `default(omit)`). One-line fix, semantically equivalent to the configure-task pattern that already works in production.

Closes #111

## Test plan

- [x] `ansible-lint` clean
- [ ] CI passes