### PR TITLE
refactor(networkmanager): drop toggle_wifi cleanup task

### DIFF
--- a/roles/networkmanager/molecule/default/verify.yml
+++ b/roles/networkmanager/molecule/default/verify.yml
@@ -335,18 +335,6 @@
         label: "{{ item.item }}"
       when: sshfs_configured | bool
 
-    - name: Verify | Assert WiFi toggle dispatcher script is absent
-      ansible.builtin.stat:
-        path: /etc/NetworkManager/dispatcher.d/10-wifi-auto-toggle.sh
-      register: wifi_toggle_script
-
-    - name: Verify | WiFi toggle dispatcher script must not exist
-      ansible.builtin.assert:
-        that:
-          - not wifi_toggle_script.stat.exists
-        fail_msg: WiFi toggle dispatcher script must be removed (toggle_wifi was deprecated)
-        success_msg: WiFi toggle dispatcher script is correctly absent
-
     #
     # VPN Auto-Connect Verification (only when VPN configured)
     #

--- a/roles/networkmanager/tasks/dispatcher.yml
+++ b/roles/networkmanager/tasks/dispatcher.yml
@@ -287,14 +287,3 @@
     path: /usr/local/lib/wireguard-smb-mount.sh
     state: absent
   when: __networkmanager_smb_wg_deps | default([]) | length == 0
-
-# The WiFi auto-toggle dispatcher (formerly enabled via `toggle_wifi: true`
-# on an ethernet connection) has been removed. It conflicted with
-# systemd-rfkill state persistence and was unnecessary on hosts using
-# `rp_filter=2` (loose mode), where ETH + WiFi on the same subnet
-# coexist without DNS/routing issues. The task below cleans up the
-# script on hosts upgrading from an earlier role version.
-- name: Dispatcher | Ensure WiFi auto-toggle dispatcher script is removed
-  ansible.builtin.file:
-    path: /etc/NetworkManager/dispatcher.d/10-wifi-auto-toggle.sh
-    state: absent


### PR DESCRIPTION
## Summary

Drop the one-shot migration cleanup task left in PR #114, plus the molecule verify regression-guard. After PR #114 ran once on existing hosts, the dispatcher script is gone — keeping the cleanup as permanent role code is dead weight.

Closes #115

## Test plan

- [x] `ansible-lint` clean (production profile)
- [ ] CI passes (lint + molecule)