### PR TITLE
fix(networkmanager): classify SMB dispatcher depends_on by inventory data

### DIFF
--- a/roles/networkmanager/molecule/default/converge.yml
+++ b/roles/networkmanager/molecule/default/converge.yml
@@ -15,6 +15,7 @@
     networkmanager_connections: "{{ test_networkmanager_connections }}"
     networkmanager_smb_shares: "{{ test_networkmanager_smb_shares | default([]) }}"
     networkmanager_sshfs_shares: "{{ test_networkmanager_sshfs_shares | default([]) }}"
+    wireguard_interfaces: "{{ test_wireguard_interfaces | default([]) }}"
     users_list: "{{ test_users_list }}"
     networkmanager_unmanaged_devices: "{{ test_networkmanager_unmanaged_devices }}"
     networkmanager_polkit_enabled: "{{ test_networkmanager_polkit_enabled }}"

--- a/roles/networkmanager/molecule/default/molecule.yml
+++ b/roles/networkmanager/molecule/default/molecule.yml
@@ -129,6 +129,21 @@ provisioner:
               - name: vagrant
                 smb_username: testuser
                 smb_password: testpass
+          - name: WireGuard Only Share
+            src: //wg-internal.corp/wg
+            mount_subpath: wg/data
+            credentials_name: wg-corp
+            mount_options:
+              iocharset: utf8
+            depends_on:
+              - wg0
+            users:
+              - name: vagrant
+                smb_username: testuser
+                smb_password: testpass
+
+        test_wireguard_interfaces:
+          - name: wg0
 
         test_networkmanager_sshfs_shares:
           - name: Remote Dev Server

--- a/roles/networkmanager/tasks/connections.yml
+++ b/roles/networkmanager/tasks/connections.yml
@@ -295,6 +295,8 @@
   changed_when: false
   # nmcli may fail if NetworkManager is not running or no connections exist
   failed_when: false
+  # Read-only lookup, must run under --check so downstream templates have UUIDs.
+  check_mode: false
 
 - name: Connections | Add type to UUID results
   ansible.builtin.set_fact:
@@ -346,6 +348,8 @@
   changed_when: false
   # nmcli may fail if NetworkManager is not running or no connections exist
   failed_when: false
+  # Read-only lookup, must run under --check so downstream templates have UUIDs.
+  check_mode: false
 
 - name: Connections | Collect VPN connection details
   ansible.builtin.set_fact:

--- a/roles/networkmanager/tasks/dispatcher.yml
+++ b/roles/networkmanager/tasks/dispatcher.yml
@@ -1,4 +1,9 @@
 ---
+- name: Dispatcher | Build explicit WireGuard interface name list
+  ansible.builtin.set_fact:
+    __networkmanager_wg_interface_names: >-
+      {{ wireguard_interfaces | default([]) | map(attribute='name') | list }}
+
 - name: Dispatcher | Ensure timezone dispatcher script is installed
   ansible.builtin.template:
     src: dispatcher.d/09-timezone.sh.j2
@@ -238,10 +243,7 @@
       {{ networkmanager_smb_shares
          | selectattr('depends_on', 'defined')
          | map(attribute='depends_on') | flatten
-         | difference(
-             (all_network_connections.ethernet.keys() | list) +
-             (all_network_connections.wifi.keys() | list) +
-             (all_network_connections.vpn.keys() | list))
+         | intersect(__networkmanager_wg_interface_names)
          | unique | list }}
   when: networkmanager_smb_shares | length > 0
 

--- a/roles/networkmanager/templates/dispatcher.d/20-vpn-autoconnect.sh.j2
+++ b/roles/networkmanager/templates/dispatcher.d/20-vpn-autoconnect.sh.j2
@@ -10,12 +10,15 @@ LOG_PREFIX="NM-VPN-Autoconnect"
 WG_INTERFACE="{{ networkmanager_vpn_autoconnect.interface }}"
 WG_CONNECTION="WireGuard ${WG_INTERFACE}"
 
+{# Configured NM base connection names (always present in inventory). #}
+{% set _nm_base_names = ((networkmanager_connections.ethernet | default({})).keys() | list)
+                        + ((networkmanager_connections.wifi | default({})).keys() | list) %}
+{# UUID lookup uses live nmcli output. #}
 {% set uuid_map = {} %}
-{# Build UUID map for home connections that should NOT trigger VPN #}
 {% for conn_type in ['ethernet', 'wifi'] %}
   {% if network_connections_data[conn_type] is defined %}
     {% for conn_name, conn_details in network_connections_data[conn_type].items() %}
-      {% if conn_details.uuid is defined %}
+      {% if conn_details.uuid is defined and conn_details.uuid | length > 0 %}
         {% set _ = uuid_map.update({conn_name: conn_details.uuid}) %}
       {% endif %}
     {% endfor %}
@@ -24,9 +27,13 @@ WG_CONNECTION="WireGuard ${WG_INTERFACE}"
 
 {% set home_uuids = [] %}
 {% for conn_name in networkmanager_vpn_autoconnect.home_connections %}
-  {% if uuid_map[conn_name] is defined %}
-    {% set _ = home_uuids.append(uuid_map[conn_name]) %}
+  {% if conn_name not in _nm_base_names %}
+    {{ undef('home_connections entry "' ~ conn_name ~ '" is not a key in networkmanager_connections.{ethernet,wifi}.') }}
   {% endif %}
+  {% if conn_name not in uuid_map %}
+    {{ undef('NM connection "' ~ conn_name ~ '" is configured but no UUID was collected. Investigate connections enumeration (see issue #121).') }}
+  {% endif %}
+  {% set _ = home_uuids.append(uuid_map[conn_name]) %}
 {% endfor %}
 
 # Only react to ethernet and wifi interfaces, skip loopback/bridge/docker/wg/etc.

--- a/roles/networkmanager/templates/dispatcher.d/30-mount-smb.sh.j2
+++ b/roles/networkmanager/templates/dispatcher.d/30-mount-smb.sh.j2
@@ -11,22 +11,22 @@
 # CONNECTION_UUID is provided by NetworkManager dispatcher.
 LOG_PREFIX="NM-SMB-Mount"
 
+{# Classification sources: configured inventory data (always present). #}
+{% set _nm_base_names = ((networkmanager_connections.ethernet | default({})).keys() | list)
+                        + ((networkmanager_connections.wifi | default({})).keys() | list) -%}
+{% set _vpn_names = (networkmanager_connections.vpn | default({})).keys() | list -%}
+{% set _wg_names = __networkmanager_wg_interface_names | default([]) -%}
+{# UUID lookup uses live nmcli output. #}
 {% set uuid_map = {} -%}
-{% set vpn_connection_names = [] -%}
 {% for conn_type in ['ethernet', 'wifi'] -%}
   {% if network_connections_data[conn_type] is defined -%}
     {% for conn_name, conn_details in network_connections_data[conn_type].items() -%}
-      {% if conn_details.uuid is defined -%}
+      {% if conn_details.uuid is defined and conn_details.uuid | length > 0 -%}
         {% set _ = uuid_map.update({conn_name: conn_details.uuid}) -%}
       {% endif -%}
     {% endfor -%}
   {% endif -%}
 {% endfor -%}
-{% if network_connections_data.vpn is defined -%}
-  {% for vpn_name in network_connections_data.vpn.keys() -%}
-    {% set _ = vpn_connection_names.append(vpn_name) -%}
-  {% endfor -%}
-{% endif -%}
 {% set user_homes = {} -%}
 {% for user in users_list | default([]) -%}
   {% set _ = user_homes.update({user.name: user.home | default('/home/' + user.name)}) -%}
@@ -40,12 +40,17 @@ if [ "$2" = "up" ]; then
       {% set ns = namespace(has_vpn_dependency=false) %}
 
       {% for dependency_name in share.depends_on %}
-        {% if dependency_name in vpn_connection_names %}
+        {% if dependency_name in _vpn_names %}
           {% set ns.has_vpn_dependency = true %}
-        {% elif uuid_map[dependency_name] is defined %}
+        {% elif dependency_name in _nm_base_names %}
+          {% if dependency_name not in uuid_map %}
+            {{ undef('NM connection "' ~ dependency_name ~ '" is configured but no UUID was collected. Investigate connections enumeration (see issue #121).') }}
+          {% endif %}
           {% set _ = dependency_uuids_for_this_share.append(uuid_map[dependency_name]) %}
-        {% else %}
+        {% elif dependency_name in _wg_names %}
           {% set _ = dependency_wg_interfaces.append(dependency_name) %}
+        {% else %}
+          {{ undef('Unknown depends_on "' ~ dependency_name ~ '" for share "' ~ share.name ~ '". Must be a key in networkmanager_connections.{ethernet,wifi,vpn} or a name in wireguard_interfaces.') }}
         {% endif %}
       {% endfor %}
 
@@ -59,8 +64,8 @@ if [ "$2" = "up" ]; then
   fi
         {% endif %}
         {% if dependency_wg_interfaces | length > 0 %}
-  # WireGuard interface dependencies (managed by wg-quick/systemd)
-  if {% for iface in dependency_wg_interfaces %}systemctl is-active --quiet "wg-quick@{{ iface }}.service"{% if not loop.last %} || {% endif %}{% endfor %}; then
+  # WireGuard interface dependencies (sysfs check works for both nm and wg-quick modes)
+  if {% for iface in dependency_wg_interfaces %}[ -d "/sys/class/net/{{ iface }}" ]{% if not loop.last %} || {% endif %}{% endfor %}; then
     SHOULD_MOUNT="true"
   fi
         {% endif %}

--- a/roles/networkmanager/templates/dispatcher.d/40-umount-smb.sh.j2
+++ b/roles/networkmanager/templates/dispatcher.d/40-umount-smb.sh.j2
@@ -11,23 +11,25 @@
 # CONNECTION_UUID is provided by NetworkManager dispatcher.
 LOG_PREFIX="NM-SMB-Unmount-Down"
 
+{# Classification sources: configured inventory data (always present). #}
+{% set _nm_base_names = ((networkmanager_connections.ethernet | default({})).keys() | list)
+                        + ((networkmanager_connections.wifi | default({})).keys() | list) -%}
+{% set _vpn_names = (networkmanager_connections.vpn | default({})).keys() | list -%}
+{% set _wg_names = __networkmanager_wg_interface_names | default([]) -%}
+{# id_map: NM connection → UUID, VPN → name (matches get_active_connection_ids output). #}
 {% set id_map = {} -%}
-{% if network_connections_data is defined -%}
-  {% for conn_type in ['ethernet', 'wifi'] -%}
-    {% if network_connections_data[conn_type] is defined -%}
-      {% for conn_name, conn_details in network_connections_data[conn_type].items() -%}
-        {% if conn_details.uuid is defined -%}
-          {% set _ = id_map.update({conn_name: conn_details.uuid}) -%}
-        {% endif -%}
-      {% endfor -%}
-    {% endif -%}
-  {% endfor -%}
-  {% if network_connections_data.vpn is defined -%}
-    {% for vpn_name, vpn_details in network_connections_data.vpn.items() -%}
-      {% set _ = id_map.update({vpn_name: vpn_name}) -%}
+{% for conn_type in ['ethernet', 'wifi'] -%}
+  {% if network_connections_data[conn_type] is defined -%}
+    {% for conn_name, conn_details in network_connections_data[conn_type].items() -%}
+      {% if conn_details.uuid is defined and conn_details.uuid | length > 0 -%}
+        {% set _ = id_map.update({conn_name: conn_details.uuid}) -%}
+      {% endif -%}
     {% endfor -%}
   {% endif -%}
-{% endif -%}
+{% endfor -%}
+{% for vpn_name in _vpn_names -%}
+  {% set _ = id_map.update({vpn_name: vpn_name}) -%}
+{% endfor -%}
 {% set user_homes = {} -%}
 {% for user in users_list | default([]) -%}
   {% set _ = user_homes.update({user.name: user.home | default('/home/' + user.name)}) -%}
@@ -51,10 +53,17 @@ if [ "$2" = "down" ]; then
     {% set resolved_nm_dependencies = [] %}
     {% set wg_interface_dependencies = [] %}
     {% for dependency_name in share.depends_on %}
-      {% if id_map[dependency_name] is defined %}
+      {% if dependency_name in _vpn_names %}
+        {% set _ = resolved_nm_dependencies.append(dependency_name) %}
+      {% elif dependency_name in _nm_base_names %}
+        {% if dependency_name not in id_map %}
+          {{ undef('NM connection "' ~ dependency_name ~ '" is configured but no UUID was collected. Investigate connections enumeration (see issue #121).') }}
+        {% endif %}
         {% set _ = resolved_nm_dependencies.append(id_map[dependency_name]) %}
-      {% else %}
+      {% elif dependency_name in _wg_names %}
         {% set _ = wg_interface_dependencies.append(dependency_name) %}
+      {% else %}
+        {{ undef('Unknown depends_on "' ~ dependency_name ~ '" for share "' ~ share.name ~ '". Must be a key in networkmanager_connections.{ethernet,wifi,vpn} or a name in wireguard_interfaces.') }}
       {% endif %}
     {% endfor %}
 
@@ -72,8 +81,8 @@ if [ "$2" = "down" ]; then
     fi
         {% endfor %}
         {% for iface in wg_interface_dependencies %}
-    # Check if WireGuard interface dependency is still active
-    if systemctl is-active --quiet "wg-quick@{{ iface }}.service"; then
+    # Check if WireGuard interface dependency is still active (works for both nm and wg-quick modes)
+    if [ -d "/sys/class/net/{{ iface }}" ]; then
       SHARE_STILL_NEEDED="true"
     fi
         {% endfor %}

--- a/roles/networkmanager/templates/dispatcher.d/50-vpn-mount-smb.sh.j2
+++ b/roles/networkmanager/templates/dispatcher.d/50-vpn-mount-smb.sh.j2
@@ -9,23 +9,11 @@
 # NM_VPN_NAME is provided by NetworkManager dispatcher for VPN events.
 LOG_PREFIX="NM-VPN-SMB-Mount"
 
-{% set id_map = {} -%}
-{% if network_connections_data is defined -%}
-  {% for conn_type in ['ethernet', 'wifi'] -%}
-    {% if network_connections_data[conn_type] is defined -%}
-      {% for conn_name, conn_details in network_connections_data[conn_type].items() -%}
-        {% if conn_details.uuid is defined -%}
-          {% set _ = id_map.update({conn_name: conn_details.uuid}) -%}
-        {% endif -%}
-      {% endfor -%}
-    {% endif -%}
-  {% endfor -%}
-  {% if network_connections_data.vpn is defined -%}
-    {% for vpn_name, vpn_details in network_connections_data.vpn.items() -%}
-      {% set _ = id_map.update({vpn_name: vpn_name}) -%}
-    {% endfor -%}
-  {% endif -%}
-{% endif -%}
+{# Classification sources: configured inventory data (always present). #}
+{% set _nm_base_names = ((networkmanager_connections.ethernet | default({})).keys() | list)
+                        + ((networkmanager_connections.wifi | default({})).keys() | list) -%}
+{% set _vpn_names = (networkmanager_connections.vpn | default({})).keys() | list -%}
+{% set _wg_names = __networkmanager_wg_interface_names | default([]) -%}
 {% set user_homes = {} -%}
 {% for user in users_list | default([]) -%}
   {% set _ = user_homes.update({user.name: user.home | default('/home/' + user.name)}) -%}
@@ -36,8 +24,12 @@ if [ "$2" = "vpn-up" ]; then
     {% set dependency_vpn_names_for_this_share = [] %}
 
     {% for dependency_name in share.depends_on %}
-      {% if id_map[dependency_name] is defined and id_map[dependency_name] == dependency_name %}
-        {% set _ = dependency_vpn_names_for_this_share.append(id_map[dependency_name]) %}
+      {% if dependency_name in _vpn_names %}
+        {% set _ = dependency_vpn_names_for_this_share.append(dependency_name) %}
+      {% elif dependency_name in _nm_base_names or dependency_name in _wg_names %}
+        {# NM/WG dependencies are handled by other dispatcher scripts. #}
+      {% else %}
+        {{ undef('Unknown depends_on "' ~ dependency_name ~ '" for share "' ~ share.name ~ '". Must be a key in networkmanager_connections.{ethernet,wifi,vpn} or a name in wireguard_interfaces.') }}
       {% endif %}
     {% endfor %}
 

--- a/roles/networkmanager/templates/dispatcher.d/60-vpn-umount-smb.sh.j2
+++ b/roles/networkmanager/templates/dispatcher.d/60-vpn-umount-smb.sh.j2
@@ -10,23 +10,25 @@
 # NM_VPN_NAME is provided by NetworkManager dispatcher for VPN events.
 LOG_PREFIX="NM-VPN-SMB-Umount"
 
+{# Classification sources: configured inventory data (always present). #}
+{% set _nm_base_names = ((networkmanager_connections.ethernet | default({})).keys() | list)
+                        + ((networkmanager_connections.wifi | default({})).keys() | list) -%}
+{% set _vpn_names = (networkmanager_connections.vpn | default({})).keys() | list -%}
+{% set _wg_names = __networkmanager_wg_interface_names | default([]) -%}
+{# id_map: NM connection → UUID, VPN → name (matches get_active_connection_ids output). #}
 {% set id_map = {} -%}
-{% if network_connections_data is defined -%}
-  {% for conn_type in ['ethernet', 'wifi'] -%}
-    {% if network_connections_data[conn_type] is defined -%}
-      {% for conn_name, conn_details in network_connections_data[conn_type].items() -%}
-        {% if conn_details.uuid is defined -%}
-          {% set _ = id_map.update({conn_name: conn_details.uuid}) -%}
-        {% endif -%}
-      {% endfor -%}
-    {% endif -%}
-  {% endfor -%}
-  {% if network_connections_data.vpn is defined -%}
-    {% for vpn_name, vpn_details in network_connections_data.vpn.items() -%}
-      {% set _ = id_map.update({vpn_name: vpn_name}) -%}
+{% for conn_type in ['ethernet', 'wifi'] -%}
+  {% if network_connections_data[conn_type] is defined -%}
+    {% for conn_name, conn_details in network_connections_data[conn_type].items() -%}
+      {% if conn_details.uuid is defined and conn_details.uuid | length > 0 -%}
+        {% set _ = id_map.update({conn_name: conn_details.uuid}) -%}
+      {% endif -%}
     {% endfor -%}
   {% endif -%}
-{% endif -%}
+{% endfor -%}
+{% for vpn_name in _vpn_names -%}
+  {% set _ = id_map.update({vpn_name: vpn_name}) -%}
+{% endfor -%}
 {% set user_homes = {} -%}
 {% for user in users_list | default([]) -%}
   {% set _ = user_homes.update({user.name: user.home | default('/home/' + user.name)}) -%}
@@ -49,8 +51,17 @@ if [ "$2" = "vpn-down" ]; then
   {% for share in networkmanager_smb_shares %}
     {% set resolved_dependencies = [] %}
     {% for dependency_name in share.depends_on %}
-      {% if id_map[dependency_name] is defined %}
+      {% if dependency_name in _vpn_names %}
+        {% set _ = resolved_dependencies.append(dependency_name) %}
+      {% elif dependency_name in _nm_base_names %}
+        {% if dependency_name not in id_map %}
+          {{ undef('NM connection "' ~ dependency_name ~ '" is configured but no UUID was collected. Investigate connections enumeration (see issue #121).') }}
+        {% endif %}
         {% set _ = resolved_dependencies.append(id_map[dependency_name]) %}
+      {% elif dependency_name in _wg_names %}
+        {# WG interface dependencies are handled by wireguard-smb-mount.sh. #}
+      {% else %}
+        {{ undef('Unknown depends_on "' ~ dependency_name ~ '" for share "' ~ share.name ~ '". Must be a key in networkmanager_connections.{ethernet,wifi,vpn} or a name in wireguard_interfaces.') }}
       {% endif %}
     {% endfor %}
 

--- a/roles/networkmanager/templates/dispatcher.d/pre-down.d/30-umount-smb.sh.j2
+++ b/roles/networkmanager/templates/dispatcher.d/pre-down.d/30-umount-smb.sh.j2
@@ -9,23 +9,25 @@
 # CONNECTION_UUID is provided by NetworkManager dispatcher.
 LOG_PREFIX="NM-SMB-Unmount-PreDown"
 
+{# Classification sources: configured inventory data (always present). #}
+{% set _nm_base_names = ((networkmanager_connections.ethernet | default({})).keys() | list)
+                        + ((networkmanager_connections.wifi | default({})).keys() | list) -%}
+{% set _vpn_names = (networkmanager_connections.vpn | default({})).keys() | list -%}
+{% set _wg_names = __networkmanager_wg_interface_names | default([]) -%}
+{# id_map: NM connection → UUID, VPN → name (matches get_active_connection_ids output). #}
 {% set id_map = {} -%}
-{% if network_connections_data is defined -%}
-  {% for conn_type in ['ethernet', 'wifi'] -%}
-    {% if network_connections_data[conn_type] is defined -%}
-      {% for conn_name, conn_details in network_connections_data[conn_type].items() -%}
-        {% if conn_details.uuid is defined -%}
-          {% set _ = id_map.update({conn_name: conn_details.uuid}) -%}
-        {% endif -%}
-      {% endfor -%}
-    {% endif -%}
-  {% endfor -%}
-  {% if network_connections_data.vpn is defined -%}
-    {% for vpn_name, vpn_details in network_connections_data.vpn.items() -%}
-      {% set _ = id_map.update({vpn_name: vpn_name}) -%}
+{% for conn_type in ['ethernet', 'wifi'] -%}
+  {% if network_connections_data[conn_type] is defined -%}
+    {% for conn_name, conn_details in network_connections_data[conn_type].items() -%}
+      {% if conn_details.uuid is defined and conn_details.uuid | length > 0 -%}
+        {% set _ = id_map.update({conn_name: conn_details.uuid}) -%}
+      {% endif -%}
     {% endfor -%}
   {% endif -%}
-{% endif -%}
+{% endfor -%}
+{% for vpn_name in _vpn_names -%}
+  {% set _ = id_map.update({vpn_name: vpn_name}) -%}
+{% endfor -%}
 {% set user_homes = {} -%}
 {% for user in users_list | default([]) -%}
   {% set _ = user_homes.update({user.name: user.home | default('/home/' + user.name)}) -%}
@@ -48,8 +50,17 @@ if [ "$2" = "pre-down" ]; then
     {% for share in networkmanager_smb_shares %}
       {% set resolved_dependencies = [] %}
       {% for dependency_name in share.depends_on %}
-        {% if id_map[dependency_name] is defined %}
+        {% if dependency_name in _vpn_names %}
+          {% set _ = resolved_dependencies.append(dependency_name) %}
+        {% elif dependency_name in _nm_base_names %}
+          {% if dependency_name not in id_map %}
+            {{ undef('NM connection "' ~ dependency_name ~ '" is configured but no UUID was collected. Investigate connections enumeration (see issue #121).') }}
+          {% endif %}
           {% set _ = resolved_dependencies.append(id_map[dependency_name]) %}
+        {% elif dependency_name in _wg_names %}
+          {# WG interface dependencies are handled by wireguard-smb-mount.sh on wg-quick down, not in pre-down. #}
+        {% else %}
+          {{ undef('Unknown depends_on "' ~ dependency_name ~ '" for share "' ~ share.name ~ '". Must be a key in networkmanager_connections.{ethernet,wifi,vpn} or a name in wireguard_interfaces.') }}
         {% endif %}
       {% endfor %}
 

--- a/roles/networkmanager/templates/wireguard-smb-mount.sh.j2
+++ b/roles/networkmanager/templates/wireguard-smb-mount.sh.j2
@@ -14,28 +14,22 @@ LOG_PREFIX="WG-SMB-${ACTION}"
 {% for user in users_list | default([]) -%}
   {% set _ = user_homes.update({user.name: user.home | default('/home/' + user.name)}) -%}
 {% endfor -%}
-{% set nm_connection_names = [] -%}
-{% if network_connections_data is defined -%}
-  {% for conn_type in ['ethernet', 'wifi'] -%}
-    {% if network_connections_data[conn_type] is defined -%}
-      {% for conn_name in network_connections_data[conn_type].keys() -%}
-        {% set _ = nm_connection_names.append(conn_name) -%}
-      {% endfor -%}
-    {% endif -%}
-  {% endfor -%}
-  {% if network_connections_data.vpn is defined -%}
-    {% for vpn_name in network_connections_data.vpn.keys() -%}
-      {% set _ = nm_connection_names.append(vpn_name) -%}
-    {% endfor -%}
-  {% endif -%}
-{% endif -%}
+{# Classification sources: configured inventory data (always present). #}
+{% set _nm_base_names = ((networkmanager_connections.ethernet | default({})).keys() | list)
+                        + ((networkmanager_connections.wifi | default({})).keys() | list) -%}
+{% set _vpn_names = (networkmanager_connections.vpn | default({})).keys() | list -%}
+{% set _wg_names = __networkmanager_wg_interface_names | default([]) -%}
 {% if networkmanager_smb_shares is defined and networkmanager_smb_shares is not none and networkmanager_smb_shares | length > 0 %}
 if [ "$ACTION" = "up" ]; then
   {% for share in networkmanager_smb_shares %}
     {% set wg_interface_deps = [] %}
     {% for dep_name in share.depends_on | default([]) %}
-      {% if dep_name not in nm_connection_names %}
+      {% if dep_name in _wg_names %}
         {% set _ = wg_interface_deps.append(dep_name) %}
+      {% elif dep_name in _vpn_names or dep_name in _nm_base_names %}
+        {# Non-WG dependencies are handled by the NM dispatcher scripts. #}
+      {% else %}
+        {{ undef('Unknown depends_on "' ~ dep_name ~ '" for share "' ~ share.name ~ '". Must be a key in networkmanager_connections.{ethernet,wifi,vpn} or a name in wireguard_interfaces.') }}
       {% endif %}
     {% endfor %}
     {% if wg_interface_deps | length > 0 %}
@@ -67,8 +61,12 @@ if [ "$ACTION" = "down" ]; then
   {% for share in networkmanager_smb_shares %}
     {% set wg_interface_deps = [] %}
     {% for dep_name in share.depends_on | default([]) %}
-      {% if dep_name not in nm_connection_names %}
+      {% if dep_name in _wg_names %}
         {% set _ = wg_interface_deps.append(dep_name) %}
+      {% elif dep_name in _vpn_names or dep_name in _nm_base_names %}
+        {# Non-WG dependencies are handled by the NM dispatcher scripts. #}
+      {% else %}
+        {{ undef('Unknown depends_on "' ~ dep_name ~ '" for share "' ~ share.name ~ '". Must be a key in networkmanager_connections.{ethernet,wifi,vpn} or a name in wireguard_interfaces.') }}
       {% endif %}
     {% endfor %}
     {% if wg_interface_deps | length > 0 %}


### PR DESCRIPTION
## Summary

- Templates now classify `depends_on` entries by configured inventory data (`networkmanager_connections.{ethernet,wifi,vpn}.keys()` + `__networkmanager_wg_interface_names`); UUID lookup via `network_connections_data` is only used for the value, never for classification. Unknown names and missing UUIDs raise template build errors instead of falling through to the WG bucket.
- `tasks/dispatcher.yml` builds an explicit `__networkmanager_wg_interface_names` fact from `wireguard_interfaces` and uses it to compute `__networkmanager_smb_wg_deps` via `intersect`, replacing the fragile `difference()` against live nmcli data.
- `tasks/connections.yml` now runs the two `Get UUIDs for ...` shell tasks with `check_mode: false`, so the read-only nmcli lookup also runs under `--check` — root cause for empty UUIDs that surfaced this bug.
- The WireGuard-active check switches from `systemctl is-active wg-quick@<iface>.service` to a sysfs-based `[ -d "/sys/class/net/<iface>" ]` check that works for both `wg-quick` and `nm` modes of the wireguard role.
- Molecule coverage extended with a WireGuard-only SMB share and `test_wireguard_interfaces` fixture so the new WG classification path is exercised.

## Test plan

- [x] `pre-commit run` — passed (ansible-lint, yamllint, syntax, secrets)
- [x] `molecule test -p networkmanager-archlinux` — full sequence green: dependency, destroy, syntax, create, prepare, converge, idempotence, verify, destroy
- [x] Live `ansible-playbook --tags networkmanager --check --diff` on an arch host: no template build errors after fix; remaining diff is only comment-only updates that converge to zero on the next normal run
- [x] Verified `depends_on: [wg0]` renders as `[ -d "/sys/class/net/wg0" ]`
- [x] Verified `depends_on: ["<NM connection>"]` renders as `[ "$CONNECTION_UUID" = "<uuid>" ]`
- [x] Verified empty-UUID case raises a template build error (live-triggered before the `check_mode: false` patch was applied)

Closes #120
References #121