### PR TITLE
feat(networkmanager): assert UUIDs collected for all configured connections

### DIFF
--- a/roles/networkmanager/tasks/connections.yml
+++ b/roles/networkmanager/tasks/connections.yml
@@ -375,6 +375,55 @@
     - item.stdout is defined
     - item.stdout | trim | length > 0
 
+- name: Connections | Build expected present-state connection name sets
+  ansible.builtin.set_fact:
+    __nm_expected_ethernet_names: >-
+      {{ (networkmanager_connections.ethernet | default({}) | dict2items
+          | rejectattr('value.state', 'defined') | map(attribute='key') | list)
+         + (networkmanager_connections.ethernet | default({}) | dict2items
+            | selectattr('value.state', 'defined')
+            | selectattr('value.state', 'equalto', 'present')
+            | map(attribute='key') | list) }}
+    __nm_expected_wifi_names: >-
+      {{ (networkmanager_connections.wifi | default({}) | dict2items
+          | rejectattr('value.state', 'defined') | map(attribute='key') | list)
+         + (networkmanager_connections.wifi | default({}) | dict2items
+            | selectattr('value.state', 'defined')
+            | selectattr('value.state', 'equalto', 'present')
+            | map(attribute='key') | list) }}
+    __nm_expected_vpn_names: >-
+      {{ (networkmanager_connections.vpn | default({}) | dict2items
+          | rejectattr('value.state', 'defined') | map(attribute='key') | list)
+         + (networkmanager_connections.vpn | default({}) | dict2items
+            | selectattr('value.state', 'defined')
+            | selectattr('value.state', 'equalto', 'present')
+            | map(attribute='key') | list) }}
+
+# Defense in depth: catches cases the check_mode: false patch on the UUID
+# lookup tasks does not cover (e.g. nmcli daemon down, connection not yet
+# created on first install, race conditions during configure).
+- name: Connections | Verify UUIDs were collected for all configured connections
+  ansible.builtin.assert:
+    that:
+      - __nm_expected_ethernet_names
+        | difference(all_network_connections.ethernet.keys() | list)
+        | length == 0
+      - __nm_expected_wifi_names
+        | difference(all_network_connections.wifi.keys() | list)
+        | length == 0
+      - __nm_expected_vpn_names
+        | difference(all_network_connections.vpn.keys() | list)
+        | length == 0
+    fail_msg: >-
+      UUID enumeration failed for one or more configured NM connections.
+      Missing ethernet: {{ __nm_expected_ethernet_names
+        | difference(all_network_connections.ethernet.keys() | list) | list }}.
+      Missing wifi: {{ __nm_expected_wifi_names
+        | difference(all_network_connections.wifi.keys() | list) | list }}.
+      Missing vpn: {{ __nm_expected_vpn_names
+        | difference(all_network_connections.vpn.keys() | list) | list }}.
+      Run `nmcli connection show` on the target host to investigate.
+
 - name: Connections | Build VPN UUID list for Ethernet connections
   ansible.builtin.set_fact:
     vpn_uuids_for_connection: >-


### PR DESCRIPTION
## Summary

- Adds three `__nm_expected_*_names` facts that enumerate the names of configured `present`-state NM connections per type (ethernet, wifi, vpn) from `networkmanager_connections`.
- Adds an `assert` task that diffs each expected set against the keys collected in `all_network_connections` and fails the play with a per-type list of missing connection names if any UUID was not collected.
- Defense in depth on top of the `check_mode: false` patch from #120: catches edge cases that patch does not cover (NetworkManager daemon not running, connection not yet created on first install, race conditions, name typos in inventory).

## Test plan

- [x] `pre-commit run` — passed (ansible-lint, yamllint, syntax, secrets)
- [x] `molecule test -p networkmanager-archlinux` — full sequence green (assert does not trigger on the happy path; idempotence passed)
- [x] Live `ansible-playbook --tags networkmanager --check --diff` on an arch host: assert passes silently; no template build errors
- [x] Negative path was implicitly exercised in the #120 debug session: before the `check_mode: false` patch, dispatcher templates raised `undef('NM connection "..." is configured but no UUID was collected')` — same root condition this assert now catches earlier and with clearer messaging
- [ ] Dedicated molecule scenario for negative path (stubbed nmcli) — not added in this PR; existing positive-path coverage is sufficient for the assertion logic itself

Closes #121