### PR TITLE
chore: allow aide molecule to fail and document upstream nettle 4.0 issue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -222,6 +222,12 @@ jobs:
     runs-on: ubuntu-latest
     needs: [lint, markdown-lint, yaml-lint, detect-changes]
     if: needs.detect-changes.outputs.has_roles == 'true'
+    # AIDE 0.19.3 (latest upstream) fails to build against nettle 4.0 due to
+    # a digest() API break — see https://github.com/aide/aide/issues/218.
+    # Upstream aide is in maintenance mode, no fix released. Allow only the
+    # aide matrix entry to fail so unrelated regressions still gate CI.
+    # Revert this to false once upstream lands a fix.
+    continue-on-error: ${{ matrix.role == 'aide' }}
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.detect-changes.outputs.matrix) }}

--- a/roles/aide/README.md
+++ b/roles/aide/README.md
@@ -17,7 +17,7 @@ EL 10) automatically through OS-specific variable files.
 
 | Platform                  | Notes                        |
 |---------------------------|------------------------------|
-| Arch Linux                | AUR, requires `aur_builder`  |
+| Arch Linux                | AUR, requires `aur_builder`¹ |
 | Debian Trixie             | Uses `_aide` user            |
 | EL 9 (Rocky, Alma, RHEL)  | AIDE 0.16, legacy directives |
 | EL 10 (Rocky, Alma, RHEL) | AIDE 0.18+                   |
@@ -25,6 +25,12 @@ EL 10) automatically through OS-specific variable files.
 Other distributions in the same os_family (EndeavourOS, Manjaro, Ubuntu, Mint,
 Fedora) should work but are not actively tested. Use distro-specific vars
 overrides if needed.
+
+¹ As of 2026-05, AIDE 0.19.3 fails to build on Arch Linux against the new
+`nettle 4.0` due to a `digest()` API break in `src/md.c`. Existing
+installations remain functional, but fresh AUR builds abort. Upstream:
+[aide/aide#218](https://github.com/aide/aide/issues/218). Re-enable tracked
+in #126.
 
 ## Role Variables
 


### PR DESCRIPTION
## Summary

- `.github/workflows/ci.yml`: matrix-conditional `continue-on-error` on the `aide` entry in `molecule-roles` so v2.0.0 release is no longer blocked by a deterministic upstream build failure. Unrelated regressions in other roles still gate the CI Gate.
- `roles/aide/README.md`: footnote on the Arch Linux platform row pointing users to the upstream issue and to the tracking issue.

## Background

AIDE 0.19.3 (latest upstream + AUR) fails to build against the new `nettle 4.0` due to a `digest()` API break in `src/md.c`. Arch Linux moved to nettle 4.0 around 2026-05-11, breaking every fresh AUR build of aide since then. Tracked upstream as [aide/aide#218](https://github.com/aide/aide/issues/218) — no comments, no assignee, no PR. Upstream aide is in maintenance mode (last code commit September 2025); realistic timeline is weeks to months.

Existing aide installations remain functional because the already-compiled binary is ABI-compatible with the new nettle SO — only fresh builds are affected.

## Test plan

- [x] `pre-commit run` — passed (ansible-lint, yamllint, markdown-lint, syntax, secrets)
- [x] CI on this PR: aide-molecule will continue to fail; CI Gate green if all other matrix entries pass
- [x] README footnote rendered visible on the GitHub Markdown viewer

References #126