### PR TITLE
fix: read-only command tasks must survive --check (check_mode: false)

### DIFF
--- a/roles/apparmor/tasks/profiles.yml
+++ b/roles/apparmor/tasks/profiles.yml
@@ -8,24 +8,29 @@
 # Keys are inconsistent: sometimes full path (/usr/bin/man), sometimes
 # basename only (tcpdump). We check both forms for reliable matching.
 # failed_when: false — aa-status requires kernel AppArmor subsystem (unavailable in containers)
+# check_mode: false — read-only lookup, must run under --check so the
+# downstream set_fact has parseable JSON instead of an empty stdout.
 - name: Profiles | Get current AppArmor profile status
   ansible.builtin.command:
     cmd: aa-status --json
   register: __apparmor_status_json
   changed_when: false
   failed_when: false
+  check_mode: false
 
+# default('{}', true) — also fall back when stdout is an empty string
+# (aa-status failed on a host without kernel support, or skipped).
 - name: Profiles | Build profile mode lookup sets
   ansible.builtin.set_fact:
     __apparmor_enforce_set: >-
-      {{ (__apparmor_status_json.stdout | default('{}') | from_json).get('profiles', {})
+      {{ (__apparmor_status_json.stdout | default('{}', true) | from_json).get('profiles', {})
          | dict2items | selectattr('value', 'eq', 'enforce')
          | map(attribute='key') | list }}
     __apparmor_complain_set: >-
-      {{ (__apparmor_status_json.stdout | default('{}') | from_json).get('profiles', {})
+      {{ (__apparmor_status_json.stdout | default('{}', true) | from_json).get('profiles', {})
          | dict2items | selectattr('value', 'eq', 'complain')
          | map(attribute='key') | list }}
-  when: __apparmor_status_json.rc == 0
+  when: __apparmor_status_json.rc | default(1) == 0
 
 #
 # Enforce Profiles

--- a/roles/avahi/tasks/apparmor.yml
+++ b/roles/avahi/tasks/apparmor.yml
@@ -11,17 +11,19 @@
   changed_when: false
   # aa-status may fail if AppArmor has no loaded profiles
   failed_when: false
+  # Read-only lookup, must run under --check so set_fact has parseable JSON.
+  check_mode: false
   when: __avahi_apparmor_active.stat.exists
 
 - name: AppArmor | Build enforce set
   ansible.builtin.set_fact:
     __avahi_apparmor_enforce_set: >-
-      {{ (__avahi_aa_status.stdout | default('{}') | from_json).get('profiles', {})
+      {{ (__avahi_aa_status.stdout | default('{}', true) | from_json).get('profiles', {})
          | dict2items | selectattr('value', 'eq', 'enforce')
          | map(attribute='key') | list }}
   when:
     - __avahi_apparmor_active.stat.exists
-    - __avahi_aa_status.rc == 0
+    - __avahi_aa_status.rc | default(1) == 0
 
 - name: AppArmor | Enforce avahi-daemon profile
   ansible.builtin.command:

--- a/roles/chrony/tasks/apparmor.yml
+++ b/roles/chrony/tasks/apparmor.yml
@@ -10,17 +10,19 @@
   register: __chrony_aa_status
   changed_when: false
   failed_when: false
+  # Read-only lookup, must run under --check so set_fact has parseable JSON.
+  check_mode: false
   when: __chrony_apparmor_active.stat.exists
 
 - name: AppArmor | Build enforce set
   ansible.builtin.set_fact:
     __chrony_apparmor_enforce_set: >-
-      {{ (__chrony_aa_status.stdout | default('{}') | from_json).get('profiles', {})
+      {{ (__chrony_aa_status.stdout | default('{}', true) | from_json).get('profiles', {})
          | dict2items | selectattr('value', 'eq', 'enforce')
          | map(attribute='key') | list }}
   when:
     - __chrony_apparmor_active.stat.exists
-    - __chrony_aa_status.rc == 0
+    - __chrony_aa_status.rc | default(1) == 0
 
 - name: AppArmor | Enforce chronyd profile
   ansible.builtin.command:

--- a/roles/clamav/tasks/apparmor.yml
+++ b/roles/clamav/tasks/apparmor.yml
@@ -9,6 +9,8 @@
     cmd: aa-status --json
   register: __clamav_aa_status
   changed_when: false
+  # Read-only lookup, must run under --check so downstream from_json gets parseable input.
+  check_mode: false
   when: __clamav_apparmor_active.stat.exists
 
 - name: AppArmor | Enforce AppArmor profile for clamd
@@ -18,8 +20,8 @@
   when:
     - __clamav_apparmor_active.stat.exists
     - __clamav_apparmor_profile not in
-      ((__clamav_aa_status.stdout | default('{}') | from_json).get('profiles', {})
+      ((__clamav_aa_status.stdout | default('{}', true) | from_json).get('profiles', {})
       | dict2items | selectattr('value', 'eq', 'enforce') | map(attribute='key') | list)
     - __clamav_apparmor_profile | basename not in
-      ((__clamav_aa_status.stdout | default('{}') | from_json).get('profiles', {})
+      ((__clamav_aa_status.stdout | default('{}', true) | from_json).get('profiles', {})
       | dict2items | selectattr('value', 'eq', 'enforce') | map(attribute='key') | list)

--- a/roles/fail2ban/tasks/apparmor.yml
+++ b/roles/fail2ban/tasks/apparmor.yml
@@ -10,17 +10,19 @@
   register: __fail2ban_aa_status
   changed_when: false
   failed_when: false
+  # Read-only lookup, must run under --check so set_fact has parseable JSON.
+  check_mode: false
   when: __fail2ban_apparmor_active.stat.exists
 
 - name: AppArmor | Build enforce set
   ansible.builtin.set_fact:
     __fail2ban_apparmor_enforce_set: >-
-      {{ (__fail2ban_aa_status.stdout | default('{}') | from_json).get('profiles', {})
+      {{ (__fail2ban_aa_status.stdout | default('{}', true) | from_json).get('profiles', {})
          | dict2items | selectattr('value', 'eq', 'enforce')
          | map(attribute='key') | list }}
   when:
     - __fail2ban_apparmor_active.stat.exists
-    - __fail2ban_aa_status.rc == 0
+    - __fail2ban_aa_status.rc | default(1) == 0
 
 - name: AppArmor | Enforce fail2ban profile
   ansible.builtin.command:

--- a/roles/firewalld/tasks/configure.yml
+++ b/roles/firewalld/tasks/configure.yml
@@ -9,11 +9,14 @@
 # Version Detection (for firewalld.conf conditionals)
 #
 
+# check_mode: false — read-only lookup, must run under --check so the
+# downstream set_fact has a parseable version string instead of empty.
 - name: Configure | Get firewalld version
   ansible.builtin.command:
     cmd: firewall-cmd --version
   register: __firewalld_version_output
   changed_when: false
+  check_mode: false
 
 - name: Configure | Set version facts
   ansible.builtin.set_fact:

--- a/roles/graphics/tasks/detect.yml
+++ b/roles/graphics/tasks/detect.yml
@@ -1,11 +1,14 @@
 ---
 # lspci may not be installed in containers or minimal images
+# check_mode: false — read-only lookup, must run under --check so the
+# detection does not falsely report "no GPU" on every dry-run.
 - name: Detect | Get GPU controllers from lspci  # noqa: risky-shell-pipe
   ansible.builtin.shell:
     cmd: "lspci -nn | grep -iE '(VGA|3D|Display) controller'"
   register: __graphics_lspci_output
   changed_when: false
   failed_when: false
+  check_mode: false
 
 - name: Detect | Parse GPU vendors
   ansible.builtin.set_fact:
@@ -16,7 +19,7 @@
          unique | list) |
         map('replace', 'advanced micro devices', 'amd') | list
       }}
-  when: __graphics_lspci_output.rc == 0
+  when: __graphics_lspci_output.rc | default(1) == 0
 
 - name: Detect | Display detected GPUs
   ansible.builtin.debug:

--- a/roles/openssh/tasks/apparmor.yml
+++ b/roles/openssh/tasks/apparmor.yml
@@ -10,17 +10,19 @@
   register: __openssh_aa_status
   changed_when: false
   failed_when: false
+  # Read-only lookup, must run under --check so set_fact has parseable JSON.
+  check_mode: false
   when: __openssh_apparmor_active.stat.exists
 
 - name: AppArmor | Build enforce set
   ansible.builtin.set_fact:
     __openssh_apparmor_enforce_set: >-
-      {{ (__openssh_aa_status.stdout | default('{}') | from_json).get('profiles', {})
+      {{ (__openssh_aa_status.stdout | default('{}', true) | from_json).get('profiles', {})
          | dict2items | selectattr('value', 'eq', 'enforce')
          | map(attribute='key') | list }}
   when:
     - __openssh_apparmor_active.stat.exists
-    - __openssh_aa_status.rc == 0
+    - __openssh_aa_status.rc | default(1) == 0
 
 - name: AppArmor | Enforce sshd profile
   ansible.builtin.command:

--- a/roles/pki/tasks/apparmor.yml
+++ b/roles/pki/tasks/apparmor.yml
@@ -21,17 +21,19 @@
   changed_when: false
   # aa-status may fail if AppArmor has no loaded profiles
   failed_when: false
+  # Read-only lookup, must run under --check so set_fact has parseable JSON.
+  check_mode: false
   when: __pki_apparmor_active.stat.exists
 
 - name: AppArmor | Build enforce set
   ansible.builtin.set_fact:
     __pki_apparmor_enforce_set: >-
-      {{ (__pki_aa_status.stdout | default('{}') | from_json).get('profiles', {})
+      {{ (__pki_aa_status.stdout | default('{}', true) | from_json).get('profiles', {})
          | dict2items | selectattr('value', 'eq', 'enforce')
          | map(attribute='key') | list }}
   when:
     - __pki_apparmor_active.stat.exists
-    - __pki_aa_status.rc == 0
+    - __pki_aa_status.rc | default(1) == 0
 
 - name: AppArmor | Enforce OCSP responder profile
   ansible.builtin.command:

--- a/roles/snmp/tasks/apparmor.yml
+++ b/roles/snmp/tasks/apparmor.yml
@@ -10,17 +10,19 @@
   register: __snmp_aa_status
   changed_when: false
   failed_when: false
+  # Read-only lookup, must run under --check so set_fact has parseable JSON.
+  check_mode: false
   when: __snmp_apparmor_active.stat.exists
 
 - name: AppArmor | Build enforce set
   ansible.builtin.set_fact:
     __snmp_apparmor_enforce_set: >-
-      {{ (__snmp_aa_status.stdout | default('{}') | from_json).get('profiles', {})
+      {{ (__snmp_aa_status.stdout | default('{}', true) | from_json).get('profiles', {})
          | dict2items | selectattr('value', 'eq', 'enforce')
          | map(attribute='key') | list }}
   when:
     - __snmp_apparmor_active.stat.exists
-    - __snmp_aa_status.rc == 0
+    - __snmp_aa_status.rc | default(1) == 0
 
 - name: AppArmor | Enforce snmpd profile
   ansible.builtin.command:

--- a/roles/unbound/tasks/apparmor.yml
+++ b/roles/unbound/tasks/apparmor.yml
@@ -10,17 +10,19 @@
   register: __unbound_aa_status
   changed_when: false
   failed_when: false
+  # Read-only lookup, must run under --check so set_fact has parseable JSON.
+  check_mode: false
   when: __unbound_apparmor_active.stat.exists
 
 - name: AppArmor | Build enforce set
   ansible.builtin.set_fact:
     __unbound_apparmor_enforce_set: >-
-      {{ (__unbound_aa_status.stdout | default('{}') | from_json).get('profiles', {})
+      {{ (__unbound_aa_status.stdout | default('{}', true) | from_json).get('profiles', {})
          | dict2items | selectattr('value', 'eq', 'enforce')
          | map(attribute='key') | list }}
   when:
     - __unbound_apparmor_active.stat.exists
-    - __unbound_aa_status.rc == 0
+    - __unbound_aa_status.rc | default(1) == 0
 
 - name: AppArmor | Enforce unbound profile
   ansible.builtin.command:


### PR DESCRIPTION
## Summary

- Adds `check_mode: false` to 11 read-only `command`/`shell` tasks across the collection so they run under `--check` instead of being silently skipped.
- Adds `default('{}', true)` / `default(1)` defensive fallbacks on downstream `set_fact`/`assert` expressions so they also survive the legitimate case where the command runs but returns empty stdout (host without AppArmor kernel support, container/minimal image without `lspci`, etc.).
- One commit covers all affected roles since the bug class and fix shape are identical.

## Affected files

| Role | File | Command |
|------|------|---------|
| apparmor | `tasks/profiles.yml` | `aa-status --json` |
| avahi | `tasks/apparmor.yml` | `aa-status --json` |
| chrony | `tasks/apparmor.yml` | `aa-status --json` |
| clamav | `tasks/apparmor.yml` | `aa-status --json` |
| fail2ban | `tasks/apparmor.yml` | `aa-status --json` |
| firewalld | `tasks/configure.yml` | `firewall-cmd --version` |
| graphics | `tasks/detect.yml` | `lspci` |
| openssh | `tasks/apparmor.yml` | `aa-status --json` |
| pki | `tasks/apparmor.yml` | `aa-status --json` |
| snmp | `tasks/apparmor.yml` | `aa-status --json` |
| unbound | `tasks/apparmor.yml` | `aa-status --json` |

## Test plan

- [x] `pre-commit run` — passed across all 11 files (ansible-lint, yamllint, syntax, secrets)
- [x] `molecule test -p apparmor-archlinux` — full sequence green (idempotence + verify)
- [x] Live `ansible-playbook playbooks/base.yml --check --diff` on an arch host with apparmor, firewalld and lspci active: previously crashed on apparmor or firewalld, now runs through clean (`ok=551 changed=8 failed=0`); GPU detection no longer emits the false "no GPU detected" warning
- [x] Existing `failed_when: false` paths still work on containers (apparmor molecule scenario without kernel support stays green via `apparmor_kernel_active` guard)

Closes #128