### PR TITLE
feat(shell)!: migrate shell role from marcstraube.desktop

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -214,6 +214,22 @@
         "line_number": 13
       }
     ],
+    "roles/shell/molecule/default/prepare.yml": [
+      {
+        "type": "Secret Keyword",
+        "filename": "roles/shell/molecule/default/prepare.yml",
+        "hashed_secret": "6b42874e3cd20771d93096ec5ce36307a1f2ba14",
+        "is_verified": false,
+        "line_number": 118
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "roles/shell/molecule/default/prepare.yml",
+        "hashed_secret": "c9c4e10b777bc09081ea06239dbf7554bfda45d6",
+        "is_verified": false,
+        "line_number": 144
+      }
+    ],
     "roles/users/README.md": [
       {
         "type": "Secret Keyword",
@@ -292,5 +308,5 @@
       }
     ]
   },
-  "generated_at": "2026-05-11T19:44:43Z"
+  "generated_at": "2026-05-18T16:33:29Z"
 }

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 ## Description
 
 Shared Ansible roles for multi-OS infrastructure management.
-41 roles covering base system, security, networking, package management,
+42 roles covering base system, security, networking, package management,
 user management, editors, and more.
 
 ## Supported Platforms
@@ -32,6 +32,7 @@ user management, editors, and more.
 | **sudo**              | Sudo configuration                                        |
 | **editors**           | Text editors (nano, vim, neovim) with per-user config     |
 | **multiplexer**       | Terminal multiplexers (tmux, zellij) with per-user config |
+| **shell**             | Shells (zsh, bash, fish), Starship prompt, modern CLI     |
 | **utils**             | CLI utilities and monitoring tools                        |
 | **fonts**             | System and Nerd Fonts                                     |
 | **energy_management** | Power management (logind, PPD/TLP/tuned)                  |

--- a/roles/shell/README.md
+++ b/roles/shell/README.md
@@ -1,0 +1,193 @@
+# shell
+
+Install and configure shells (Zsh, Fish, Bash) and Starship prompt with modern CLI tools.
+
+## Requirements
+
+None.
+
+## Supported Platforms
+
+| Platform                   | Notes |
+|----------------------------|-------|
+| Arch Linux                 |       |
+| Debian Trixie              |       |
+| EL 9 (Rocky, Alma, RHEL)   |       |
+| EL 10 (Rocky, Alma, RHEL)  |       |
+
+Other distributions in the same os_family (EndeavourOS, Manjaro, Ubuntu, Mint,
+Fedora) should work but are not actively tested. Use distro-specific vars
+overrides if needed.
+
+## Role Variables
+
+### Role Control
+
+| Variable        | Default | Description           |
+|-----------------|---------|-----------------------|
+| `shell_enabled` | `true`  | Enable the shell role |
+
+### Default Shell
+
+| Variable                 | Default     | Description                                               |
+|--------------------------|-------------|-----------------------------------------------------------|
+| `shell_default`          | `'bash'`    | Default shell for users: zsh, fish, bash                  |
+| `shell_users`            | `[]`        | Users to change shell (empty = all from users_list)       |
+| `shell_user_config_mode` | `'initial'` | User config mode: managed, initial (if absent), disabled  |
+
+### Zsh
+
+| Variable                 | Default    | Description                                          |
+|--------------------------|------------|------------------------------------------------------|
+| `shell_zsh_enabled`      | `false`    | Enable Zsh installation                              |
+| `shell_zsh_framework`    | `'native'` | Zsh framework: native or ohmyzsh                     |
+| `shell_zsh_plugins`      | `[...]`    | Zsh plugins (native framework only)                  |
+| `shell_zsh_grml_enabled` | `false`    | Enable grml-zsh-config (native framework only)       |
+
+### Oh My Zsh
+
+Only used when `shell_zsh_framework: 'ohmyzsh'`. Installs Oh My Zsh per-user via git
+clone and deploys a managed `.zshrc`. Requires `git` to be installed.
+
+| Variable                        | Default          | Description                                    |
+|---------------------------------|------------------|------------------------------------------------|
+| `shell_ohmyzsh_theme`           | `'robbyrussell'` | Oh My Zsh theme (set to `''` for Starship)     |
+| `shell_ohmyzsh_plugins`         | `['git']`        | Built-in Oh My Zsh plugins to activate         |
+| `shell_ohmyzsh_custom_plugins`  | `[]`             | Third-party plugins (list of name/repo dicts)  |
+
+Custom plugins example:
+
+```yaml
+shell_ohmyzsh_custom_plugins:
+  - name: 'zsh-autosuggestions'
+    repo: 'https://github.com/zsh-users/zsh-autosuggestions.git'
+  - name: 'zsh-syntax-highlighting'
+    repo: 'https://github.com/zsh-users/zsh-syntax-highlighting.git'
+```
+
+When `shell_starship_enabled` is `true`, the deployed `.zshrc` sets `ZSH_THEME=""`
+and adds Starship init automatically.
+
+### Fish
+
+| Variable             | Default | Description              |
+|----------------------|---------|--------------------------|
+| `shell_fish_enabled` | `false` | Enable Fish installation |
+
+### Bash
+
+| Variable                        | Default | Description            |
+|---------------------------------|---------|------------------------|
+| `shell_bash_completion_enabled` | `true`  | Enable bash-completion |
+
+### Starship
+
+| Variable                        | Default           | Description                                |
+|---------------------------------|-------------------|--------------------------------------------|
+| `shell_starship_enabled`        | `true`            | Enable Starship prompt installation        |
+| `shell_starship_config_enabled` | `false`           | Enable Starship config deployment          |
+| `shell_starship_preset`         | `''`              | Starship preset (empty = minimal default)  |
+| `shell_starship_shells`         | `['zsh', 'bash']` | Configure Starship for these shells        |
+
+When `shell_starship_config_enabled` is `true`, the role deploys
+`~/.config/starship.toml` per user (from `shell_users` or `users_list`).
+With a preset set, content is rendered via `starship preset <name>`. With
+an empty preset, a minimal placeholder is deployed. Deployment honours
+`shell_user_config_mode`: `'managed'` reconciles every run, `'initial'`
+only deploys if the file is absent, `'disabled'` skips entirely.
+
+Valid preset names (source: `starship preset --list`):
+`bracketed-segments`, `catppuccin-powerline`, `gruvbox-rainbow`,
+`jetpack`, `nerd-font-symbols`, `no-empty-icons`, `no-nerd-font`,
+`no-runtime-versions`, `pastel-powerline`, `plain-text-symbols`,
+`pure-preset`, `tokyo-night`. An invalid preset value fails the
+role at start with a clear assertion message.
+
+`shell_starship_shells` controls which shell rcfiles get a
+starship init line appended via `blockinfile` (with marker
+`# ANSIBLE MANAGED — starship init`). Independent from
+`shell_starship_config_enabled` — a user can opt into starship
+init using starship defaults without deploying a custom config.
+
+| Shell  | Target file                  | Init line                          |
+|--------|------------------------------|------------------------------------|
+| `bash` | `~/.bashrc`                  | `eval "$(starship init bash)"`     |
+| `zsh`  | `~/.zshrc`                   | `eval "$(starship init zsh)"`      |
+| `fish` | `~/.config/fish/config.fish` | `starship init fish \| source`     |
+
+The zsh init line is skipped when `shell_zsh_framework: 'ohmyzsh'` —
+the Oh My Zsh `.zshrc` template already includes starship init when
+both are enabled, so adding it again would duplicate.
+
+Init lines honour `shell_user_config_mode`: `'managed'` reconciles
+the marker block on every run; `'initial'` deploys the block on
+first run and leaves the file alone if the marker is already present
+(preserving any user modifications inside it); `'disabled'` skips.
+
+### Additional Tools
+
+| Variable                 | Default | Description                               |
+|--------------------------|---------|-------------------------------------------|
+| `shell_fzf_enabled`      | `true`  | Enable fzf (fuzzy finder)                 |
+| `shell_zoxide_enabled`   | `false` | Enable zoxide (smarter cd)                |
+| `shell_eza_enabled`      | `false` | Enable eza (modern ls)                    |
+| `shell_bat_enabled`      | `false` | Enable bat (cat with syntax highlighting) |
+| `shell_fd_enabled`       | `false` | Enable fd (modern find)                   |
+| `shell_ripgrep_enabled`  | `false` | Enable ripgrep (modern grep)              |
+| `shell_tldr_enabled`     | `false` | Enable tldr (simplified man pages)        |
+
+## Tags
+
+| Tag               | Description                    |
+|-------------------|--------------------------------|
+| `shell`           | All shell tasks                |
+| `shell:install`   | Package installation           |
+| `shell:ohmyzsh`   | Oh My Zsh setup and config     |
+| `shell:users`     | User shell configuration       |
+| `shell:starship`  | Starship per-user config       |
+
+## Example Playbook
+
+```yaml
+- hosts: workstations
+  become: true
+  tasks:
+    - name: Include shell role
+      ansible.builtin.include_role:
+        name: marcstraube.common.shell
+      tags:
+        - shell
+      when: shell_enabled | default(true) | bool
+```
+
+## Testing
+
+```bash
+cd collections/ansible_collections/marcstraube/common
+molecule test -s default -- --limit shell-archlinux
+```
+
+## References
+
+- [Bash](https://www.gnu.org/software/bash/) — GNU Bourne Again SHell
+- [Zsh](https://www.zsh.org/) — Z Shell — extended Bourne shell with many improvements
+- [Fish](https://fishshell.com/) — Smart and user-friendly command line shell
+- [Oh My Zsh](https://ohmyz.sh/) — Community-driven framework for managing Zsh configuration
+- [Starship](https://starship.rs/) — Minimal, fast, customizable cross-shell prompt
+- [Starship Presets](https://starship.rs/presets/) — Curated configuration presets (`starship preset --list`)
+- [grml-zsh-config](https://grml.org/zsh/) — Feature-rich Zsh setup from the GRML project
+- [fzf](https://github.com/junegunn/fzf) — Command-line fuzzy finder
+- [zoxide](https://github.com/ajeetdsouza/zoxide) — Smarter `cd` command
+- [eza](https://github.com/eza-community/eza) — Modern replacement for `ls`
+- [bat](https://github.com/sharkdp/bat) — `cat` clone with syntax highlighting and Git integration
+- [fd](https://github.com/sharkdp/fd) — Simple, fast, user-friendly alternative to `find`
+- [ripgrep](https://github.com/BurntSushi/ripgrep) — Recursive `grep` alternative respecting gitignore
+- [tldr](https://tldr.sh/) — Simplified, community-driven man pages
+
+## License
+
+MIT
+
+## Author
+
+Marc Straube

--- a/roles/shell/defaults/main.yml
+++ b/roles/shell/defaults/main.yml
@@ -1,0 +1,126 @@
+---
+#
+# Role Control
+#
+
+# Enable the shell role
+shell_enabled: true
+
+#
+# Default Shell
+#
+
+# Default shell for users: zsh, fish, bash
+shell_default: 'bash'
+
+# Users to change shell for (empty = all users from users_list)
+shell_users: []
+
+# User configuration mode: managed (always deploy), initial (only if absent), disabled
+# 'initial' preserves user customisations after first deploy.
+# Set to 'managed' for continuous reconciliation.
+shell_user_config_mode: 'initial'
+
+#
+# Zsh
+#
+
+# Enable Zsh installation
+shell_zsh_enabled: false
+
+# Zsh framework: native (system packages) or ohmyzsh (Oh My Zsh per-user install)
+shell_zsh_framework: 'native'
+
+# Zsh plugins to install (native framework only)
+# Options: autosuggestions, syntax-highlighting, completions, history-substring-search
+shell_zsh_plugins:
+  - 'completions'
+  - 'autosuggestions'
+  - 'syntax-highlighting'
+
+# Enable grml-zsh-config (native framework only, Arch ISO defaults)
+shell_zsh_grml_enabled: false
+
+#
+# Oh My Zsh (only when shell_zsh_framework == 'ohmyzsh')
+#
+
+# Oh My Zsh theme (set to '' to disable, e.g. when using Starship)
+shell_ohmyzsh_theme: 'robbyrussell'
+
+# Built-in Oh My Zsh plugins to activate
+shell_ohmyzsh_plugins:
+  - 'git'
+
+# Third-party plugins to install via git clone into custom/plugins
+# Each entry requires 'name' and 'repo'. Optional 'version' (default: master).
+shell_ohmyzsh_custom_plugins: []
+# Example:
+#   - name: 'zsh-autosuggestions'
+#     repo: 'https://github.com/zsh-users/zsh-autosuggestions.git'
+#   - name: 'zsh-syntax-highlighting'
+#     repo: 'https://github.com/zsh-users/zsh-syntax-highlighting.git'
+#   - name: 'zsh-completions'
+#     repo: 'https://github.com/zsh-users/zsh-completions.git'
+
+#
+# Fish
+#
+
+# Enable Fish installation
+shell_fish_enabled: false
+
+#
+# Bash
+#
+
+# Enable bash-completion
+shell_bash_completion_enabled: true
+
+#
+# Starship
+#
+
+# Enable Starship prompt installation
+shell_starship_enabled: true
+
+# Enable Starship config deployment
+shell_starship_config_enabled: false
+
+# Starship preset (empty = minimal default config)
+# Options: bracketed-segments, catppuccin-powerline, gruvbox-rainbow,
+#          jetpack, nerd-font-symbols, no-empty-icons, no-nerd-font,
+#          no-runtime-versions, pastel-powerline, plain-text-symbols,
+#          pure-preset, tokyo-night
+# Source: `starship preset --list`
+shell_starship_preset: ''
+
+# Configure Starship for shells (adds init to shell config)
+shell_starship_shells:
+  - 'zsh'
+  - 'bash'
+
+#
+# Additional Tools
+#
+
+# Enable fzf (fuzzy finder)
+shell_fzf_enabled: true
+
+# Enable zoxide (smarter cd)
+shell_zoxide_enabled: false
+
+# Enable eza (modern ls)
+shell_eza_enabled: false
+
+# Enable bat (cat with syntax highlighting)
+shell_bat_enabled: false
+
+# Enable fd (modern find)
+shell_fd_enabled: false
+
+# Enable ripgrep (modern grep)
+shell_ripgrep_enabled: false
+
+# Enable tldr (simplified man pages)
+shell_tldr_enabled: false

--- a/roles/shell/handlers/main.yml
+++ b/roles/shell/handlers/main.yml
@@ -1,0 +1,5 @@
+---
+#
+# Shell Handlers
+#
+# No handlers needed

--- a/roles/shell/meta/main.yml
+++ b/roles/shell/meta/main.yml
@@ -1,0 +1,26 @@
+---
+galaxy_info:
+  author: Marc Straube
+  description: Install and configure shells (Zsh, Fish, Bash) and Starship prompt
+  license: MIT
+  min_ansible_version: '2.17'
+
+  platforms:
+    - name: ArchLinux
+      versions:
+        - all
+    - name: Debian
+      versions:
+        - trixie
+    - name: EL
+      versions:
+        - all
+
+  galaxy_tags:
+    - shell
+    - zsh
+    - fish
+    - starship
+    - desktop
+
+dependencies: []

--- a/roles/shell/molecule/default/converge.yml
+++ b/roles/shell/molecule/default/converge.yml
@@ -1,0 +1,77 @@
+---
+- name: Converge — Native framework
+  hosts: all
+  gather_facts: true
+
+  vars:
+    shell_enabled: true
+    shell_default: 'zsh'
+    shell_zsh_enabled: true
+    shell_zsh_framework: 'native'
+    shell_zsh_plugins:
+      - 'completions'
+    shell_fish_enabled: false
+    shell_bash_completion_enabled: true
+    shell_starship_enabled: "{{ ansible_facts['os_family'] == 'Archlinux' }}"
+    shell_fzf_enabled: true
+    shell_users: []
+
+  tasks:
+    - name: Converge | Include shell role (native)  # noqa: role-name[path]
+      ansible.builtin.include_role:
+        name: '{{ playbook_dir }}/../..'
+
+- name: Converge — Oh My Zsh framework
+  hosts: all
+  gather_facts: true
+
+  vars:
+    shell_enabled: true
+    shell_default: 'zsh'
+    shell_zsh_enabled: true
+    shell_zsh_framework: 'ohmyzsh'
+    shell_ohmyzsh_theme: 'robbyrussell'
+    shell_ohmyzsh_plugins:
+      - 'git'
+    shell_ohmyzsh_custom_plugins:
+      - name: 'zsh-autosuggestions'
+        repo: 'https://github.com/zsh-users/zsh-autosuggestions.git'
+    shell_starship_enabled: false
+    shell_zoxide_enabled: false
+    shell_fzf_enabled: false
+    shell_fish_enabled: false
+    shell_bash_completion_enabled: false
+    shell_users:
+      - 'testuser'
+    shell_user_config_mode: 'managed'
+
+  tasks:
+    - name: Converge | Include shell role (ohmyzsh)  # noqa: role-name[path]
+      ansible.builtin.include_role:
+        name: '{{ playbook_dir }}/../..'
+
+- name: Converge — Starship config (Arch only — starship not in Debian/EL repos)
+  hosts: all
+  gather_facts: true
+
+  vars:
+    shell_enabled: true
+    shell_default: 'bash'
+    shell_zsh_enabled: false
+    shell_fish_enabled: false
+    shell_bash_completion_enabled: false
+    shell_starship_enabled: true
+    shell_starship_config_enabled: true
+    shell_starship_preset: 'plain-text-symbols'
+    shell_starship_shells:
+      - 'bash'
+    shell_user_config_mode: 'managed'
+    shell_users:
+      - 'testuser'
+    shell_fzf_enabled: false
+
+  tasks:
+    - name: Converge | Include shell role (starship)  # noqa: role-name[path]
+      ansible.builtin.include_role:
+        name: '{{ playbook_dir }}/../..'
+      when: ansible_facts['os_family'] == 'Archlinux'

--- a/roles/shell/molecule/default/molecule.yml
+++ b/roles/shell/molecule/default/molecule.yml
@@ -1,0 +1,73 @@
+---
+driver:
+  name: podman
+platforms:
+  - name: shell-archlinux
+    image: docker.io/marcstraube/archlinux-ansible:latest
+    pre_build_image: true
+    command: /usr/lib/systemd/systemd
+    privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    tmpfs:
+      /run: rw,nosuid,nodev,size=65536k
+      /tmp: rw,nosuid,nodev
+  - name: shell-debian-trixie
+    image: docker.io/geerlingguy/docker-debian13-ansible:latest
+    pre_build_image: true
+    command: /usr/lib/systemd/systemd
+    privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    tmpfs:
+      /run: rw,nosuid,nodev,size=65536k
+      /tmp: rw,nosuid,nodev
+  - name: shell-rocky-9
+    image: docker.io/geerlingguy/docker-rockylinux9-ansible:latest
+    pre_build_image: true
+    command: /usr/lib/systemd/systemd
+    privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    tmpfs:
+      /run: rw,nosuid,nodev,size=65536k
+      /tmp: rw,nosuid,nodev
+  - name: shell-rocky-10
+    image: docker.io/geerlingguy/docker-rockylinux10-ansible:latest
+    pre_build_image: true
+    command: /usr/lib/systemd/systemd
+    privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    tmpfs:
+      /run: rw,nosuid,nodev,size=65536k
+      /tmp: rw,nosuid,nodev
+provisioner:
+  name: ansible
+  playbooks:
+    converge: converge.yml
+    prepare: prepare.yml
+    verify: verify.yml
+  config_options:
+    defaults:
+      allow_broken_conditionals: true
+  inventory:
+    host_vars:
+      shell-archlinux:
+        ansible_python_interpreter: /usr/bin/python
+      shell-debian-trixie:
+        ansible_python_interpreter: /usr/bin/python3
+      shell-rocky-9:
+        ansible_python_interpreter: /usr/bin/python3
+      shell-rocky-10:
+        ansible_python_interpreter: /usr/bin/python3
+verifier:
+  name: ansible
+scenario:
+  test_sequence:
+    - create
+    - prepare
+    - converge
+    - idempotence
+    - verify
+    - destroy

--- a/roles/shell/molecule/default/prepare.yml
+++ b/roles/shell/molecule/default/prepare.yml
@@ -1,0 +1,144 @@
+---
+- name: Prepare
+  hosts: all
+  gather_facts: true
+
+  vars:
+    __prepare_packages:
+      Debian:
+        - systemd
+        - systemd-timesyncd
+        - locales
+        - dbus
+      RedHat:
+        - glibc-langpack-en
+        - glibc-locale-source
+
+  tasks:
+    #
+    # Package Cache
+    #
+
+    - name: Prepare | Update package cache (Arch)
+      community.general.pacman:
+        update_cache: true
+        upgrade: true
+      when: ansible_facts['os_family'] == 'Archlinux'
+
+    - name: Prepare | Update package cache (Debian)
+      ansible.builtin.apt:
+        update_cache: true
+      when: ansible_facts['os_family'] == 'Debian'
+
+    - name: Prepare | Install EPEL release (RedHat)  # noqa: package-latest
+      ansible.builtin.package:
+        name: epel-release
+        state: latest
+      when: ansible_facts['os_family'] == 'RedHat'
+
+    - name: Prepare | Update package cache (RedHat)
+      ansible.builtin.dnf:
+        update_cache: true
+      when: ansible_facts['os_family'] == 'RedHat'
+
+    #
+    # Container Dependencies
+    #
+
+    - name: Prepare | Replace curl-minimal with curl (RedHat)
+      ansible.builtin.dnf:
+        name:
+          - curl
+        state: present
+        allowerasing: true
+      when: ansible_facts['os_family'] == 'RedHat'
+
+    # Sudo PAM bypass — required for tasks using `become_user` on
+    # geerlingguy Rocky containers under GitHub-hosted runners
+    # (test container only).
+
+    - name: Prepare | Bypass sudo PAM stack (RedHat container)
+      ansible.builtin.copy:
+        content: |
+          #%PAM-1.0
+          auth       sufficient   pam_permit.so
+          account    sufficient   pam_permit.so
+          password   sufficient   pam_permit.so
+          session    sufficient   pam_permit.so
+        dest: /etc/pam.d/sudo
+        owner: root
+        group: root
+        mode: '0644'
+      when: ansible_facts['os_family'] == 'RedHat'
+
+    - name: Prepare | Disable sudoers authentication (RedHat container)
+      ansible.builtin.copy:
+        content: 'Defaults !authenticate'
+        dest: /etc/sudoers.d/molecule-no-auth
+        owner: root
+        group: root
+        mode: '0440'
+        validate: 'visudo -cf %s'
+      when: ansible_facts['os_family'] == 'RedHat'
+
+    - name: Prepare | Install container dependencies
+      ansible.builtin.package:
+        name: '{{ __prepare_packages[ansible_facts["os_family"]] }}'
+        state: present
+      when: ansible_facts['os_family'] in __prepare_packages
+
+    - name: Prepare | Start D-Bus (RedHat)
+      ansible.builtin.systemd_service:
+        name: dbus-broker
+        state: started
+      when: ansible_facts['os_family'] == 'RedHat'
+
+    #
+    # AUR Builder (Arch)
+    #
+
+    - name: Prepare | Install base-devel and sudo (Arch)
+      community.general.pacman:
+        name:
+          - base-devel
+          - sudo
+        state: present
+      when: ansible_facts['os_family'] == 'Archlinux'
+
+    - name: Prepare | Create aur_builder user (Arch)
+      ansible.builtin.user:
+        name: aur_builder
+        group: wheel
+        create_home: true
+      when: ansible_facts['os_family'] == 'Archlinux'
+
+    - name: Prepare | Configure sudoers for aur_builder (Arch)
+      ansible.builtin.lineinfile:
+        path: /etc/sudoers.d/aur_builder
+        line: 'aur_builder ALL=(ALL) NOPASSWD: ALL'
+        create: true
+        mode: '0440'
+        validate: 'visudo -cf %s'
+      when: ansible_facts['os_family'] == 'Archlinux'
+
+    #
+    # Test Dependencies
+    #
+
+    - name: Prepare | Install git
+      ansible.builtin.package:
+        name: git
+        state: present
+
+    - name: Prepare | Create test user
+      ansible.builtin.user:
+        name: testuser
+        create_home: true
+        shell: /bin/bash
+        # Real sha512 password hash. Required so PAM account management
+        # accepts root → testuser become in containerised Rocky under
+        # GitHub-hosted runners (locked accounts and `*` placeholder
+        # both fail pam_unix account check with "Authentication service
+        # cannot retrieve authentication info").
+        password: "{{ 'molecule-testuser-noop' | password_hash('sha512') }}"
+        update_password: 'on_create'

--- a/roles/shell/molecule/default/verify.yml
+++ b/roles/shell/molecule/default/verify.yml
@@ -1,0 +1,179 @@
+---
+- name: Verify
+  hosts: all
+  gather_facts: true
+
+  tasks:
+    - name: Verify | Load OS-specific variables
+      ansible.builtin.include_vars: '{{ item }}'
+      with_first_found:
+        - files:
+            - '{{ ansible_facts["distribution"] }}-{{ ansible_facts["distribution_major_version"] }}.yml'
+            - '{{ ansible_facts["os_family"] }}-{{ ansible_facts["distribution_major_version"] }}.yml'
+            - '{{ ansible_facts["distribution"] }}.yml'
+            - '{{ ansible_facts["os_family"] }}.yml'
+          paths:
+            - '../../vars'
+
+    #
+    # Zsh
+    #
+
+    - name: Verify | Check zsh installed (Arch)
+      ansible.builtin.command:
+        cmd: 'pacman -Q {{ __shell_zsh_package }}'
+      register: _shell_zsh_arch
+      changed_when: false
+      failed_when: _shell_zsh_arch.rc != 0
+      when:
+        - ansible_facts['os_family'] == 'Archlinux'
+        - __shell_zsh_package | default('') | length > 0
+
+    - name: Verify | Check zsh installed (Debian)
+      ansible.builtin.command:
+        cmd: 'dpkg -l {{ __shell_zsh_package }}'
+      register: _shell_zsh_deb
+      changed_when: false
+      failed_when: _shell_zsh_deb.rc != 0
+      when:
+        - ansible_facts['os_family'] == 'Debian'
+        - __shell_zsh_package | default('') | length > 0
+
+    - name: Verify | Check zsh installed (RedHat)
+      ansible.builtin.command:  # noqa: command-instead-of-module
+        cmd: 'rpm -q {{ __shell_zsh_package }}'
+      register: _shell_zsh_rpm
+      changed_when: false
+      failed_when: _shell_zsh_rpm.rc != 0
+      when:
+        - ansible_facts['os_family'] == 'RedHat'
+        - __shell_zsh_package | default('') | length > 0
+
+    #
+    # Fzf
+    #
+
+    - name: Verify | Check fzf installed (Arch)
+      ansible.builtin.command:
+        cmd: 'pacman -Q {{ __shell_fzf_package }}'
+      register: _shell_fzf_arch
+      changed_when: false
+      failed_when: _shell_fzf_arch.rc != 0
+      when:
+        - ansible_facts['os_family'] == 'Archlinux'
+        - __shell_fzf_package | default('') | length > 0
+
+    - name: Verify | Check fzf installed (Debian)
+      ansible.builtin.command:
+        cmd: 'dpkg -l {{ __shell_fzf_package }}'
+      register: _shell_fzf_deb
+      changed_when: false
+      failed_when: _shell_fzf_deb.rc != 0
+      when:
+        - ansible_facts['os_family'] == 'Debian'
+        - __shell_fzf_package | default('') | length > 0
+
+    - name: Verify | Check fzf installed (RedHat)
+      ansible.builtin.command:  # noqa: command-instead-of-module
+        cmd: 'rpm -q {{ __shell_fzf_package }}'
+      register: _shell_fzf_rpm
+      changed_when: false
+      failed_when: _shell_fzf_rpm.rc != 0
+      when:
+        - ansible_facts['os_family'] == 'RedHat'
+        - __shell_fzf_package | default('') | length > 0
+
+    #
+    # Starship (Arch only)
+    #
+
+    - name: Verify | Check starship installed (Arch)
+      ansible.builtin.command:
+        cmd: 'pacman -Q {{ __shell_starship_package }}'
+      register: _shell_starship_arch
+      changed_when: false
+      failed_when: _shell_starship_arch.rc != 0
+      when:
+        - ansible_facts['os_family'] == 'Archlinux'
+        - __shell_starship_package | default('') | length > 0
+
+    #
+    # Oh My Zsh
+    #
+
+    - name: Verify | Check Oh My Zsh directory exists
+      ansible.builtin.stat:
+        path: '/home/testuser/.oh-my-zsh'
+      register: _shell_ohmyzsh_dir
+      failed_when: not _shell_ohmyzsh_dir.stat.exists
+
+    - name: Verify | Check Oh My Zsh oh-my-zsh.sh exists
+      ansible.builtin.stat:
+        path: '/home/testuser/.oh-my-zsh/oh-my-zsh.sh'
+      register: _shell_ohmyzsh_sh
+      failed_when: not _shell_ohmyzsh_sh.stat.exists
+
+    - name: Verify | Check custom plugin cloned
+      ansible.builtin.stat:
+        path: '/home/testuser/.oh-my-zsh/custom/plugins/zsh-autosuggestions'
+      register: _shell_ohmyzsh_custom_plugin
+      failed_when: not _shell_ohmyzsh_custom_plugin.stat.exists
+
+    - name: Verify | Check .zshrc deployed
+      ansible.builtin.stat:
+        path: '/home/testuser/.zshrc'
+      register: _shell_ohmyzsh_zshrc
+      failed_when: not _shell_ohmyzsh_zshrc.stat.exists
+
+    - name: Verify | Check .zshrc contains Oh My Zsh source
+      ansible.builtin.command:
+        cmd: 'grep -q "source.*oh-my-zsh.sh" /home/testuser/.zshrc'
+      register: _shell_ohmyzsh_source
+      changed_when: false
+      failed_when: _shell_ohmyzsh_source.rc != 0
+
+    - name: Verify | Check .zshrc contains theme
+      ansible.builtin.command:
+        cmd: 'grep -q "ZSH_THEME=\"robbyrussell\"" /home/testuser/.zshrc'
+      register: _shell_ohmyzsh_theme
+      changed_when: false
+      failed_when: _shell_ohmyzsh_theme.rc != 0
+
+    #
+    # Starship config (Arch only)
+    #
+
+    - name: Verify | Check starship.toml deployed (Arch)
+      ansible.builtin.stat:
+        path: '/home/testuser/.config/starship.toml'
+      register: _shell_starship_toml
+      failed_when: not _shell_starship_toml.stat.exists
+      when: ansible_facts['os_family'] == 'Archlinux'
+
+    - name: Verify | Check starship.toml contains plain-text-symbols content (Arch)
+      ansible.builtin.command:
+        cmd: 'grep -q "success_symbol" /home/testuser/.config/starship.toml'
+      register: _shell_starship_content
+      changed_when: false
+      failed_when: _shell_starship_content.rc != 0
+      when: ansible_facts['os_family'] == 'Archlinux'
+
+    #
+    # Starship init line in shell rc (Arch only — testuser has bash init via converge)
+    #
+
+    - name: Verify | Check starship init block in testuser .bashrc (Arch)
+      ansible.builtin.command:
+        cmd: 'grep -q "starship init bash" /home/testuser/.bashrc'
+      register: _shell_starship_bash_init
+      changed_when: false
+      failed_when: _shell_starship_bash_init.rc != 0
+      when: ansible_facts['os_family'] == 'Archlinux'
+
+    - name: Verify | Check starship init block has ansible-managed marker (Arch)
+      ansible.builtin.command:
+        cmd: 'grep -q "ANSIBLE MANAGED — starship init" /home/testuser/.bashrc'
+      register: _shell_starship_marker
+      changed_when: false
+      failed_when: _shell_starship_marker.rc != 0
+      when: ansible_facts['os_family'] == 'Archlinux'

--- a/roles/shell/tasks/install.yml
+++ b/roles/shell/tasks/install.yml
@@ -1,0 +1,38 @@
+---
+#
+# Shell Installation
+#
+
+- name: Install | Build package list
+  ansible.builtin.set_fact:
+    __shell_install_packages: >-
+      {{
+        (shell_zsh_enabled | bool | ternary([__shell_zsh_package], [])) +
+        ((shell_zsh_enabled | bool and shell_zsh_framework == 'native') | ternary(
+          shell_zsh_plugins | map('extract', __shell_zsh_plugin_packages) | select('string') | list, [])) +
+        ((shell_zsh_grml_enabled | bool and shell_zsh_framework == 'native' and __shell_zsh_grml_package | length > 0)
+          | ternary([__shell_zsh_grml_package], [])) +
+        (shell_fish_enabled | bool | ternary([__shell_fish_package], [])) +
+        (shell_bash_completion_enabled | bool | ternary([__shell_bash_completion_package], [])) +
+        (shell_starship_enabled | bool | ternary([__shell_starship_package], [])) +
+        (shell_fzf_enabled | bool | ternary([__shell_fzf_package], [])) +
+        (shell_zoxide_enabled | bool | ternary([__shell_zoxide_package], [])) +
+        (shell_eza_enabled | bool | ternary([__shell_eza_package], [])) +
+        (shell_bat_enabled | bool | ternary([__shell_bat_package], [])) +
+        (shell_fd_enabled | bool | ternary([__shell_fd_package], [])) +
+        (shell_ripgrep_enabled | bool | ternary([__shell_ripgrep_package], [])) +
+        (shell_tldr_enabled | bool | ternary([__shell_tldr_package], []))
+      }}
+
+- name: Install | Filter empty packages
+  ansible.builtin.set_fact:
+    __shell_install_packages: >-
+      {{ __shell_install_packages | select('string') | reject('equalto', '') | unique | list }}
+
+- name: Install | Shell packages
+  ansible.builtin.package:
+    name: '{{ __shell_install_packages }}'
+    state: present
+  when: __shell_install_packages | length > 0
+  retries: 3
+  delay: 5

--- a/roles/shell/tasks/main.yml
+++ b/roles/shell/tasks/main.yml
@@ -1,0 +1,79 @@
+---
+#
+# Shell Main Tasks
+#
+
+- name: Main | Load OS-specific variables
+  ansible.builtin.include_vars: '{{ item }}'
+  with_first_found:
+    - files:
+        - '{{ ansible_facts["distribution"] }}-{{ ansible_facts["distribution_major_version"] }}.yml'
+        - '{{ ansible_facts["os_family"] }}-{{ ansible_facts["distribution_major_version"] }}.yml'
+        - '{{ ansible_facts["distribution"] }}.yml'
+        - '{{ ansible_facts["os_family"] }}.yml'
+      paths:
+        - 'vars'
+  tags:
+    - shell
+    - shell:vars
+
+- name: Main | Validate Starship preset
+  ansible.builtin.assert:
+    that:
+      - shell_starship_preset | length == 0
+        or shell_starship_preset in __shell_starship_valid_presets
+    fail_msg: >-
+      shell_starship_preset must be empty or one of
+      {{ __shell_starship_valid_presets }}, got: '{{ shell_starship_preset }}'
+  when:
+    - shell_enabled | bool
+    - shell_starship_enabled | bool
+    - shell_starship_config_enabled | bool
+  tags:
+    - shell
+
+- name: Main | Import install tasks
+  ansible.builtin.import_tasks: install.yml
+  when: shell_enabled | bool
+  tags:
+    - shell
+    - shell:install
+
+- name: Main | Import Oh My Zsh tasks
+  ansible.builtin.import_tasks: ohmyzsh.yml
+  when:
+    - shell_enabled | bool
+    - shell_zsh_enabled | bool
+    - shell_zsh_framework == 'ohmyzsh'
+  tags:
+    - shell
+    - shell:ohmyzsh
+
+- name: Main | Import user tasks
+  ansible.builtin.import_tasks: users.yml
+  when:
+    - shell_enabled | bool
+    - shell_default != 'bash'
+  tags:
+    - shell
+    - shell:users
+
+- name: Main | Import Starship config tasks
+  ansible.builtin.import_tasks: starship.yml
+  when:
+    - shell_enabled | bool
+    - shell_starship_enabled | bool
+    - shell_starship_config_enabled | bool
+  tags:
+    - shell
+    - shell:starship
+
+- name: Main | Import Starship shell init tasks
+  ansible.builtin.import_tasks: starship_init.yml
+  when:
+    - shell_enabled | bool
+    - shell_starship_enabled | bool
+    - shell_starship_shells | length > 0
+  tags:
+    - shell
+    - shell:starship

--- a/roles/shell/tasks/ohmyzsh.yml
+++ b/roles/shell/tasks/ohmyzsh.yml
@@ -1,0 +1,53 @@
+---
+#
+# Oh My Zsh Installation and Configuration
+#
+
+- name: OhMyZsh | Get users to configure
+  ansible.builtin.set_fact:
+    __shell_ohmyzsh_users: >-
+      {{ shell_users if shell_users | length > 0
+         else (users_list | default([]) | map(attribute='name') | list) }}
+
+- name: OhMyZsh | Clone Oh My Zsh
+  ansible.builtin.git:
+    repo: 'https://github.com/ohmyzsh/ohmyzsh.git'
+    dest: '/home/{{ item }}/.oh-my-zsh'
+    depth: 1
+    version: 'master'
+    update: "{{ shell_user_config_mode == 'managed' }}"
+  become: true
+  become_user: '{{ item }}'
+  loop: '{{ __shell_ohmyzsh_users }}'
+  when: shell_user_config_mode != 'disabled'
+  retries: 5
+  delay: 10
+
+- name: OhMyZsh | Clone custom plugins  # noqa: latest[git]
+  ansible.builtin.git:
+    repo: '{{ item.1.repo }}'
+    dest: '/home/{{ item.0 }}/.oh-my-zsh/custom/plugins/{{ item.1.name }}'
+    depth: 1
+    version: '{{ item.1.version | default("master") }}'
+    update: "{{ shell_user_config_mode == 'managed' }}"
+  become: true
+  become_user: '{{ item.0 }}'
+  loop: '{{ __shell_ohmyzsh_users | product(shell_ohmyzsh_custom_plugins) | list }}'
+  loop_control:
+    label: '{{ item.0 }}: {{ item.1.name }}'
+  when:
+    - shell_user_config_mode != 'disabled'
+    - shell_ohmyzsh_custom_plugins | length > 0
+  retries: 5
+  delay: 10
+
+- name: OhMyZsh | Deploy .zshrc
+  ansible.builtin.template:
+    src: 'ohmyzsh.zshrc.j2'
+    dest: '/home/{{ item }}/.zshrc'
+    owner: '{{ item }}'
+    group: '{{ item }}'
+    mode: '0644'
+    force: "{{ shell_user_config_mode == 'managed' }}"
+  loop: '{{ __shell_ohmyzsh_users }}'
+  when: shell_user_config_mode != 'disabled'

--- a/roles/shell/tasks/starship.yml
+++ b/roles/shell/tasks/starship.yml
@@ -1,0 +1,55 @@
+---
+#
+# Starship Per-User Configuration
+#
+
+- name: Starship | Get users to configure
+  ansible.builtin.set_fact:
+    __shell_starship_users: >-
+      {{ shell_users if shell_users | length > 0
+         else (users_list | default([]) | map(attribute='name') | list) }}
+
+- name: Starship | Ensure ~/.config exists
+  ansible.builtin.file:
+    path: '/home/{{ item }}/.config'
+    state: directory
+    owner: '{{ item }}'
+    group: '{{ item }}'
+    mode: '0755'
+  loop: '{{ __shell_starship_users }}'
+  when: shell_user_config_mode != 'disabled'
+
+- name: Starship | Render preset content
+  ansible.builtin.command:
+    cmd: 'starship preset {{ shell_starship_preset }}'
+  register: __shell_starship_preset_content
+  changed_when: false
+  when:
+    - shell_user_config_mode != 'disabled'
+    - shell_starship_preset | length > 0
+
+- name: Starship | Deploy preset config
+  ansible.builtin.copy:
+    content: "{{ __shell_starship_preset_content.stdout }}\n"
+    dest: '/home/{{ item }}/.config/starship.toml'
+    owner: '{{ item }}'
+    group: '{{ item }}'
+    mode: '0644'
+    force: "{{ shell_user_config_mode == 'managed' }}"
+  loop: '{{ __shell_starship_users }}'
+  when:
+    - shell_user_config_mode != 'disabled'
+    - shell_starship_preset | length > 0
+
+- name: Starship | Deploy minimal default config (no preset)
+  ansible.builtin.template:
+    src: 'starship.toml.j2'
+    dest: '/home/{{ item }}/.config/starship.toml'
+    owner: '{{ item }}'
+    group: '{{ item }}'
+    mode: '0644'
+    force: "{{ shell_user_config_mode == 'managed' }}"
+  loop: '{{ __shell_starship_users }}'
+  when:
+    - shell_user_config_mode != 'disabled'
+    - shell_starship_preset | length == 0

--- a/roles/shell/tasks/starship_init.yml
+++ b/roles/shell/tasks/starship_init.yml
@@ -1,0 +1,138 @@
+---
+#
+# Starship Shell Initialization
+#
+# Adds `eval "$(starship init <shell>)"` (or fish equivalent) to the
+# per-user shell rc file via blockinfile. Independent from the config
+# deployment in starship.yml — a user can opt into starship init
+# without a custom config (using starship defaults).
+#
+# Honours `shell_user_config_mode`:
+#   managed  — reconcile the marker block on every run
+#   initial  — deploy on first run; if the marker is already present
+#              for the user, leave the file alone (preserve any
+#              modifications inside the marker block)
+#   disabled — skip
+#
+# zsh handling: when `shell_zsh_framework == 'ohmyzsh'`, the
+# ohmyzsh.zshrc.j2 template already includes the starship init line.
+# Skip the zsh init task in that case to avoid duplication.
+#
+
+- name: StarshipInit | Get users to configure
+  ansible.builtin.set_fact:
+    __shell_starship_init_users: >-
+      {{ shell_users if shell_users | length > 0
+         else (users_list | default([]) | map(attribute='name') | list) }}
+
+#
+# bash
+#
+
+- name: StarshipInit | Check existing bash starship init per user
+  ansible.builtin.shell:
+    cmd: 'test -f /home/{{ item }}/.bashrc && grep -q "starship init bash" /home/{{ item }}/.bashrc'
+  loop: '{{ __shell_starship_init_users }}'
+  register: __shell_starship_init_bash_check
+  changed_when: false
+  failed_when: false
+  when:
+    - "'bash' in shell_starship_shells"
+    - shell_user_config_mode != 'disabled'
+
+- name: StarshipInit | Add bash init line
+  ansible.builtin.blockinfile:
+    path: '/home/{{ item.0 }}/.bashrc'
+    block: 'eval "$(starship init bash)"'
+    marker: '# {mark} ANSIBLE MANAGED — starship init'
+    create: true
+    owner: '{{ item.0 }}'
+    group: '{{ item.0 }}'
+    mode: '0644'
+  loop: '{{ __shell_starship_init_users | zip(__shell_starship_init_bash_check.results | default([])) | list }}'
+  loop_control:
+    label: '{{ item.0 }}'
+  when:
+    - "'bash' in shell_starship_shells"
+    - shell_user_config_mode != 'disabled'
+    - shell_user_config_mode == 'managed' or (item.1.rc | default(1)) != 0
+
+#
+# zsh
+#
+
+- name: StarshipInit | Check existing zsh starship init per user
+  ansible.builtin.shell:
+    cmd: 'test -f /home/{{ item }}/.zshrc && grep -q "starship init zsh" /home/{{ item }}/.zshrc'
+  loop: '{{ __shell_starship_init_users }}'
+  register: __shell_starship_init_zsh_check
+  changed_when: false
+  failed_when: false
+  when:
+    - "'zsh' in shell_starship_shells"
+    - shell_zsh_framework != 'ohmyzsh'
+    - shell_user_config_mode != 'disabled'
+
+- name: StarshipInit | Add zsh init line
+  ansible.builtin.blockinfile:
+    path: '/home/{{ item.0 }}/.zshrc'
+    block: 'eval "$(starship init zsh)"'
+    marker: '# {mark} ANSIBLE MANAGED — starship init'
+    create: true
+    owner: '{{ item.0 }}'
+    group: '{{ item.0 }}'
+    mode: '0644'
+  loop: '{{ __shell_starship_init_users | zip(__shell_starship_init_zsh_check.results | default([])) | list }}'
+  loop_control:
+    label: '{{ item.0 }}'
+  when:
+    - "'zsh' in shell_starship_shells"
+    - shell_zsh_framework != 'ohmyzsh'
+    - shell_user_config_mode != 'disabled'
+    - shell_user_config_mode == 'managed' or (item.1.rc | default(1)) != 0
+
+#
+# fish
+#
+
+- name: StarshipInit | Ensure fish config directory exists
+  ansible.builtin.file:
+    path: '/home/{{ item }}/.config/fish'
+    state: directory
+    owner: '{{ item }}'
+    group: '{{ item }}'
+    mode: '0755'
+  loop: '{{ __shell_starship_init_users }}'
+  when:
+    - "'fish' in shell_starship_shells"
+    - shell_user_config_mode != 'disabled'
+
+- name: StarshipInit | Check existing fish starship init per user
+  ansible.builtin.shell:
+    cmd: >-
+      test -f /home/{{ item }}/.config/fish/config.fish &&
+      grep -q "starship init fish" /home/{{ item }}/.config/fish/config.fish
+  loop: '{{ __shell_starship_init_users }}'
+  register: __shell_starship_init_fish_check
+  changed_when: false
+  failed_when: false
+  when:
+    - "'fish' in shell_starship_shells"
+    - shell_user_config_mode != 'disabled'
+
+- name: StarshipInit | Add fish init line
+  ansible.builtin.blockinfile:
+    path: '/home/{{ item.0 }}/.config/fish/config.fish'
+    block: 'starship init fish | source'
+    marker: '# {mark} ANSIBLE MANAGED — starship init'
+    create: true
+    owner: '{{ item.0 }}'
+    group: '{{ item.0 }}'
+    mode: '0644'
+  loop: '{{ __shell_starship_init_users | zip(__shell_starship_init_fish_check.results | default([])) | list }}'
+  loop_control:
+    label: '{{ item.0 }}'
+  when:
+    - "'fish' in shell_starship_shells"
+    - shell_user_config_mode != 'disabled'
+    - shell_user_config_mode == 'managed' or (item.1.rc | default(1)) != 0

--- a/roles/shell/tasks/users.yml
+++ b/roles/shell/tasks/users.yml
@@ -1,0 +1,19 @@
+---
+#
+# Shell User Configuration
+#
+
+- name: Users | Get users to configure
+  ansible.builtin.set_fact:
+    __shell_configure_users: >-
+      {{ shell_users if shell_users | length > 0
+         else (users_list | default([]) | map(attribute='name') | list) }}
+
+- name: Users | Change default shell for users
+  ansible.builtin.user:
+    name: '{{ item }}'
+    shell: '{{ __shell_paths[shell_default] }}'
+  loop: '{{ __shell_configure_users }}'
+  when:
+    - __shell_configure_users | length > 0
+    - shell_user_config_mode != 'disabled'

--- a/roles/shell/templates/ohmyzsh.zshrc.j2
+++ b/roles/shell/templates/ohmyzsh.zshrc.j2
@@ -1,0 +1,43 @@
+{{ ansible_managed | comment }}
+#
+# Oh My Zsh Configuration
+#
+
+# Path to Oh My Zsh installation
+export ZSH="$HOME/.oh-my-zsh"
+
+# Theme
+{% if shell_starship_enabled | default(false) | bool %}
+# Disabled — Starship handles the prompt
+ZSH_THEME=""
+{% else %}
+ZSH_THEME="{{ shell_ohmyzsh_theme }}"
+{% endif %}
+
+# Plugins
+plugins=(
+{% for plugin in shell_ohmyzsh_plugins %}
+  {{ plugin }}
+{% endfor %}
+{% for plugin in shell_ohmyzsh_custom_plugins %}
+  {{ plugin.name }}
+{% endfor %}
+)
+
+# Load Oh My Zsh
+source "$ZSH/oh-my-zsh.sh"
+
+#
+# Tool Initialization
+#
+
+{% if shell_starship_enabled | default(false) | bool %}
+# Starship prompt
+eval "$(starship init zsh)"
+
+{% endif %}
+{% if shell_zoxide_enabled | default(false) | bool %}
+# Zoxide (smarter cd)
+eval "$(zoxide init zsh)"
+
+{% endif %}

--- a/roles/shell/templates/starship.toml.j2
+++ b/roles/shell/templates/starship.toml.j2
@@ -1,0 +1,3 @@
+# {{ ansible_managed }}
+# Starship config — minimal default (no preset selected).
+# See https://starship.rs/config/ for available options.

--- a/roles/shell/vars/Archlinux.yml
+++ b/roles/shell/vars/Archlinux.yml
@@ -1,0 +1,25 @@
+---
+#
+# Arch Linux Variables
+#
+
+# Zsh plugins
+__shell_zsh_plugin_packages:
+  completions: 'zsh-completions'
+  autosuggestions: 'zsh-autosuggestions'
+  syntax-highlighting: 'zsh-syntax-highlighting'
+  history-substring-search: 'zsh-history-substring-search'
+
+__shell_zsh_grml_package: 'grml-zsh-config'
+
+# Starship
+__shell_starship_package: 'starship'
+
+# Additional tools
+__shell_fzf_package: 'fzf'
+__shell_zoxide_package: 'zoxide'
+__shell_eza_package: 'eza'
+__shell_bat_package: 'bat'
+__shell_fd_package: 'fd'
+__shell_ripgrep_package: 'ripgrep'
+__shell_tldr_package: 'tldr'

--- a/roles/shell/vars/Debian.yml
+++ b/roles/shell/vars/Debian.yml
@@ -1,0 +1,25 @@
+---
+#
+# Debian Variables
+#
+
+# Zsh plugins
+__shell_zsh_plugin_packages:
+  completions: ''
+  autosuggestions: 'zsh-autosuggestions'
+  syntax-highlighting: 'zsh-syntax-highlighting'
+  history-substring-search: ''
+
+__shell_zsh_grml_package: ''
+
+# Starship
+__shell_starship_package: ''
+
+# Additional tools
+__shell_fzf_package: 'fzf'
+__shell_zoxide_package: 'zoxide'
+__shell_eza_package: ''
+__shell_bat_package: 'bat'
+__shell_fd_package: 'fd-find'
+__shell_ripgrep_package: 'ripgrep'
+__shell_tldr_package: 'tldr'

--- a/roles/shell/vars/RedHat.yml
+++ b/roles/shell/vars/RedHat.yml
@@ -1,0 +1,25 @@
+---
+#
+# RedHat Variables
+#
+
+# Zsh plugins
+__shell_zsh_plugin_packages:
+  completions: ''
+  autosuggestions: 'zsh-autosuggestions'
+  syntax-highlighting: 'zsh-syntax-highlighting'
+  history-substring-search: ''
+
+__shell_zsh_grml_package: ''
+
+# Starship
+__shell_starship_package: ''
+
+# Additional tools
+__shell_fzf_package: 'fzf'
+__shell_zoxide_package: 'zoxide'
+__shell_eza_package: 'eza'
+__shell_bat_package: 'bat'
+__shell_fd_package: 'fd-find'
+__shell_ripgrep_package: 'ripgrep'
+__shell_tldr_package: 'tldr'

--- a/roles/shell/vars/main.yml
+++ b/roles/shell/vars/main.yml
@@ -1,0 +1,30 @@
+---
+#
+# OS-independent Variables
+#
+
+# Shell packages
+__shell_zsh_package: 'zsh'
+__shell_fish_package: 'fish'
+__shell_bash_completion_package: 'bash-completion'
+
+# Shell paths
+__shell_paths:
+  zsh: '/usr/bin/zsh'
+  fish: '/usr/bin/fish'
+  bash: '/bin/bash'
+
+# Valid Starship presets (source: `starship preset --list`)
+__shell_starship_valid_presets:
+  - 'bracketed-segments'
+  - 'catppuccin-powerline'
+  - 'gruvbox-rainbow'
+  - 'jetpack'
+  - 'nerd-font-symbols'
+  - 'no-empty-icons'
+  - 'no-nerd-font'
+  - 'no-runtime-versions'
+  - 'pastel-powerline'
+  - 'plain-text-symbols'
+  - 'pure-preset'
+  - 'tokyo-night'


### PR DESCRIPTION
## Summary

- Adds `roles/shell/` to `marcstraube.common`, verbatim copy from `marcstraube.desktop` (zsh, bash, fish, Oh My Zsh, Starship prompt).
- Updates two references in the role's own `README.md` from `marcstraube.desktop.shell` to `marcstraube.common.shell`.
- Adds the role to the common `README.md` role table; bumps the role count from 41 to 42.
- Whitelists two new `Secret Keyword` false positives in `.secrets.baseline` (existing pattern in the role's molecule prepare.yml: NOPASSWD sudoers line + ansible `update_password` parameter name).

## Breaking Change

The role's FQCN moves from `marcstraube.desktop.shell` to `marcstraube.common.shell`. Inventories that include the role must update their FQCN references. Covered by the v2.0.0 major bump in both collections.

## Test plan

- [x] `pre-commit run --all-files` — passed (ansible-lint production profile, yamllint, markdownlint, secrets baseline updated)
- [x] `molecule test -p shell-archlinux` — full sequence green: create, prepare, converge, idempotence, verify, destroy
- [x] No functional changes vs the desktop counterpart (verbatim copy)
- [ ] Counterpart removal in desktop (#115) — follow-up PR after this merges

Closes #132