### PR TITLE
fix(base-system): include shell role in base_system.yml playbook

### DIFF
--- a/playbooks/tasks/base_system.yml
+++ b/playbooks/tasks/base_system.yml
@@ -337,6 +337,18 @@
     - multiplexer
   when: multiplexer_enabled | default(true) | bool
 
+- name: Base System | Include shell role
+  ansible.builtin.include_role:
+    name: marcstraube.common.shell
+    apply:
+      tags:
+        - base-system
+        - shell
+  tags:
+    - base-system
+    - shell
+  when: shell_enabled | default(true) | bool
+
 - name: Base System | Include fonts role
   ansible.builtin.include_role:
     name: marcstraube.common.fonts


### PR DESCRIPTION
## Summary

Follow-up to #132. The shell role migration added the role to common but missed wiring it into the `base_system.yml` task file alongside `multiplexer`. Without this include, the role exists on disk but is never deployed by `playbooks/base.yml`, which is the canonical CLI tooling entry point for all hosts (workstations and servers).

The new include sits directly after `Base System | Include multiplexer role` — both are CLI tooling that applies equally to every host type.

## Test plan

- [x] `pre-commit run` — passed (ansible-lint production profile, yamllint, syntax)
- [x] Diff inspection: 12 lines added, mirrors multiplexer include structure exactly
- [ ] Live `ansible-playbook playbooks/base.yml --tags shell --check --diff` — to be run after merge, expects shell role to deploy

References #132