### PR TITLE
fix(podman): skip docker socket symlink when real Docker is installed

### DIFF
--- a/roles/podman/tasks/configure.yml
+++ b/roles/podman/tasks/configure.yml
@@ -38,13 +38,27 @@
     state: absent
   when: not (podman_docker_alias_enabled | bool)
 
+# Re-check the docker binary here so the symlink guard also works when
+# install.yml was skipped via --tags podman:configure.
+- name: Configure | Check if real Docker binary exists
+  ansible.builtin.stat:
+    path: /usr/bin/docker
+  register: __podman_docker_bin
+
 - name: Configure | Create docker socket symlink
   ansible.builtin.file:
     src: '/run/podman/podman.sock'
     dest: '/run/docker.sock'
     state: link
     force: true
-  when: podman_docker_socket_symlink_enabled | bool
+  when:
+    - podman_docker_socket_symlink_enabled | bool
+    # Skip when the docker role is enabled — its daemon owns /run/docker.sock.
+    - not (docker_enabled | default(false) | bool)
+    # Skip when real Docker binary exists (regular file, not the podman-docker shim,
+    # which is a symlink to /usr/bin/podman). Mirrors the guard in install.yml for
+    # the podman-docker package.
+    - not (__podman_docker_bin.stat.exists and not __podman_docker_bin.stat.islnk)
   # Socket may not exist yet before podman.socket is started
   failed_when: false
 


### PR DESCRIPTION
## Summary

Applies the same 3-guard pattern that #77 already established for the `podman-docker` package install (`install.yml:36-39`) to the `Configure | Create docker socket symlink` task in `configure.yml`. On hosts with both Podman and the real Docker daemon, the symlink task previously tried to replace dockerd's owned `/run/docker.sock` on every run.

## Guard rationale

1. `podman_docker_socket_symlink_enabled` — existing feature toggle
2. `not (docker_enabled | default(false) | bool)` — loose coupling to the docker role's enable flag, so inventories that intentionally enable Docker are respected
3. `not (stat.exists and not stat.islnk)` — real-binary check: the `podman-docker` AUR shim installs `/usr/bin/docker` as a *symlink* to `/usr/bin/podman`; real Docker installs it as a regular *file*. The `islnk` distinction prevents a false positive on shim-only hosts.

The required `__podman_docker_bin` stat is registered in `install.yml`, but `install.yml` is skipped under `--tags podman:configure`. To make the guard self-sufficient, a sibling stat task is added at the top of `configure.yml`.

## Test plan

- [x] `pre-commit run` on the changed file — passed (ansible-lint, yamllint, syntax)
- [x] `molecule test -p podman-archlinux` — full sequence green: create, prepare, converge, idempotence, verify, destroy
- [x] Guard logic mirrors the existing install.yml package guard one-to-one
- [ ] Live verification on a host with both Docker and Podman: previously `--check --diff` reported `state: file → state: link` as changed every run; after fix should report no change

Closes #130