### PR TITLE
fix(shell): source zoxide init in user rc files

### DIFF
--- a/roles/shell/README.md
+++ b/roles/shell/README.md
@@ -158,6 +158,10 @@ the marker block on every run; `'initial'` deploys the block on
 first run and leaves the file alone if the marker is already present
 (preserving any user modifications inside it); `'disabled'` skips.
 
+On platforms where `zoxide` is not packaged (currently EL 10 — not in
+EPEL 10), `shell_zoxide_enabled` is a silent no-op: neither the
+package nor the init line is deployed.
+
 ## Tags
 
 | Tag               | Description                    |

--- a/roles/shell/README.md
+++ b/roles/shell/README.md
@@ -126,15 +126,37 @@ first run and leaves the file alone if the marker is already present
 
 ### Additional Tools
 
-| Variable                 | Default | Description                               |
-|--------------------------|---------|-------------------------------------------|
-| `shell_fzf_enabled`      | `true`  | Enable fzf (fuzzy finder)                 |
-| `shell_zoxide_enabled`   | `false` | Enable zoxide (smarter cd)                |
-| `shell_eza_enabled`      | `false` | Enable eza (modern ls)                    |
-| `shell_bat_enabled`      | `false` | Enable bat (cat with syntax highlighting) |
-| `shell_fd_enabled`       | `false` | Enable fd (modern find)                   |
-| `shell_ripgrep_enabled`  | `false` | Enable ripgrep (modern grep)              |
-| `shell_tldr_enabled`     | `false` | Enable tldr (simplified man pages)        |
+| Variable                 | Default           | Description                                  |
+|--------------------------|-------------------|----------------------------------------------|
+| `shell_fzf_enabled`      | `true`            | Enable fzf (fuzzy finder)                    |
+| `shell_zoxide_enabled`   | `false`           | Enable zoxide (smarter cd)                   |
+| `shell_zoxide_shells`    | `['zsh', 'bash']` | Configure zoxide init for these shells       |
+| `shell_eza_enabled`      | `false`           | Enable eza (modern ls)                       |
+| `shell_bat_enabled`      | `false`           | Enable bat (cat with syntax highlighting)    |
+| `shell_fd_enabled`       | `false`           | Enable fd (modern find)                      |
+| `shell_ripgrep_enabled`  | `false`           | Enable ripgrep (modern grep)                 |
+| `shell_tldr_enabled`     | `false`           | Enable tldr (simplified man pages)           |
+
+`shell_zoxide_shells` controls which shell rcfiles get a zoxide init
+line appended via `blockinfile` (with marker
+`# ANSIBLE MANAGED — zoxide init`). Without an init line, the
+`zoxide` package is installed but unusable — `eval "$(zoxide init <shell>)"`
+must be sourced for the `z` command to work.
+
+| Shell  | Target file                  | Init line                          |
+|--------|------------------------------|------------------------------------|
+| `bash` | `~/.bashrc`                  | `eval "$(zoxide init bash)"`       |
+| `zsh`  | `~/.zshrc`                   | `eval "$(zoxide init zsh)"`        |
+| `fish` | `~/.config/fish/config.fish` | `zoxide init fish \| source`       |
+
+The zsh init line is skipped when `shell_zsh_framework: 'ohmyzsh'` —
+the Oh My Zsh `.zshrc` template already includes zoxide init when
+`shell_zoxide_enabled` is true, so adding it again would duplicate.
+
+Init lines honour `shell_user_config_mode`: `'managed'` reconciles
+the marker block on every run; `'initial'` deploys the block on
+first run and leaves the file alone if the marker is already present
+(preserving any user modifications inside it); `'disabled'` skips.
 
 ## Tags
 
@@ -145,6 +167,7 @@ first run and leaves the file alone if the marker is already present
 | `shell:ohmyzsh`   | Oh My Zsh setup and config     |
 | `shell:users`     | User shell configuration       |
 | `shell:starship`  | Starship per-user config       |
+| `shell:zoxide`    | Zoxide per-user init           |
 
 ## Example Playbook
 

--- a/roles/shell/defaults/main.yml
+++ b/roles/shell/defaults/main.yml
@@ -110,6 +110,11 @@ shell_fzf_enabled: true
 # Enable zoxide (smarter cd)
 shell_zoxide_enabled: false
 
+# Configure zoxide for shells (adds init to shell config)
+shell_zoxide_shells:
+  - 'zsh'
+  - 'bash'
+
 # Enable eza (modern ls)
 shell_eza_enabled: false
 

--- a/roles/shell/molecule/default/converge.yml
+++ b/roles/shell/molecule/default/converge.yml
@@ -75,3 +75,27 @@
       ansible.builtin.include_role:
         name: '{{ playbook_dir }}/../..'
       when: ansible_facts['os_family'] == 'Archlinux'
+
+- name: Converge — Zoxide init (all distros — zoxide ships in every repo)
+  hosts: all
+  gather_facts: true
+
+  vars:
+    shell_enabled: true
+    shell_default: 'bash'
+    shell_zsh_enabled: false
+    shell_fish_enabled: false
+    shell_bash_completion_enabled: false
+    shell_starship_enabled: false
+    shell_zoxide_enabled: true
+    shell_zoxide_shells:
+      - 'bash'
+    shell_user_config_mode: 'managed'
+    shell_users:
+      - 'testuser'
+    shell_fzf_enabled: false
+
+  tasks:
+    - name: Converge | Include shell role (zoxide)  # noqa: role-name[path]
+      ansible.builtin.include_role:
+        name: '{{ playbook_dir }}/../..'

--- a/roles/shell/molecule/default/verify.yml
+++ b/roles/shell/molecule/default/verify.yml
@@ -177,3 +177,55 @@
       changed_when: false
       failed_when: _shell_starship_marker.rc != 0
       when: ansible_facts['os_family'] == 'Archlinux'
+
+    #
+    # Zoxide (all distros)
+    #
+
+    - name: Verify | Check zoxide installed (Arch)
+      ansible.builtin.command:
+        cmd: 'pacman -Q {{ __shell_zoxide_package }}'
+      register: _shell_zoxide_arch
+      changed_when: false
+      failed_when: _shell_zoxide_arch.rc != 0
+      when:
+        - ansible_facts['os_family'] == 'Archlinux'
+        - __shell_zoxide_package | default('') | length > 0
+
+    - name: Verify | Check zoxide installed (Debian)
+      ansible.builtin.command:
+        cmd: 'dpkg -l {{ __shell_zoxide_package }}'
+      register: _shell_zoxide_deb
+      changed_when: false
+      failed_when: _shell_zoxide_deb.rc != 0
+      when:
+        - ansible_facts['os_family'] == 'Debian'
+        - __shell_zoxide_package | default('') | length > 0
+
+    - name: Verify | Check zoxide installed (RedHat)
+      ansible.builtin.command:  # noqa: command-instead-of-module
+        cmd: 'rpm -q {{ __shell_zoxide_package }}'
+      register: _shell_zoxide_rpm
+      changed_when: false
+      failed_when: _shell_zoxide_rpm.rc != 0
+      when:
+        - ansible_facts['os_family'] == 'RedHat'
+        - __shell_zoxide_package | default('') | length > 0
+
+    #
+    # Zoxide init line in shell rc (all distros — testuser has bash init via converge)
+    #
+
+    - name: Verify | Check zoxide init block in testuser .bashrc
+      ansible.builtin.command:
+        cmd: 'grep -q "zoxide init bash" /home/testuser/.bashrc'
+      register: _shell_zoxide_bash_init
+      changed_when: false
+      failed_when: _shell_zoxide_bash_init.rc != 0
+
+    - name: Verify | Check zoxide init block has ansible-managed marker
+      ansible.builtin.command:
+        cmd: 'grep -q "ANSIBLE MANAGED — zoxide init" /home/testuser/.bashrc'
+      register: _shell_zoxide_marker
+      changed_when: false
+      failed_when: _shell_zoxide_marker.rc != 0

--- a/roles/shell/molecule/default/verify.yml
+++ b/roles/shell/molecule/default/verify.yml
@@ -213,7 +213,7 @@
         - __shell_zoxide_package | default('') | length > 0
 
     #
-    # Zoxide init line in shell rc (all distros — testuser has bash init via converge)
+    # Zoxide init line in shell rc (skipped when zoxide unavailable, e.g. EL 10)
     #
 
     - name: Verify | Check zoxide init block in testuser .bashrc
@@ -222,6 +222,7 @@
       register: _shell_zoxide_bash_init
       changed_when: false
       failed_when: _shell_zoxide_bash_init.rc != 0
+      when: __shell_zoxide_package | default('') | length > 0
 
     - name: Verify | Check zoxide init block has ansible-managed marker
       ansible.builtin.command:
@@ -229,3 +230,12 @@
       register: _shell_zoxide_marker
       changed_when: false
       failed_when: _shell_zoxide_marker.rc != 0
+      when: __shell_zoxide_package | default('') | length > 0
+
+    - name: Verify | Check zoxide init block absent when package unavailable
+      ansible.builtin.command:
+        cmd: 'grep -q "ANSIBLE MANAGED — zoxide init" /home/testuser/.bashrc'
+      register: _shell_zoxide_absent
+      changed_when: false
+      failed_when: _shell_zoxide_absent.rc == 0
+      when: __shell_zoxide_package | default('') | length == 0

--- a/roles/shell/tasks/main.yml
+++ b/roles/shell/tasks/main.yml
@@ -84,6 +84,7 @@
     - shell_enabled | bool
     - shell_zoxide_enabled | bool
     - shell_zoxide_shells | length > 0
+    - __shell_zoxide_package | default('') | length > 0
   tags:
     - shell
     - shell:zoxide

--- a/roles/shell/tasks/main.yml
+++ b/roles/shell/tasks/main.yml
@@ -77,3 +77,13 @@
   tags:
     - shell
     - shell:starship
+
+- name: Main | Import Zoxide shell init tasks
+  ansible.builtin.import_tasks: zoxide_init.yml
+  when:
+    - shell_enabled | bool
+    - shell_zoxide_enabled | bool
+    - shell_zoxide_shells | length > 0
+  tags:
+    - shell
+    - shell:zoxide

--- a/roles/shell/tasks/zoxide_init.yml
+++ b/roles/shell/tasks/zoxide_init.yml
@@ -1,0 +1,116 @@
+---
+#
+# Zoxide Shell Initialization
+#
+# Adds `eval "$(zoxide init <shell>)"` (or fish equivalent) to the
+# per-user shell rc file via blockinfile. The zoxide package
+# install happens in install.yml; this file wires the init line so
+# the tool is actually usable.
+#
+# Honours `shell_user_config_mode`:
+#
+#   managed  — reconcile the marker block on every run (Ansible wins)
+#   initial  — act only on users present in `__users_newly_created`
+#              for this run (fact set by `marcstraube.common.users`);
+#              existing users' rc files are left alone
+#   disabled — skip entirely
+#
+# zsh handling: when `shell_zsh_framework == 'ohmyzsh'`, the
+# ohmyzsh.zshrc.j2 template already includes the zoxide init line.
+# Skip the zsh init task in that case to avoid duplication.
+#
+
+- name: ZoxideInit | Get users to configure
+  ansible.builtin.set_fact:
+    __shell_zoxide_init_users: >-
+      {{ shell_users if shell_users | length > 0
+         else (users_list | default([]) | map(attribute='name') | list) }}
+
+#
+# bash
+#
+
+- name: ZoxideInit | Add bash init line
+  ansible.builtin.blockinfile:
+    path: '/home/{{ item }}/.bashrc'
+    block: 'eval "$(zoxide init bash)"'
+    marker: '# {mark} ANSIBLE MANAGED — zoxide init'
+    create: true
+    owner: '{{ item }}'
+    group: '{{ item }}'
+    mode: '0644'
+  loop: '{{ __shell_zoxide_init_users }}'
+  loop_control:
+    label: '{{ item }}'
+  when:
+    - "'bash' in shell_zoxide_shells"
+    - shell_user_config_mode != 'disabled'
+    - >-
+      shell_user_config_mode == 'managed'
+      or (shell_user_config_mode == 'initial'
+          and item in (__users_newly_created | default([])))
+
+#
+# zsh
+#
+
+- name: ZoxideInit | Add zsh init line
+  ansible.builtin.blockinfile:
+    path: '/home/{{ item }}/.zshrc'
+    block: 'eval "$(zoxide init zsh)"'
+    marker: '# {mark} ANSIBLE MANAGED — zoxide init'
+    create: true
+    owner: '{{ item }}'
+    group: '{{ item }}'
+    mode: '0644'
+  loop: '{{ __shell_zoxide_init_users }}'
+  loop_control:
+    label: '{{ item }}'
+  when:
+    - "'zsh' in shell_zoxide_shells"
+    - shell_zsh_framework != 'ohmyzsh'
+    - shell_user_config_mode != 'disabled'
+    - >-
+      shell_user_config_mode == 'managed'
+      or (shell_user_config_mode == 'initial'
+          and item in (__users_newly_created | default([])))
+
+#
+# fish
+#
+
+- name: ZoxideInit | Ensure fish config directory exists
+  ansible.builtin.file:
+    path: '/home/{{ item }}/.config/fish'
+    state: directory
+    owner: '{{ item }}'
+    group: '{{ item }}'
+    mode: '0755'
+  loop: '{{ __shell_zoxide_init_users }}'
+  when:
+    - "'fish' in shell_zoxide_shells"
+    - shell_user_config_mode != 'disabled'
+    - >-
+      shell_user_config_mode == 'managed'
+      or (shell_user_config_mode == 'initial'
+          and item in (__users_newly_created | default([])))
+
+- name: ZoxideInit | Add fish init line
+  ansible.builtin.blockinfile:
+    path: '/home/{{ item }}/.config/fish/config.fish'
+    block: 'zoxide init fish | source'
+    marker: '# {mark} ANSIBLE MANAGED — zoxide init'
+    create: true
+    owner: '{{ item }}'
+    group: '{{ item }}'
+    mode: '0644'
+  loop: '{{ __shell_zoxide_init_users }}'
+  loop_control:
+    label: '{{ item }}'
+  when:
+    - "'fish' in shell_zoxide_shells"
+    - shell_user_config_mode != 'disabled'
+    - >-
+      shell_user_config_mode == 'managed'
+      or (shell_user_config_mode == 'initial'
+          and item in (__users_newly_created | default([])))

--- a/roles/shell/vars/RedHat-9.yml
+++ b/roles/shell/vars/RedHat-9.yml
@@ -1,8 +1,6 @@
 ---
 #
-# RedHat / EL 10 Variables
-#
-# For EL 9, see RedHat-9.yml.
+# EL 9 Variables — EPEL 9 ships some tools not yet packaged for EPEL 10
 #
 
 # Zsh plugins
@@ -19,7 +17,7 @@ __shell_starship_package: ''
 
 # Additional tools
 __shell_fzf_package: 'fzf'
-__shell_zoxide_package: ''  # not in EPEL 10
+__shell_zoxide_package: 'zoxide'  # EPEL 9 only
 __shell_eza_package: 'eza'
 __shell_bat_package: 'bat'
 __shell_fd_package: 'fd-find'


### PR DESCRIPTION
## Summary

- `shell_zoxide_enabled` installed the `zoxide` package but never appended `eval "$(zoxide init <shell>)"` to user rc files, leaving the tool unusable.
- Adds `tasks/zoxide_init.yml` (bash, zsh, fish) mirroring `starship_init.yml`, using the canonical `__users_newly_created` pattern and honouring `shell_user_config_mode`.
- Skips the zsh init line under `shell_zsh_framework=ohmyzsh` (the Oh My Zsh template already sources `zoxide init zsh`).
- New default `shell_zoxide_shells: ['zsh', 'bash']` and new `shell:zoxide` tag.
- Molecule: fourth converge play for zoxide init across all distros + verify assertions for package install, init block, and ansible-managed marker.

### Follow-up: zoxide on EL 10

The multi-distro CI matrix introduced in #144 revealed a pre-existing var bug: `vars/RedHat.yml` declared `__shell_zoxide_package: 'zoxide'` as the EL baseline, but EPEL 10 does not ship zoxide.

- Splits the EL vars: EL 10 baseline now sets the package to `''` (no-op), EL 9 keeps zoxide via a new `vars/RedHat-9.yml` override.
- Guards the zoxide init import with `__shell_zoxide_package | length > 0` so the rc-file init line is not deployed on platforms without the package — otherwise users would get a broken shell on next login from sourcing a missing binary.
- Verify mirrors the guard: marker block must be present where zoxide is packaged, absent where it isn't.

## Test plan

- [x] `ansible-lint roles/shell/` — passed
- [x] `yamllint` on changed files — passed
- [x] `markdownlint` on `roles/shell/README.md` — passed
- [x] `molecule test` on `shell-archlinux` — converge/idempotence/verify all green (`ok=17 changed=0 failed=0` for verify)
- [x] `molecule test` on `shell-rocky-10` (post-fix) — converge/idempotence/verify all green (`ok=10 changed=0 failed=0` for verify; zoxide tasks correctly skipped)
- [x] CI: Debian Trixie
- [x] CI: Rocky 9
- [x] CI: Rocky 10

Closes #134