### PR TITLE
feat(shell): add atuin, ble.sh, and bash-preexec toggles

### DIFF
--- a/roles/shell/README.md
+++ b/roles/shell/README.md
@@ -162,16 +162,74 @@ On platforms where `zoxide` is not packaged (currently EL 10 — not in
 EPEL 10), `shell_zoxide_enabled` is a silent no-op: neither the
 package nor the init line is deployed.
 
+### atuin / ble.sh / bash-preexec
+
+| Variable                       | Default                     | Description                                       |
+|--------------------------------|-----------------------------|---------------------------------------------------|
+| `shell_atuin_enabled`          | `false`                     | Enable atuin (magical shell history)              |
+| `shell_atuin_shells`           | `['bash', 'zsh', 'fish']`   | Configure atuin init for these shells             |
+| `shell_blesh_enabled`          | `false`                     | Enable ble.sh (Bash Line Editor) — Arch AUR only  |
+| `shell_blesh_variant`          | `'stable'`                  | ble.sh variant: `'stable'` or `'git'`             |
+| `shell_bash_preexec_enabled`   | `false`                     | Enable bash-preexec — Arch only                   |
+
+Package availability:
+
+| Tool         | Arch                        | Debian Trixie | Rocky 9 (EPEL 9) | Rocky 10               |
+|--------------|-----------------------------|---------------|------------------|------------------------|
+| atuin        | `extra/atuin`               | `main/atuin`  | `epel/atuin`     | — (not in EPEL 10 yet) |
+| ble.sh       | AUR (`blesh` / `blesh-git`) | —             | —                | —                      |
+| bash-preexec | `extra/bash-preexec`        | —             | —                | —                      |
+
+`shell_blesh_variant: 'git'` selects the `blesh-git` AUR package
+(rolling upstream) instead of `blesh` (tagged release). The AUR
+install uses `kewlfft.aur.aur` and runs as the `aur_builder` user.
+
+`shell_atuin_shells` writes the atuin init line via `blockinfile`:
+
+| Shell  | Target file                  | Init line                          |
+|--------|------------------------------|------------------------------------|
+| `bash` | `~/.bashrc`                  | `eval "$(atuin init bash)"`        |
+| `zsh`  | `~/.zshrc`                   | `eval "$(atuin init zsh)"`         |
+| `fish` | `~/.config/fish/config.fish` | `atuin init fish \| source`        |
+
+bash-preexec and ble.sh each add a single source line to `~/.bashrc`:
+
+| Tool         | Init line                              |
+|--------------|----------------------------------------|
+| bash-preexec | `source /usr/share/bash-preexec.sh`    |
+| ble.sh       | `source /usr/share/blesh/ble.sh`       |
+
+atuin's bash integration depends on either `bash-preexec` or
+`ble.sh` being sourced first. The role writes blocks to `.bashrc`
+in this order so the dependency is satisfied at shell startup:
+
+1. `bash-preexec` source line
+2. `ble.sh` source line
+3. atuin init line
+
+The role does not enforce the dependency. If `shell_atuin_enabled`
+is set with `bash` in `shell_atuin_shells` but neither
+`shell_bash_preexec_enabled` nor `shell_blesh_enabled` is set,
+atuin's bash hooks will not fire — the user is responsible for
+enabling one of the two.
+
+All three toggles honour `shell_user_config_mode` like the other
+init blocks. On platforms where the package is not available, the
+toggle is a silent no-op (no package install, no init block).
+
 ## Tags
 
-| Tag               | Description                    |
-|-------------------|--------------------------------|
-| `shell`           | All shell tasks                |
-| `shell:install`   | Package installation           |
-| `shell:ohmyzsh`   | Oh My Zsh setup and config     |
-| `shell:users`     | User shell configuration       |
-| `shell:starship`  | Starship per-user config       |
-| `shell:zoxide`    | Zoxide per-user init           |
+| Tag                   | Description                    |
+|-----------------------|--------------------------------|
+| `shell`               | All shell tasks                |
+| `shell:install`       | Package installation           |
+| `shell:ohmyzsh`       | Oh My Zsh setup and config     |
+| `shell:users`         | User shell configuration       |
+| `shell:starship`      | Starship per-user config       |
+| `shell:zoxide`        | Zoxide per-user init           |
+| `shell:atuin`         | atuin per-user init            |
+| `shell:blesh`         | ble.sh per-user init           |
+| `shell:bash-preexec`  | bash-preexec per-user init     |
 
 ## Example Playbook
 
@@ -209,6 +267,9 @@ molecule test -s default -- --limit shell-archlinux
 - [bat](https://github.com/sharkdp/bat) — `cat` clone with syntax highlighting and Git integration
 - [fd](https://github.com/sharkdp/fd) — Simple, fast, user-friendly alternative to `find`
 - [ripgrep](https://github.com/BurntSushi/ripgrep) — Recursive `grep` alternative respecting gitignore
+- [atuin](https://github.com/atuinsh/atuin) — Magical shell history with sync, search, and stats
+- [ble.sh](https://github.com/akinomyoga/ble.sh) — Bash Line Editor — full-featured replacement for the bash readline
+- [bash-preexec](https://github.com/rcaloras/bash-preexec) — `preexec` and `precmd` hook framework for bash
 - [tldr](https://tldr.sh/) — Simplified, community-driven man pages
 
 ## License

--- a/roles/shell/defaults/main.yml
+++ b/roles/shell/defaults/main.yml
@@ -129,3 +129,38 @@ shell_ripgrep_enabled: false
 
 # Enable tldr (simplified man pages)
 shell_tldr_enabled: false
+
+#
+# Atuin (magical shell history)
+#
+
+# Enable atuin installation
+# Not in EPEL 10 yet — toggle is a no-op there
+shell_atuin_enabled: false
+
+# Configure atuin init for these shells (adds eval to shell config)
+shell_atuin_shells:
+  - 'bash'
+  - 'zsh'
+  - 'fish'
+
+#
+# ble.sh (Bash Line Editor) — Arch AUR only, bash only
+#
+
+# Enable ble.sh installation
+shell_blesh_enabled: false
+
+# ble.sh variant: 'stable' or 'git' (latest upstream development)
+# Stable releases lag upstream; many users want the 'git' variant.
+shell_blesh_variant: 'stable'
+
+#
+# bash-preexec (preexec/precmd hooks for bash) — Arch only, bash only
+#
+
+# Enable bash-preexec installation
+# Required by atuin's bash integration; sourced before atuin init line.
+# If not enabled, atuin bash integration depends on ble.sh being enabled
+# (which provides its own preexec/precmd hooks).
+shell_bash_preexec_enabled: false

--- a/roles/shell/molecule/default/converge.yml
+++ b/roles/shell/molecule/default/converge.yml
@@ -99,3 +99,77 @@
     - name: Converge | Include shell role (zoxide)  # noqa: role-name[path]
       ansible.builtin.include_role:
         name: '{{ playbook_dir }}/../..'
+
+- name: Converge — atuin + bash-preexec (Arch/Debian/EL9 — atuin available)
+  hosts: all
+  gather_facts: true
+
+  vars:
+    shell_enabled: true
+    shell_default: 'bash'
+    shell_zsh_enabled: false
+    shell_fish_enabled: false
+    shell_bash_completion_enabled: false
+    shell_starship_enabled: false
+    shell_atuin_enabled: true
+    shell_atuin_shells:
+      - 'bash'
+    shell_bash_preexec_enabled: true
+    shell_user_config_mode: 'managed'
+    shell_users:
+      - 'testuser'
+    shell_fzf_enabled: false
+
+  tasks:
+    - name: Converge | Include shell role (atuin + bash-preexec)  # noqa: role-name[path]
+      ansible.builtin.include_role:
+        name: '{{ playbook_dir }}/../..'
+
+- name: Converge — ble.sh (Arch only — AUR)
+  hosts: all
+  gather_facts: true
+
+  vars:
+    shell_enabled: true
+    shell_default: 'bash'
+    shell_zsh_enabled: false
+    shell_fish_enabled: false
+    shell_bash_completion_enabled: false
+    shell_starship_enabled: false
+    shell_blesh_enabled: true
+    shell_blesh_variant: 'stable'
+    shell_user_config_mode: 'managed'
+    shell_users:
+      - 'testuser'
+    shell_fzf_enabled: false
+
+  tasks:
+    - name: Converge | Include shell role (blesh)  # noqa: role-name[path]
+      ansible.builtin.include_role:
+        name: '{{ playbook_dir }}/../..'
+      when: ansible_facts['os_family'] == 'Archlinux'
+
+- name: Converge — atuin fish init (Arch only — keep fish-converge scope small)
+  hosts: all
+  gather_facts: true
+
+  vars:
+    shell_enabled: true
+    shell_default: 'bash'
+    shell_zsh_enabled: false
+    shell_fish_enabled: true
+    shell_bash_completion_enabled: false
+    shell_starship_enabled: false
+    shell_atuin_enabled: true
+    shell_atuin_shells:
+      - 'fish'
+    shell_user_config_mode: 'managed'
+    shell_users:
+      - 'testuser'
+    shell_fzf_enabled: false
+
+  tasks:
+    - name: Converge | Include shell role (atuin fish)  # noqa: role-name[path]
+      ansible.builtin.include_role:
+        name: '{{ playbook_dir }}/../..'
+      when: ansible_facts['os_family'] == 'Archlinux'

--- a/roles/shell/molecule/default/verify.yml
+++ b/roles/shell/molecule/default/verify.yml
@@ -239,3 +239,130 @@
       changed_when: false
       failed_when: _shell_zoxide_absent.rc == 0
       when: __shell_zoxide_package | default('') | length == 0
+
+    #
+    # atuin (Arch / Debian / EL 9 — not in EL 10)
+    #
+
+    - name: Verify | Check atuin installed (Arch)
+      ansible.builtin.command:
+        cmd: 'pacman -Q {{ __shell_atuin_package }}'
+      register: _shell_atuin_arch
+      changed_when: false
+      failed_when: _shell_atuin_arch.rc != 0
+      when:
+        - ansible_facts['os_family'] == 'Archlinux'
+        - __shell_atuin_package | default('') | length > 0
+
+    - name: Verify | Check atuin installed (Debian)
+      ansible.builtin.command:
+        cmd: 'dpkg -l {{ __shell_atuin_package }}'
+      register: _shell_atuin_deb
+      changed_when: false
+      failed_when: _shell_atuin_deb.rc != 0
+      when:
+        - ansible_facts['os_family'] == 'Debian'
+        - __shell_atuin_package | default('') | length > 0
+
+    - name: Verify | Check atuin installed (RedHat)
+      ansible.builtin.command:  # noqa: command-instead-of-module
+        cmd: 'rpm -q {{ __shell_atuin_package }}'
+      register: _shell_atuin_rpm
+      changed_when: false
+      failed_when: _shell_atuin_rpm.rc != 0
+      when:
+        - ansible_facts['os_family'] == 'RedHat'
+        - __shell_atuin_package | default('') | length > 0
+
+    - name: Verify | Check atuin init block in testuser .bashrc
+      ansible.builtin.command:
+        cmd: 'grep -q "ANSIBLE MANAGED — atuin init" /home/testuser/.bashrc'
+      register: _shell_atuin_bash_init
+      changed_when: false
+      failed_when: _shell_atuin_bash_init.rc != 0
+      when: __shell_atuin_package | default('') | length > 0
+
+    - name: Verify | Check atuin init block absent when package unavailable
+      ansible.builtin.command:
+        cmd: 'grep -q "ANSIBLE MANAGED — atuin init" /home/testuser/.bashrc'
+      register: _shell_atuin_absent
+      changed_when: false
+      failed_when: _shell_atuin_absent.rc == 0
+      when: __shell_atuin_package | default('') | length == 0
+
+    #
+    # atuin fish init (Arch only — Arch is the only platform with the
+    # fish-converge play). Checks the fish config file directly.
+    #
+
+    - name: Verify | Check atuin fish init block (Arch)
+      ansible.builtin.command:
+        cmd: 'grep -q "ANSIBLE MANAGED — atuin init" /home/testuser/.config/fish/config.fish'
+      register: _shell_atuin_fish_init
+      changed_when: false
+      failed_when: _shell_atuin_fish_init.rc != 0
+      when: ansible_facts['os_family'] == 'Archlinux'
+
+    #
+    # bash-preexec (Arch only — extra/bash-preexec)
+    #
+
+    - name: Verify | Check bash-preexec installed (Arch)
+      ansible.builtin.command:
+        cmd: 'pacman -Q {{ __shell_bash_preexec_package }}'
+      register: _shell_bash_preexec_arch
+      changed_when: false
+      failed_when: _shell_bash_preexec_arch.rc != 0
+      when:
+        - ansible_facts['os_family'] == 'Archlinux'
+        - __shell_bash_preexec_package | default('') | length > 0
+
+    - name: Verify | Check bash-preexec init block in testuser .bashrc (Arch)
+      ansible.builtin.command:
+        cmd: 'grep -q "ANSIBLE MANAGED — bash-preexec init" /home/testuser/.bashrc'
+      register: _shell_bash_preexec_init
+      changed_when: false
+      failed_when: _shell_bash_preexec_init.rc != 0
+      when:
+        - ansible_facts['os_family'] == 'Archlinux'
+        - __shell_bash_preexec_package | default('') | length > 0
+
+    #
+    # bash-preexec init line must come before atuin init in .bashrc
+    # (atuin's bash hooks depend on bash-preexec already loaded).
+    #
+
+    - name: Verify | Check bash-preexec block precedes atuin block (Arch)
+      ansible.builtin.shell: |
+        set -o pipefail
+        preexec_line=$(grep -n "ANSIBLE MANAGED — bash-preexec init" /home/testuser/.bashrc | head -1 | cut -d: -f1)
+        atuin_line=$(grep -n "ANSIBLE MANAGED — atuin init" /home/testuser/.bashrc | head -1 | cut -d: -f1)
+        [ -n "$preexec_line" ] && [ -n "$atuin_line" ] && [ "$preexec_line" -lt "$atuin_line" ]
+      register: _shell_init_order
+      changed_when: false
+      failed_when: _shell_init_order.rc != 0
+      when: ansible_facts['os_family'] == 'Archlinux'
+
+    #
+    # ble.sh (Arch only — AUR)
+    #
+
+    - name: Verify | Check ble.sh installed (Arch)
+      ansible.builtin.command:
+        cmd: 'pacman -Q {{ __shell_blesh_package }}'
+      register: _shell_blesh_arch
+      changed_when: false
+      failed_when: _shell_blesh_arch.rc != 0
+      when:
+        - ansible_facts['os_family'] == 'Archlinux'
+        - __shell_blesh_package | default('') | length > 0
+
+    - name: Verify | Check ble.sh init block in testuser .bashrc (Arch)
+      ansible.builtin.command:
+        cmd: 'grep -q "ANSIBLE MANAGED — ble.sh init" /home/testuser/.bashrc'
+      register: _shell_blesh_init
+      changed_when: false
+      failed_when: _shell_blesh_init.rc != 0
+      when:
+        - ansible_facts['os_family'] == 'Archlinux'
+        - __shell_blesh_package | default('') | length > 0

--- a/roles/shell/tasks/atuin_init.yml
+++ b/roles/shell/tasks/atuin_init.yml
@@ -1,0 +1,116 @@
+---
+#
+# atuin Shell Initialization
+#
+# Adds `eval "$(atuin init <shell>)"` (or fish equivalent) to the
+# per-user shell rc file via blockinfile. atuin's bash integration
+# depends on either bash-preexec or ble.sh being sourced first; the
+# wiring order in tasks/main.yml ensures those init blocks are
+# written to `.bashrc` before this one.
+#
+# Honours `shell_user_config_mode`:
+#
+#   managed  — reconcile the marker block on every run (Ansible wins)
+#   initial  — act only on users present in `__users_newly_created`
+#              for this run (fact set by `marcstraube.common.users`);
+#              existing users' rc files are left alone
+#   disabled — skip entirely
+#
+# Unlike zoxide and starship, atuin is not pre-wired in the Oh My Zsh
+# .zshrc template — under `shell_zsh_framework: 'ohmyzsh'` the atuin
+# init block is appended below the templated content via blockinfile.
+#
+
+- name: AtuinInit | Get users to configure
+  ansible.builtin.set_fact:
+    __shell_atuin_init_users: >-
+      {{ shell_users if shell_users | length > 0
+         else (users_list | default([]) | map(attribute='name') | list) }}
+
+#
+# bash
+#
+
+- name: AtuinInit | Add bash init line
+  ansible.builtin.blockinfile:
+    path: '/home/{{ item }}/.bashrc'
+    block: 'eval "$(atuin init bash)"'
+    marker: '# {mark} ANSIBLE MANAGED — atuin init'
+    create: true
+    owner: '{{ item }}'
+    group: '{{ item }}'
+    mode: '0644'
+  loop: '{{ __shell_atuin_init_users }}'
+  loop_control:
+    label: '{{ item }}'
+  when:
+    - "'bash' in shell_atuin_shells"
+    - shell_user_config_mode != 'disabled'
+    - >-
+      shell_user_config_mode == 'managed'
+      or (shell_user_config_mode == 'initial'
+          and item in (__users_newly_created | default([])))
+
+#
+# zsh
+#
+
+- name: AtuinInit | Add zsh init line
+  ansible.builtin.blockinfile:
+    path: '/home/{{ item }}/.zshrc'
+    block: 'eval "$(atuin init zsh)"'
+    marker: '# {mark} ANSIBLE MANAGED — atuin init'
+    create: true
+    owner: '{{ item }}'
+    group: '{{ item }}'
+    mode: '0644'
+  loop: '{{ __shell_atuin_init_users }}'
+  loop_control:
+    label: '{{ item }}'
+  when:
+    - "'zsh' in shell_atuin_shells"
+    - shell_user_config_mode != 'disabled'
+    - >-
+      shell_user_config_mode == 'managed'
+      or (shell_user_config_mode == 'initial'
+          and item in (__users_newly_created | default([])))
+
+#
+# fish
+#
+
+- name: AtuinInit | Ensure fish config directory exists
+  ansible.builtin.file:
+    path: '/home/{{ item }}/.config/fish'
+    state: directory
+    owner: '{{ item }}'
+    group: '{{ item }}'
+    mode: '0755'
+  loop: '{{ __shell_atuin_init_users }}'
+  when:
+    - "'fish' in shell_atuin_shells"
+    - shell_user_config_mode != 'disabled'
+    - >-
+      shell_user_config_mode == 'managed'
+      or (shell_user_config_mode == 'initial'
+          and item in (__users_newly_created | default([])))
+
+- name: AtuinInit | Add fish init line
+  ansible.builtin.blockinfile:
+    path: '/home/{{ item }}/.config/fish/config.fish'
+    block: 'atuin init fish | source'
+    marker: '# {mark} ANSIBLE MANAGED — atuin init'
+    create: true
+    owner: '{{ item }}'
+    group: '{{ item }}'
+    mode: '0644'
+  loop: '{{ __shell_atuin_init_users }}'
+  loop_control:
+    label: '{{ item }}'
+  when:
+    - "'fish' in shell_atuin_shells"
+    - shell_user_config_mode != 'disabled'
+    - >-
+      shell_user_config_mode == 'managed'
+      or (shell_user_config_mode == 'initial'
+          and item in (__users_newly_created | default([])))

--- a/roles/shell/tasks/bash_preexec_init.yml
+++ b/roles/shell/tasks/bash_preexec_init.yml
@@ -1,0 +1,47 @@
+---
+#
+# bash-preexec Shell Initialization
+#
+# Adds `source /usr/share/bash-preexec.sh` to the per-user `.bashrc`
+# via blockinfile. bash-preexec is bash-only and ships only on Arch
+# Linux (extra/bash-preexec); on other distros this play is gated
+# off by the package guard in tasks/main.yml.
+#
+# Honours `shell_user_config_mode`:
+#
+#   managed  — reconcile the marker block on every run (Ansible wins)
+#   initial  — act only on users present in `__users_newly_created`
+#              for this run (fact set by `marcstraube.common.users`);
+#              existing users' rc files are left alone
+#   disabled — skip entirely
+#
+# Wiring order: bash-preexec must be sourced before any tool that
+# depends on its preexec/precmd hooks (notably atuin). The import
+# order in tasks/main.yml places this file before atuin_init.yml so
+# the corresponding `.bashrc` blockinfile entry appears earlier.
+#
+
+- name: BashPreexecInit | Get users to configure
+  ansible.builtin.set_fact:
+    __shell_bash_preexec_init_users: >-
+      {{ shell_users if shell_users | length > 0
+         else (users_list | default([]) | map(attribute='name') | list) }}
+
+- name: BashPreexecInit | Add bash init line
+  ansible.builtin.blockinfile:
+    path: '/home/{{ item }}/.bashrc'
+    block: 'source /usr/share/bash-preexec.sh'
+    marker: '# {mark} ANSIBLE MANAGED — bash-preexec init'
+    create: true
+    owner: '{{ item }}'
+    group: '{{ item }}'
+    mode: '0644'
+  loop: '{{ __shell_bash_preexec_init_users }}'
+  loop_control:
+    label: '{{ item }}'
+  when:
+    - shell_user_config_mode != 'disabled'
+    - >-
+      shell_user_config_mode == 'managed'
+      or (shell_user_config_mode == 'initial'
+          and item in (__users_newly_created | default([])))

--- a/roles/shell/tasks/blesh_init.yml
+++ b/roles/shell/tasks/blesh_init.yml
@@ -1,0 +1,46 @@
+---
+#
+# ble.sh (Bash Line Editor) Shell Initialization
+#
+# Adds `source /usr/share/blesh/ble.sh` to the per-user `.bashrc`
+# via blockinfile. ble.sh is bash-only and packaged only on Arch
+# (AUR: blesh / blesh-git); on other distros this play is gated
+# off by the package guard in tasks/main.yml.
+#
+# Honours `shell_user_config_mode`:
+#
+#   managed  — reconcile the marker block on every run (Ansible wins)
+#   initial  — act only on users present in `__users_newly_created`
+#              for this run (fact set by `marcstraube.common.users`);
+#              existing users' rc files are left alone
+#   disabled — skip entirely
+#
+# ble.sh provides its own preexec/precmd hooks, so it can replace
+# bash-preexec as the dependency for atuin's bash integration.
+# Init line order in `.bashrc`: bash-preexec → ble.sh → atuin.
+#
+
+- name: BleshInit | Get users to configure
+  ansible.builtin.set_fact:
+    __shell_blesh_init_users: >-
+      {{ shell_users if shell_users | length > 0
+         else (users_list | default([]) | map(attribute='name') | list) }}
+
+- name: BleshInit | Add bash init line
+  ansible.builtin.blockinfile:
+    path: '/home/{{ item }}/.bashrc'
+    block: 'source /usr/share/blesh/ble.sh'
+    marker: '# {mark} ANSIBLE MANAGED — ble.sh init'
+    create: true
+    owner: '{{ item }}'
+    group: '{{ item }}'
+    mode: '0644'
+  loop: '{{ __shell_blesh_init_users }}'
+  loop_control:
+    label: '{{ item }}'
+  when:
+    - shell_user_config_mode != 'disabled'
+    - >-
+      shell_user_config_mode == 'managed'
+      or (shell_user_config_mode == 'initial'
+          and item in (__users_newly_created | default([])))

--- a/roles/shell/tasks/install.yml
+++ b/roles/shell/tasks/install.yml
@@ -21,7 +21,9 @@
         (shell_bat_enabled | bool | ternary([__shell_bat_package], [])) +
         (shell_fd_enabled | bool | ternary([__shell_fd_package], [])) +
         (shell_ripgrep_enabled | bool | ternary([__shell_ripgrep_package], [])) +
-        (shell_tldr_enabled | bool | ternary([__shell_tldr_package], []))
+        (shell_tldr_enabled | bool | ternary([__shell_tldr_package], [])) +
+        (shell_atuin_enabled | bool | ternary([__shell_atuin_package], [])) +
+        (shell_bash_preexec_enabled | bool | ternary([__shell_bash_preexec_package], []))
       }}
 
 - name: Install | Filter empty packages
@@ -36,3 +38,20 @@
   when: __shell_install_packages | length > 0
   retries: 3
   delay: 5
+
+#
+# AUR Packages (Arch Linux only)
+#
+
+- name: Install | ble.sh from AUR
+  become: true
+  become_user: 'aur_builder'
+  kewlfft.aur.aur:
+    name: '{{ __shell_blesh_package }}'
+    state: present
+  retries: 3
+  delay: 5
+  when:
+    - ansible_facts['os_family'] == 'Archlinux'
+    - shell_blesh_enabled | bool
+    - __shell_blesh_package | length > 0

--- a/roles/shell/tasks/main.yml
+++ b/roles/shell/tasks/main.yml
@@ -88,3 +88,34 @@
   tags:
     - shell
     - shell:zoxide
+
+- name: Main | Import bash-preexec shell init tasks
+  ansible.builtin.import_tasks: bash_preexec_init.yml
+  when:
+    - shell_enabled | bool
+    - shell_bash_preexec_enabled | bool
+    - __shell_bash_preexec_package | default('') | length > 0
+  tags:
+    - shell
+    - shell:bash-preexec
+
+- name: Main | Import ble.sh shell init tasks
+  ansible.builtin.import_tasks: blesh_init.yml
+  when:
+    - shell_enabled | bool
+    - shell_blesh_enabled | bool
+    - __shell_blesh_package | default('') | length > 0
+  tags:
+    - shell
+    - shell:blesh
+
+- name: Main | Import atuin shell init tasks
+  ansible.builtin.import_tasks: atuin_init.yml
+  when:
+    - shell_enabled | bool
+    - shell_atuin_enabled | bool
+    - shell_atuin_shells | length > 0
+    - __shell_atuin_package | default('') | length > 0
+  tags:
+    - shell
+    - shell:atuin

--- a/roles/shell/vars/Archlinux.yml
+++ b/roles/shell/vars/Archlinux.yml
@@ -23,3 +23,8 @@ __shell_bat_package: 'bat'
 __shell_fd_package: 'fd'
 __shell_ripgrep_package: 'ripgrep'
 __shell_tldr_package: 'tldr'
+
+# atuin / ble.sh / bash-preexec
+__shell_atuin_package: 'atuin'
+__shell_blesh_package: "{{ 'blesh-git' if shell_blesh_variant == 'git' else 'blesh' }}"
+__shell_bash_preexec_package: 'bash-preexec'

--- a/roles/shell/vars/Debian.yml
+++ b/roles/shell/vars/Debian.yml
@@ -23,3 +23,8 @@ __shell_bat_package: 'bat'
 __shell_fd_package: 'fd-find'
 __shell_ripgrep_package: 'ripgrep'
 __shell_tldr_package: 'tldr'
+
+# atuin / ble.sh / bash-preexec
+__shell_atuin_package: 'atuin'
+__shell_blesh_package: ''  # AUR only on Arch
+__shell_bash_preexec_package: ''  # not in Debian

--- a/roles/shell/vars/RedHat-9.yml
+++ b/roles/shell/vars/RedHat-9.yml
@@ -23,3 +23,8 @@ __shell_bat_package: 'bat'
 __shell_fd_package: 'fd-find'
 __shell_ripgrep_package: 'ripgrep'
 __shell_tldr_package: 'tldr'
+
+# atuin / ble.sh / bash-preexec
+__shell_atuin_package: 'atuin'  # EPEL 9 only
+__shell_blesh_package: ''  # AUR only on Arch
+__shell_bash_preexec_package: ''  # not in EPEL

--- a/roles/shell/vars/RedHat.yml
+++ b/roles/shell/vars/RedHat.yml
@@ -25,3 +25,8 @@ __shell_bat_package: 'bat'
 __shell_fd_package: 'fd-find'
 __shell_ripgrep_package: 'ripgrep'
 __shell_tldr_package: 'tldr'
+
+# atuin / ble.sh / bash-preexec
+__shell_atuin_package: ''  # not in EPEL 10 yet
+__shell_blesh_package: ''  # AUR only on Arch
+__shell_bash_preexec_package: ''  # not in EPEL


### PR DESCRIPTION
## Summary

Adds three shell-tool toggles to the `shell` role:

- `shell_atuin_enabled` — atuin (magical shell history), bash + zsh + fish
- `shell_blesh_enabled` — ble.sh (Bash Line Editor), bash only, Arch AUR
- `shell_bash_preexec_enabled` — bash preexec/precmd hook framework

`shell_atuin_shells` defaults to `['bash', 'zsh', 'fish']`. `shell_blesh_variant` selects between `blesh` (stable) and `blesh-git` (rolling upstream) on Arch via a Jinja conditional. The AUR install uses `kewlfft.aur.aur` running as `aur_builder`.

## Package availability

Per-distro mapping; empty string makes the toggle a no-op (follows the established `__pkg: ''` convention pending the cross-collection alternative-installs strategy):

| Tool         | Arch                        | Debian Trixie | Rocky 9 (EPEL 9) | Rocky 10               |
|--------------|-----------------------------|---------------|------------------|------------------------|
| atuin        | `extra/atuin`               | `main/atuin`  | `epel/atuin`     | — (not in EPEL 10 yet) |
| ble.sh       | AUR (`blesh` / `blesh-git`) | —             | —                | —                      |
| bash-preexec | `extra/bash-preexec`        | —             | —                | —                      |

## Wiring order

atuin's bash integration depends on either `bash-preexec` or `ble.sh` being sourced first (the latter provides its own preexec/precmd hooks). `tasks/main.yml` imports the new init files in this order so the `blockinfile` entries in `.bashrc` are appended in the correct sequence:

1. `bash-preexec` source line
2. `ble.sh` source line
3. atuin init line

The role does not enforce the dependency. README documents that enabling atuin bash without `bash-preexec` or `ble.sh` leaves atuin's bash hooks inactive — same pattern as other optional dependencies in the role.

## Test plan

- [x] `ansible-lint roles/shell/` — passed
- [x] `yamllint` on changed files — passed
- [x] `markdownlint` on `roles/shell/README.md` — passed
- [x] `molecule test` on `shell-archlinux` (all three tools enabled) — converge ok=68, idempotence ok=68 changed=0, verify ok=23 failed=0
- [x] `molecule test` on `shell-rocky-9` (atuin via EPEL 9, blesh/bash-preexec no-ops) — converge ok=38, idempotence ok=38 changed=0, verify ok=14 failed=0
- [x] `molecule test` on `shell-rocky-10` (all three tools no-ops — not in EPEL 10) — converge ok=32, idempotence ok=32 changed=0, verify ok=11 failed=0
- [x] CI: Debian Trixie

The molecule verify includes a marker-order assertion in the Arch bash test: the `# ANSIBLE MANAGED — bash-preexec init` block must appear in `.bashrc` before the `# ANSIBLE MANAGED — atuin init` block.

Closes #133