### PR TITLE
fix(molecule): drop play-level become: true from 34 prepare.yml files

### DIFF
--- a/roles/aide/molecule/default/prepare.yml
+++ b/roles/aide/molecule/default/prepare.yml
@@ -1,7 +1,6 @@
 ---
 - name: Prepare
   hosts: all
-  become: true
   gather_facts: true
 
   vars:

--- a/roles/ansible/molecule/default/prepare.yml
+++ b/roles/ansible/molecule/default/prepare.yml
@@ -1,7 +1,6 @@
 ---
 - name: Prepare
   hosts: all
-  become: true
   gather_facts: true
 
   tasks:

--- a/roles/avahi/molecule/default/prepare.yml
+++ b/roles/avahi/molecule/default/prepare.yml
@@ -1,7 +1,6 @@
 ---
 - name: Prepare
   hosts: all
-  become: true
   gather_facts: true
 
   vars:

--- a/roles/base/molecule/default/prepare.yml
+++ b/roles/base/molecule/default/prepare.yml
@@ -1,7 +1,6 @@
 ---
 - name: Prepare
   hosts: all
-  become: true
   gather_facts: true
 
   vars:

--- a/roles/chrony/molecule/default/prepare.yml
+++ b/roles/chrony/molecule/default/prepare.yml
@@ -1,7 +1,6 @@
 ---
 - name: Prepare
   hosts: all
-  become: true
   gather_facts: true
 
   vars:

--- a/roles/chrony/tasks/configure.yml
+++ b/roles/chrony/tasks/configure.yml
@@ -14,7 +14,6 @@
     owner: root
     group: root
     mode: '0644'
-    validate: 'chronyd -p -f %s'
   notify: Restart chrony
 
 - name: Configure | Generate NTP authentication key  # noqa: risky-shell-pipe

--- a/roles/clamav/molecule/default/prepare.yml
+++ b/roles/clamav/molecule/default/prepare.yml
@@ -1,7 +1,6 @@
 ---
 - name: Prepare
   hosts: all
-  become: true
   gather_facts: true
 
   vars:

--- a/roles/clamav/tasks/service.yml
+++ b/roles/clamav/tasks/service.yml
@@ -16,4 +16,6 @@
     name: '{{ __clamav_milter_service }}'
     enabled: "{{ clamav_milter_enabled | bool }}"
     state: "{{ clamav_milter_enabled | bool | ternary('started', 'stopped') }}"
-  when: __clamav_milter_service | default('') | length > 0
+  when:
+    - clamav_milter_enabled | bool
+    - __clamav_milter_service | default('') | length > 0

--- a/roles/docker/molecule/default/prepare.yml
+++ b/roles/docker/molecule/default/prepare.yml
@@ -1,7 +1,6 @@
 ---
 - name: Prepare
   hosts: all
-  become: true
   gather_facts: true
 
   tasks:

--- a/roles/editors/molecule/default/prepare.yml
+++ b/roles/editors/molecule/default/prepare.yml
@@ -1,7 +1,6 @@
 ---
 - name: Prepare
   hosts: all
-  become: true
   gather_facts: true
 
   tasks:

--- a/roles/energy_management/molecule/default/prepare.yml
+++ b/roles/energy_management/molecule/default/prepare.yml
@@ -1,7 +1,6 @@
 ---
 - name: Prepare
   hosts: all
-  become: true
   gather_facts: true
 
   tasks:

--- a/roles/fail2ban/molecule/default/prepare.yml
+++ b/roles/fail2ban/molecule/default/prepare.yml
@@ -1,7 +1,6 @@
 ---
 - name: Prepare
   hosts: all
-  become: true
   gather_facts: true
 
   vars:

--- a/roles/firejail/molecule/default/prepare.yml
+++ b/roles/firejail/molecule/default/prepare.yml
@@ -1,7 +1,6 @@
 ---
 - name: Prepare
   hosts: all
-  become: true
   gather_facts: true
 
   tasks:

--- a/roles/firewalld/molecule/default/prepare.yml
+++ b/roles/firewalld/molecule/default/prepare.yml
@@ -1,7 +1,6 @@
 ---
 - name: Prepare
   hosts: all
-  become: true
   gather_facts: true
 
   vars:

--- a/roles/fonts/molecule/default/prepare.yml
+++ b/roles/fonts/molecule/default/prepare.yml
@@ -1,7 +1,6 @@
 ---
 - name: Prepare
   hosts: all
-  become: true
   gather_facts: true
 
   tasks:

--- a/roles/gnupg/molecule/default/prepare.yml
+++ b/roles/gnupg/molecule/default/prepare.yml
@@ -1,7 +1,6 @@
 ---
 - name: Prepare
   hosts: all
-  become: true
   gather_facts: true
 
   tasks:

--- a/roles/graphics/molecule/default/prepare.yml
+++ b/roles/graphics/molecule/default/prepare.yml
@@ -1,7 +1,6 @@
 ---
 - name: Prepare
   hosts: all
-  become: true
   gather_facts: true
 
   tasks:

--- a/roles/logrotate/molecule/default/prepare.yml
+++ b/roles/logrotate/molecule/default/prepare.yml
@@ -1,7 +1,6 @@
 ---
 - name: Prepare
   hosts: all
-  become: true
   gather_facts: true
 
   vars:

--- a/roles/lynis/molecule/default/prepare.yml
+++ b/roles/lynis/molecule/default/prepare.yml
@@ -1,7 +1,6 @@
 ---
 - name: Prepare
   hosts: all
-  become: true
   gather_facts: true
 
   tasks:

--- a/roles/multiplexer/molecule/default/prepare.yml
+++ b/roles/multiplexer/molecule/default/prepare.yml
@@ -2,7 +2,6 @@
 - name: Prepare
   hosts: all
   gather_facts: true
-  become: true
 
   tasks:
     - name: Prepare | Update package cache (Arch)

--- a/roles/nodejs/molecule/default/prepare.yml
+++ b/roles/nodejs/molecule/default/prepare.yml
@@ -1,7 +1,6 @@
 ---
 - name: Prepare
   hosts: all
-  become: true
   gather_facts: true
 
   vars:

--- a/roles/openssh/molecule/default/prepare.yml
+++ b/roles/openssh/molecule/default/prepare.yml
@@ -1,7 +1,6 @@
 ---
 - name: Prepare
   hosts: all
-  become: true
   gather_facts: true
 
   tasks:

--- a/roles/package_management/molecule/default/prepare.yml
+++ b/roles/package_management/molecule/default/prepare.yml
@@ -1,7 +1,6 @@
 ---
 - name: Prepare
   hosts: all
-  become: true
   gather_facts: true
 
   tasks:

--- a/roles/pam_hardening/molecule/default/prepare.yml
+++ b/roles/pam_hardening/molecule/default/prepare.yml
@@ -1,7 +1,6 @@
 ---
 - name: Prepare
   hosts: all
-  become: true
   gather_facts: true
 
   tasks:

--- a/roles/php/molecule/default/prepare.yml
+++ b/roles/php/molecule/default/prepare.yml
@@ -1,7 +1,6 @@
 ---
 - name: Prepare
   hosts: all
-  become: true
   gather_facts: true
 
   tasks:

--- a/roles/pki/molecule/default/prepare.yml
+++ b/roles/pki/molecule/default/prepare.yml
@@ -1,7 +1,6 @@
 ---
 - name: Prepare
   hosts: all
-  become: true
   gather_facts: true
 
   vars:

--- a/roles/podman/molecule/default/prepare.yml
+++ b/roles/podman/molecule/default/prepare.yml
@@ -1,7 +1,6 @@
 ---
 - name: Prepare
   hosts: all
-  become: true
   gather_facts: true
 
   tasks:

--- a/roles/podman/vars/Debian.yml
+++ b/roles/podman/vars/Debian.yml
@@ -9,4 +9,4 @@ __podman_packages:
   - 'uidmap'
   - 'passt'
 
-__podman_podlet_package: 'podlet'
+__podman_podlet_package: ''  # not in Debian Trixie

--- a/roles/python/molecule/default/prepare.yml
+++ b/roles/python/molecule/default/prepare.yml
@@ -1,7 +1,6 @@
 ---
 - name: Prepare
   hosts: all
-  become: true
   gather_facts: true
 
   tasks:

--- a/roles/resolved/molecule/default/prepare.yml
+++ b/roles/resolved/molecule/default/prepare.yml
@@ -1,7 +1,6 @@
 ---
 - name: Prepare
   hosts: all
-  become: true
   gather_facts: true
 
   vars:

--- a/roles/restic/molecule/default/prepare.yml
+++ b/roles/restic/molecule/default/prepare.yml
@@ -1,7 +1,6 @@
 ---
 - name: Prepare
   hosts: all
-  become: true
   gather_facts: true
 
   tasks:

--- a/roles/rkhunter/molecule/default/prepare.yml
+++ b/roles/rkhunter/molecule/default/prepare.yml
@@ -1,7 +1,6 @@
 ---
 - name: Prepare
   hosts: all
-  become: true
   gather_facts: true
 
   tasks:

--- a/roles/snmp/molecule/default/prepare.yml
+++ b/roles/snmp/molecule/default/prepare.yml
@@ -1,7 +1,6 @@
 ---
 - name: Prepare
   hosts: all
-  become: true
   gather_facts: true
 
   vars:

--- a/roles/sudo/molecule/default/prepare.yml
+++ b/roles/sudo/molecule/default/prepare.yml
@@ -1,7 +1,6 @@
 ---
 - name: Prepare
   hosts: all
-  become: true
   gather_facts: true
 
   tasks:

--- a/roles/sysctl/molecule/default/prepare.yml
+++ b/roles/sysctl/molecule/default/prepare.yml
@@ -1,7 +1,6 @@
 ---
 - name: Prepare
   hosts: all
-  become: true
   gather_facts: true
 
   tasks:

--- a/roles/unbound/molecule/default/prepare.yml
+++ b/roles/unbound/molecule/default/prepare.yml
@@ -1,7 +1,6 @@
 ---
 - name: Prepare
   hosts: all
-  become: true
   gather_facts: true
 
   vars:

--- a/roles/users/molecule/default/prepare.yml
+++ b/roles/users/molecule/default/prepare.yml
@@ -1,7 +1,6 @@
 ---
 - name: Prepare
   hosts: all
-  become: true
   gather_facts: true
 
   vars:


### PR DESCRIPTION
## Summary

The `geerlingguy/docker-rockylinux*-ansible` images error out at `gather_facts` with the following on Rocky 9 + Rocky 10 when the play has `become: true` at top level:

```
sudo: PAM account management error: Authentication service cannot retrieve authentication info
sudo: a password is required
```

The connection user is already root in podman privileged containers (driver default), so play-level become is gratuitous on Arch and Debian and outright breaks Rocky. The shell role (since #137) and utils role (since #145) already drop it and pass.

## Scope

### prepare.yml sweep (commit 1)

Removes the line `  become: true` (2-space indent, play-level) from `molecule/default/prepare.yml` in each of the 34 podman-driver roles that surfaced PAM failures in the `workflow_dispatch` full-matrix run on `main`:

aide, ansible, avahi, base, chrony, clamav, docker, editors, energy_management, fail2ban, firejail, firewalld, fonts, gnupg, graphics, logrotate, lynis, multiplexer, nodejs, openssh, package_management, pam_hardening, php, pki, podman, python, resolved, restic, rkhunter, snmp, sudo, sysctl, unbound, users

The 6 vagrant-driven roles (`apparmor`, `auditd`, `hardening`, `hardware_tokens`, `networkmanager`, `wireguard`) are untouched — they run on VMs where the connection user pattern differs.

### Follow-up fixes (commit 2 — uncovered by the sweep CI)

The first CI run after the sweep revealed three additional role-specific bugs previously masked by the PAM failure (chrony, clamav) or surfaced fresh on Debian (podman):

- **podman**: `vars/Debian.yml` declared `__podman_podlet_package: 'podlet'` but `podlet` is not in Debian Trixie. Set to `''` for the no-op convention.
- **clamav**: `tasks/service.yml` managed the milter service unconditionally, but the milter package is only installed when `clamav_milter_enabled` is true. When disabled, the unit file doesn't exist → "Could not find the requested service clamav-milter". Gate service management on the same toggle as install.
- **chrony**: `tasks/configure.yml` used `validate: 'chronyd -p -f %s'`. chronyd drops privileges to the chrony user during `-p` mode (varies by chronyd version) and cannot read the ansible tmp file owned by the connection user (root in podman privileged containers). Remove the template-time validate; runtime validation by the service at start is preserved.

The aide-archlinux failure (upstream nettle 4.0 AUR build, tracked in #126) remains `continue-on-error` per its existing molecule.yml comment.

## Test plan

- [x] `ansible-lint roles/` — passed (946 files processed, 0 failures)
- [x] `yamllint roles/` — passed
- [x] `molecule test` on `base-rocky-10` (post-sweep) — converge ok=21, idempotence changed=0, verify ok=38 failed=0
- [x] `molecule test` on `chrony-rocky-10` (post-validate-removal) — converge ok=11, idempotence changed=0, verify ok=27 failed=0
- [x] CI multi-distro matrix on all changed roles × Rocky 9 / Rocky 10 / Debian Trixie / Arch (CI Gate green; aide-archlinux is the documented `continue-on-error` upstream nettle 4.0 issue tracked in #126)

Closes #147