### PR TITLE
feat(shell): include fish in shell_zoxide_shells default

### DIFF
--- a/roles/shell/README.md
+++ b/roles/shell/README.md
@@ -126,16 +126,16 @@ first run and leaves the file alone if the marker is already present
 
 ### Additional Tools
 
-| Variable                 | Default           | Description                                  |
-|--------------------------|-------------------|----------------------------------------------|
-| `shell_fzf_enabled`      | `true`            | Enable fzf (fuzzy finder)                    |
-| `shell_zoxide_enabled`   | `false`           | Enable zoxide (smarter cd)                   |
-| `shell_zoxide_shells`    | `['zsh', 'bash']` | Configure zoxide init for these shells       |
-| `shell_eza_enabled`      | `false`           | Enable eza (modern ls)                       |
-| `shell_bat_enabled`      | `false`           | Enable bat (cat with syntax highlighting)    |
-| `shell_fd_enabled`       | `false`           | Enable fd (modern find)                      |
-| `shell_ripgrep_enabled`  | `false`           | Enable ripgrep (modern grep)                 |
-| `shell_tldr_enabled`     | `false`           | Enable tldr (simplified man pages)           |
+| Variable                 | Default                   | Description                                  |
+|--------------------------|---------------------------|----------------------------------------------|
+| `shell_fzf_enabled`      | `true`                    | Enable fzf (fuzzy finder)                    |
+| `shell_zoxide_enabled`   | `false`                   | Enable zoxide (smarter cd)                   |
+| `shell_zoxide_shells`    | `['bash', 'zsh', 'fish']` | Configure zoxide init for these shells       |
+| `shell_eza_enabled`      | `false`                   | Enable eza (modern ls)                       |
+| `shell_bat_enabled`      | `false`                   | Enable bat (cat with syntax highlighting)    |
+| `shell_fd_enabled`       | `false`                   | Enable fd (modern find)                      |
+| `shell_ripgrep_enabled`  | `false`                   | Enable ripgrep (modern grep)                 |
+| `shell_tldr_enabled`     | `false`                   | Enable tldr (simplified man pages)           |
 
 `shell_zoxide_shells` controls which shell rcfiles get a zoxide init
 line appended via `blockinfile` (with marker

--- a/roles/shell/defaults/main.yml
+++ b/roles/shell/defaults/main.yml
@@ -112,8 +112,9 @@ shell_zoxide_enabled: false
 
 # Configure zoxide for shells (adds init to shell config)
 shell_zoxide_shells:
-  - 'zsh'
   - 'bash'
+  - 'zsh'
+  - 'fish'
 
 # Enable eza (modern ls)
 shell_eza_enabled: false

--- a/roles/shell/molecule/default/converge.yml
+++ b/roles/shell/molecule/default/converge.yml
@@ -100,6 +100,31 @@
       ansible.builtin.include_role:
         name: '{{ playbook_dir }}/../..'
 
+- name: Converge — zoxide fish init (Arch only — keep fish-converge scope small)
+  hosts: all
+  gather_facts: true
+
+  vars:
+    shell_enabled: true
+    shell_default: 'bash'
+    shell_zsh_enabled: false
+    shell_fish_enabled: true
+    shell_bash_completion_enabled: false
+    shell_starship_enabled: false
+    shell_zoxide_enabled: true
+    shell_zoxide_shells:
+      - 'fish'
+    shell_user_config_mode: 'managed'
+    shell_users:
+      - 'testuser'
+    shell_fzf_enabled: false
+
+  tasks:
+    - name: Converge | Include shell role (zoxide fish)  # noqa: role-name[path]
+      ansible.builtin.include_role:
+        name: '{{ playbook_dir }}/../..'
+      when: ansible_facts['os_family'] == 'Archlinux'
+
 - name: Converge — atuin + bash-preexec (Arch/Debian/EL9 — atuin available)
   hosts: all
   gather_facts: true

--- a/roles/shell/molecule/default/verify.yml
+++ b/roles/shell/molecule/default/verify.yml
@@ -241,6 +241,19 @@
       when: __shell_zoxide_package | default('') | length == 0
 
     #
+    # zoxide fish init (Arch only — Arch is the only platform with the
+    # fish-converge play). Checks the fish config file directly.
+    #
+
+    - name: Verify | Check zoxide fish init block (Arch)
+      ansible.builtin.command:
+        cmd: 'grep -q "ANSIBLE MANAGED — zoxide init" /home/testuser/.config/fish/config.fish'
+      register: _shell_zoxide_fish_init
+      changed_when: false
+      failed_when: _shell_zoxide_fish_init.rc != 0
+      when: ansible_facts['os_family'] == 'Archlinux'
+
+    #
     # atuin (Arch / Debian / EL 9 — not in EL 10)
     #
 


### PR DESCRIPTION
## Summary

`shell_zoxide_shells` previously defaulted to `['zsh', 'bash']` even though `tasks/zoxide_init.yml` has always supported fish (writes `zoxide init fish | source` to `~/.config/fish/config.fish`). Fish users had to override the variable explicitly.

This PR mirrors the atuin default from #133 (`shell_atuin_shells: ['bash', 'zsh', 'fish']`) so the three-shell coverage is consistent across both tools.

## Behaviour

- Default value changes from `['zsh', 'bash']` to `['bash', 'zsh', 'fish']`.
- The fish init block is written only when `shell_zoxide_enabled` is true AND `__shell_zoxide_package` is non-empty (existing guard from #142). EL 10 stays a silent no-op.
- Inventories that previously set `shell_zoxide_shells` explicitly are unaffected — explicit lists override the default.

## Molecule

- New converge play `Converge — zoxide fish init (Arch only — keep fish-converge scope small)` enables `shell_fish_enabled: true` + `shell_zoxide_shells: ['fish']` for `testuser`, mirroring the existing atuin-fish play scope.
- New verify task asserts the ANSIBLE MANAGED — zoxide init marker block exists in `~/.config/fish/config.fish` on Arch.

## Test plan

- [x] `ansible-lint roles/shell/` — passed
- [x] `yamllint` on changed files — passed
- [x] `markdownlint` on `roles/shell/README.md` — passed
- [x] `molecule test` on `shell-archlinux` — converge ok=77, idempotence ok=77 changed=0, verify ok=24 failed=0 (added zoxide-fish init check)
- [x] CI: Debian Trixie
- [x] CI: Rocky 9
- [x] CI: Rocky 10

Closes #149