### PR TITLE
fix(networkmanager): reapply NetworkManager device after connection modify

### DIFF
--- a/roles/networkmanager/tasks/connections.yml
+++ b/roles/networkmanager/tasks/connections.yml
@@ -81,6 +81,28 @@
     label: "{{ item.key }}"
   register: ethernet_connections_result
 
+# `community.general.nmcli` persists profile changes but does not push them to
+# the live interface state. `nmcli device reapply` applies most settings
+# (incl. ipv4.dns-search) without disrupting the active connection. "Device
+# not active" / "not found" are expected for connections whose device is down
+# or absent — silently ignored.
+
+- name: Connections | Reapply ethernet device for live changes
+  ansible.builtin.command:
+    cmd: 'nmcli device reapply {{ item.item.value.ifname }}'
+  loop: "{{ ethernet_connections_result.results | default([]) }}"
+  loop_control:
+    label: "{{ item.item.key }}"
+  when:
+    - item.changed | default(false)
+    - item.item.value.ifname is defined
+  register: __nm_reapply_eth
+  changed_when: false
+  failed_when:
+    - __nm_reapply_eth.rc | default(0) != 0
+    - "'not active' not in (__nm_reapply_eth.stderr | default(''))"
+    - "'not found' not in (__nm_reapply_eth.stderr | default(''))"
+
 - name: Connections | Force NetworkManager WiFi scan before creating WiFi connections
   ansible.builtin.shell: |
     nmcli device wifi rescan || true
@@ -163,6 +185,22 @@
     label: "{{ item.key }}"
   register: wifi_connections_result
 
+- name: Connections | Reapply WiFi device for live changes
+  ansible.builtin.command:
+    cmd: 'nmcli device reapply {{ item.item.value.ifname }}'
+  loop: "{{ wifi_connections_result.results | default([]) }}"
+  loop_control:
+    label: "{{ item.item.key }}"
+  when:
+    - item.changed | default(false)
+    - item.item.value.ifname is defined
+  register: __nm_reapply_wifi
+  changed_when: false
+  failed_when:
+    - __nm_reapply_wifi.rc | default(0) != 0
+    - "'not active' not in (__nm_reapply_wifi.stderr | default(''))"
+    - "'not found' not in (__nm_reapply_wifi.stderr | default(''))"
+
 - name: Connections | Check current WiFi cloned-mac-address
   ansible.builtin.shell: |
     set -o pipefail
@@ -193,6 +231,23 @@
     - item.stdout | trim != item.item.value.mac
   changed_when: true
   notify: Reload NetworkManager connections
+  register: wifi_cloned_mac_result
+
+- name: Connections | Reapply WiFi device after cloned-mac change
+  ansible.builtin.command:
+    cmd: 'nmcli device reapply {{ item.item.item.value.ifname }}'
+  loop: "{{ wifi_cloned_mac_result.results | default([]) }}"
+  loop_control:
+    label: "{{ item.item.item.key }}"
+  when:
+    - item.changed | default(false)
+    - item.item.item.value.ifname is defined
+  register: __nm_reapply_mac
+  changed_when: false
+  failed_when:
+    - __nm_reapply_mac.rc | default(0) != 0
+    - "'not active' not in (__nm_reapply_mac.stderr | default(''))"
+    - "'not found' not in (__nm_reapply_mac.stderr | default(''))"
 
 - name: Connections | Check current ipv4.dhcp-send-hostname for connections
   ansible.builtin.shell: |
@@ -225,6 +280,23 @@
     - item.stdout | trim != ('1' if item.item.value.dhcp_send_hostname_ipv4 else '0')
   changed_when: true
   notify: Reload NetworkManager connections
+  register: ipv4_dhcp_send_hostname_result
+
+- name: Connections | Reapply device after ipv4.dhcp-send-hostname change
+  ansible.builtin.command:
+    cmd: 'nmcli device reapply {{ item.item.item.value.ifname }}'
+  loop: "{{ ipv4_dhcp_send_hostname_result.results | default([]) }}"
+  loop_control:
+    label: "{{ item.item.item.key }}"
+  when:
+    - item.changed | default(false)
+    - item.item.item.value.ifname is defined
+  register: __nm_reapply_dhcp4
+  changed_when: false
+  failed_when:
+    - __nm_reapply_dhcp4.rc | default(0) != 0
+    - "'not active' not in (__nm_reapply_dhcp4.stderr | default(''))"
+    - "'not found' not in (__nm_reapply_dhcp4.stderr | default(''))"
 
 - name: Connections | Check current ipv6.dhcp-send-hostname for connections
   ansible.builtin.shell: |
@@ -257,6 +329,23 @@
     - item.stdout | trim != ('1' if item.item.value.dhcp_send_hostname_ipv6 else '0')
   changed_when: true
   notify: Reload NetworkManager connections
+  register: ipv6_dhcp_send_hostname_result
+
+- name: Connections | Reapply device after ipv6.dhcp-send-hostname change
+  ansible.builtin.command:
+    cmd: 'nmcli device reapply {{ item.item.item.value.ifname }}'
+  loop: "{{ ipv6_dhcp_send_hostname_result.results | default([]) }}"
+  loop_control:
+    label: "{{ item.item.item.key }}"
+  when:
+    - item.changed | default(false)
+    - item.item.item.value.ifname is defined
+  register: __nm_reapply_dhcp6
+  changed_when: false
+  failed_when:
+    - __nm_reapply_dhcp6.rc | default(0) != 0
+    - "'not active' not in (__nm_reapply_dhcp6.stderr | default(''))"
+    - "'not found' not in (__nm_reapply_dhcp6.stderr | default(''))"
 
 - name: Connections | Ensure NetworkManager VPN connections exist
   community.general.nmcli:


### PR DESCRIPTION
## Summary

`community.general.nmcli` persists profile changes but does not push them to the live interface state. The same applies to the explicit `nmcli connection modify` tasks for `802-11-wireless.cloned-mac-address` and `ipv4`/`ipv6.dhcp-send-hostname`. The notified `nmcli connection reload` handler only reloads profile definitions from disk — it does not update the running connection.

Effect: changing `ipv4.dns-search` (and other `ipv4.`/`ipv6.`/`connection.*` settings) updated the persisted profile but left the active link unchanged until the connection was brought down/up or the link was reapplied. Diff-check and deploy reported `changed=1`, but `resolvectl status <iface>` still showed the old DNS-Search list until manual `sudo nmcli device reapply <iface>` was run.

## Fix

After each of the five connection-modify task sites, run `nmcli device reapply <ifname>` for the connections that actually changed, gated on `ifname` being defined. `"Device not active"` / `"not found"` are silently accepted (connection profile exists but the link is currently down or absent).

Five reapply sites added:

- Configure NetworkManager ethernet connections
- Configure NetworkManager WiFi connections
- Set WiFi cloned-mac-address
- Set ipv4.dhcp-send-hostname for connections
- Set ipv6.dhcp-send-hostname for connections

The existing `Reload NetworkManager connections` handler is kept — it's redundant for nmcli-mediated changes but harmless and serves as a safety net for any future direct-file modifications.

## Test plan

- [x] `ansible-lint roles/networkmanager/` — passed
- [x] `yamllint` on changed files — passed
- [x] Live deploy of the role with an inventory `dns4_search` change reproduced as a drift (manually removed `~home.arpa` from the WiFi link via `nmcli connection modify -ipv4.dns-search`), then re-applied: role detected drift, modified connection, **and the new reapply task ran automatically**. `resolvectl status <iface>` immediately showed the restored DNS Search list with no manual intervention. `resolvectl query` for the home-internal name returned NOERROR.
- [ ] CI: not exercised — the networkmanager role uses the vagrant driver, which is excluded from the podman matrix.

## Follow-up

The deeply nested loop indexing (`item.item.item.value.ifname`) and the proliferation of check+modify+reapply task triplets are a symptom of the per-setting modify pattern in `tasks/connections.yml`. A consolidation refactor is tracked in #153 (`v2.0.0` milestone, marked breaking) — that PR will replace the five inline reapply tasks added here with a single accumulator-pattern handler.

Closes #151