### PR TITLE
feat(networkmanager)!: add generic settings dict for nmcli-native passthrough

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ __pycache__/
 *.py[cod]
 .molecule/
 molecule/**/instance_config.yml
+**/.vagrant/
 *.retry
 *.log
 *.tar.gz

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,5 +1,5 @@
 {
-  "version": "1.5.0",
+  "version": "1.4.0",
   "plugins_used": [
     {
       "name": "ArtifactoryDetector"
@@ -127,7 +127,7 @@
         "filename": "roles/networkmanager/molecule/default/molecule.yml",
         "hashed_secret": "206c80413b9a96c1312cc346b7d2517b84463edd",
         "is_verified": false,
-        "line_number": 107
+        "line_number": 113
       }
     ],
     "roles/package_management/molecule/default/converge.yml": [
@@ -286,7 +286,7 @@
         "filename": "roles/utils/vars/Debian.yml",
         "hashed_secret": "bae9a180ddd1d8d15b75701f65368844a972d456",
         "is_verified": false,
-        "line_number": 49
+        "line_number": 57
       }
     ],
     "roles/utils/vars/RedHat-9.yml": [
@@ -295,7 +295,7 @@
         "filename": "roles/utils/vars/RedHat-9.yml",
         "hashed_secret": "bae9a180ddd1d8d15b75701f65368844a972d456",
         "is_verified": false,
-        "line_number": 50
+        "line_number": 62
       }
     ],
     "roles/wireguard/molecule/default/molecule.yml": [
@@ -308,5 +308,5 @@
       }
     ]
   },
-  "generated_at": "2026-05-19T12:15:53Z"
+  "generated_at": "2026-05-20T18:01:19Z"
 }

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,0 +1,82 @@
+# Migration Guide
+
+Upgrade guide for users of `marcstraube.common`. Each release with
+breaking changes adds a section here with before/after inventory
+snippets. For the full list of changes per release, see
+[CHANGELOG.md](CHANGELOG.md).
+
+## v2.0.0 (unreleased)
+
+> **Note**: this section is in progress. Earlier `v2.0.0` breaking
+> changes are tracked in the v2.0.0 migration backfill issue and will
+> be added before the release tag.
+
+### `networkmanager` — generic `settings:` dict (#153)
+
+Three per-connection fields are removed and must be migrated into the
+new generic `settings:` dict, which takes nmcli-native keys verbatim.
+
+#### Field renames
+
+| Old per-connection field         | New `settings:` key                                |
+|----------------------------------|----------------------------------------------------|
+| `mac: "..."`                     | `802-11-wireless.cloned-mac-address: "..."` (WiFi) |
+| `dhcp_send_hostname_ipv4: true`  | `ipv4.dhcp-send-hostname: "yes"`                   |
+| `dhcp_send_hostname_ipv4: false` | `ipv4.dhcp-send-hostname: "no"`                    |
+| `dhcp_send_hostname_ipv6: true`  | `ipv6.dhcp-send-hostname: "yes"`                   |
+| `dhcp_send_hostname_ipv6: false` | `ipv6.dhcp-send-hostname: "no"`                    |
+
+Note: the old `mac:` field was overloaded — it was passed to the
+`community.general.nmcli` module as the device MAC selector *and* used
+for the cloned MAC address. The new schema separates these:
+
+- `802-11-wireless.cloned-mac-address` — clone / randomize on connect
+- `802-11-wireless.mac-address` — device selector (lock connection to this MAC)
+- `802-3-ethernet.mac-address` — ethernet device selector
+
+#### Before
+
+```yaml
+networkmanager_connections:
+  ethernet:
+    "Office":
+      ifname: "eth0"
+      dhcp_send_hostname_ipv4: false
+      dhcp_send_hostname_ipv6: false
+  wifi:
+    "Home WiFi":
+      ssid: "MyNetwork"
+      mac: "random"
+```
+
+#### After
+
+```yaml
+networkmanager_connections:
+  ethernet:
+    "Office":
+      ifname: "eth0"
+      settings:
+        ipv4.dhcp-send-hostname: "no"
+        ipv6.dhcp-send-hostname: "no"
+  wifi:
+    "Home WiFi":
+      ssid: "MyNetwork"
+      settings:
+        802-11-wireless.cloned-mac-address: "random"
+```
+
+#### Value formats
+
+For ternary-boolean keys (`*.dhcp-send-hostname`, `connection.metered`,
+etc.) any of nmcli's accepted forms work: `yes`/`true`/`1`,
+`no`/`false`/`0`, or `default`/`unknown`/`-1`. The role normalizes both
+sides before comparing, so the choice is purely cosmetic.
+
+For all other keys (strings, MAC addresses, enums like `random`), use
+the value verbatim — comparison is case-sensitive against the exact
+string nmcli returns.
+
+The global daemon-config defaults (`networkmanager_dhcp_send_hostname_ipv4`
+/ `_ipv6`) are unaffected by this change — they continue to write the
+`[connection]` section of `/etc/NetworkManager/conf.d/00-ansible.conf`.

--- a/roles/networkmanager/README.md
+++ b/roles/networkmanager/README.md
@@ -143,8 +143,9 @@ networkmanager_connections:
       dns4_search: ["office.local"]
       routes4: ["10.0.0.0/8 192.168.1.254"]
       route_metric4: 100
-      dhcp_send_hostname_ipv4: false    # per-connection override
-      vpn: ["Company VPN"]             # auto-connect VPN via connection.secondaries
+      vpn: ["Company VPN"]              # auto-connect VPN via connection.secondaries
+      settings:                         # generic nmcli-native settings (see below)
+        ipv4.dhcp-send-hostname: "no"
 ```
 
 #### WiFi Connections
@@ -158,7 +159,41 @@ networkmanager_connections:
       ssid: "MyNetwork"
       ifname: "wlan0"
       autoconnect: true
+      settings:
+        802-11-wireless.cloned-mac-address: "random"
 ```
+
+#### Generic `settings:` dict
+
+Any nmcli-native key not exposed as a first-class option above can be set
+via `settings:`. The value is passed verbatim to `nmcli connection modify
+<conn> <key> <value>`. Settings are diffed against the current stored
+value, so only changed keys are applied, and the device is reapplied once
+at the end of the play (not per setting).
+
+Common keys:
+
+| Key                                  | Purpose                              |
+|--------------------------------------|--------------------------------------|
+| `802-11-wireless.cloned-mac-address` | WiFi MAC randomization / clone       |
+| `802-3-ethernet.cloned-mac-address`  | Ethernet MAC clone                   |
+| `ipv4.dhcp-send-hostname`            | Send hostname to IPv4 DHCP server    |
+| `ipv6.dhcp-send-hostname`            | Send hostname to IPv6 DHCP server    |
+| `ipv4.dhcp-hostname`                 | Override hostname sent to DHCP       |
+| `connection.metered`                 | Mark connection as metered           |
+
+See <https://networkmanager.dev/docs/api/latest/settings-spec.html> for
+the full key reference.
+
+**Value formats**: the role accepts ternary-boolean values (used by keys
+like `*.dhcp-send-hostname`, `connection.metered`) in any of the forms
+nmcli's CLI parser understands: `yes`/`true`/`1`, `no`/`false`/`0`, or
+`default`/`unknown`/`-1`. The role normalizes both stored and desired
+values before comparing, so writing `"yes"` is equivalent to `"1"`.
+
+For other keys (strings, MAC addresses, enums like `random`), use the
+value verbatim — comparison is case-sensitive and uses the exact string
+nmcli returns.
 
 #### VPN Connections
 
@@ -257,7 +292,8 @@ networkmanager_unmanaged_devices:
             "Home WiFi":
               ssid: "HomeNetwork"
               autoconnect: true
-              dhcp_send_hostname_ipv4: false
+              settings:
+                ipv4.dhcp-send-hostname: "no"
           vpn:
             "Company VPN":
               vpn:

--- a/roles/networkmanager/TESTING.md
+++ b/roles/networkmanager/TESTING.md
@@ -224,9 +224,10 @@ test_networkmanager_connections:
     'Test Ethernet Connection':
       ifname: eth1
       ip4: 192.168.1.10/24
-      dhcp_send_hostname_ipv4: true
       vpn:
         - Test VPN Company
+      settings:
+        ipv4.dhcp-send-hostname: "yes"
   wifi:
     'Office WiFi':
       ifname: wlan2

--- a/roles/networkmanager/defaults/main.yml
+++ b/roles/networkmanager/defaults/main.yml
@@ -137,6 +137,19 @@ networkmanager_vpn_plugins: []
 # Connections
 #
 # Connection profiles managed via community.general.nmcli.
+#
+# First-class fields map to community.general.nmcli module parameters
+# (ifname, ip4, gw4, dns4, routes4, autoconnect, ...).
+#
+# The generic `settings:` dict takes nmcli-native keys and is applied via
+# a single `nmcli connection modify` per connection. Any setting nmcli
+# supports works — see https://networkmanager.dev/docs/api/latest/settings-spec.html
+#
+# Idempotency note: values are compared verbatim against `nmcli -t -f all
+# connection show <conn>` output. nmcli normalizes some values on store
+# (e.g. ipv4.dhcp-send-hostname "1" is stored as "yes"). Use the form
+# nmcli returns to avoid every run being reported as changed.
+#
 # Example:
 #   ethernet:
 #     "My Office Connection":
@@ -148,8 +161,14 @@ networkmanager_vpn_plugins: []
 #       dns4:
 #         - "8.8.8.8"
 #         - "8.8.4.4"
-#       dhcp_send_hostname_ipv4: true
-#       dhcp_send_hostname_ipv6: true
+#       settings:
+#         ipv4.dhcp-send-hostname: "yes"
+#         ipv6.dhcp-send-hostname: "yes"
+#   wifi:
+#     "Home WiFi":
+#       ssid: "MyNetwork"
+#       settings:
+#         802-11-wireless.cloned-mac-address: "random"
 networkmanager_connections:
   ethernet: {}
   wifi: {}

--- a/roles/networkmanager/molecule/default/molecule.yml
+++ b/roles/networkmanager/molecule/default/molecule.yml
@@ -48,18 +48,20 @@ provisioner:
               gw4: 192.168.1.1
               state: present
               autoconnect: false
-              dhcp_send_hostname_ipv4: true
-              dhcp_send_hostname_ipv6: true
               vpn:
                 - Test VPN Company
+              settings:
+                ipv4.dhcp-send-hostname: "yes"
+                ipv6.dhcp-send-hostname: "yes"
             'Home Ethernet':
               ifname: eth2
               ip4: 192.168.2.10/24
               gw4: 192.168.2.1
               state: present
               autoconnect: false
-              dhcp_send_hostname_ipv4: false
-              dhcp_send_hostname_ipv6: false
+              settings:
+                ipv4.dhcp-send-hostname: "no"
+                ipv6.dhcp-send-hostname: "no"
           wifi:
             'Office WiFi':
               ifname: wlan2
@@ -68,11 +70,15 @@ provisioner:
               autoconnect: false
               vpn:
                 - Test VPN Company
+              settings:
+                802-11-wireless.cloned-mac-address: random
             'Home WiFi':
               ifname: wlan3
               ssid: Home-Network
               state: present
               autoconnect: false
+              settings:
+                802-11-wireless.cloned-mac-address: AA:BB:CC:DD:EE:FF
           vpn:
             'Test VPN Company':
               vpn:
@@ -169,8 +175,9 @@ provisioner:
               gw4: 192.168.1.1
               state: present
               autoconnect: false
-              dhcp_send_hostname_ipv4: true
-              dhcp_send_hostname_ipv6: true
+              settings:
+                ipv4.dhcp-send-hostname: "yes"
+                ipv6.dhcp-send-hostname: "yes"
           wifi: {}
           vpn: {}
         test_networkmanager_smb_shares: []
@@ -192,8 +199,9 @@ provisioner:
               gw4: 192.168.1.1
               state: present
               autoconnect: false
-              dhcp_send_hostname_ipv4: true
-              dhcp_send_hostname_ipv6: true
+              settings:
+                ipv4.dhcp-send-hostname: "yes"
+                ipv6.dhcp-send-hostname: "yes"
           wifi: {}
           vpn: {}
         test_networkmanager_smb_shares: []
@@ -215,8 +223,9 @@ provisioner:
               gw4: 192.168.1.1
               state: present
               autoconnect: false
-              dhcp_send_hostname_ipv4: true
-              dhcp_send_hostname_ipv6: true
+              settings:
+                ipv4.dhcp-send-hostname: "yes"
+                ipv6.dhcp-send-hostname: "yes"
           wifi: {}
           vpn: {}
         test_networkmanager_smb_shares: []

--- a/roles/networkmanager/molecule/default/verify.yml
+++ b/roles/networkmanager/molecule/default/verify.yml
@@ -200,42 +200,67 @@
         success_msg: Unmanaged devices correctly configured in daemon config
 
     #
-    # DHCP Hostname Verification
+    # Generic Settings Dict Verification
     #
+    # Walks every `settings:` entry on every present connection and asserts
+    # nmcli's stored value (after unescaping `\:` -> `:`) matches the value
+    # in the inventory.
 
-    - name: Verify | Set fact for connections with dhcp_send_hostname explicitly set to false
+    - name: Verify | Flatten settings entries from test inventory
       ansible.builtin.set_fact:
-        dhcp_hostname_disabled_connections: >-
-          {{ (test_networkmanager_connections.ethernet | dict2items +
-          test_networkmanager_connections.wifi | dict2items) |
-          selectattr('value.dhcp_send_hostname_ipv4', 'defined') |
-          rejectattr('value.dhcp_send_hostname_ipv4') | map(attribute='key') | list }}
+        verify_settings_entries: >-
+          {{ verify_settings_entries | default([])
+             + (item.value.settings | default({}) | dict2items
+                | map('combine', {'conn_name': item.key})
+                | list) }}
+      loop: >-
+        {{ (test_networkmanager_connections.ethernet | default({}) | dict2items)
+           + (test_networkmanager_connections.wifi | default({}) | dict2items) }}
+      loop_control:
+        label: "{{ item.key }}"
+      when:
+        - item.value.state | default('present') == 'present'
+        - item.value.settings | default({}) | length > 0
 
-    - name: Verify | Check connections for dhcp-send-hostname override
-      ansible.builtin.shell: |
-        set -o pipefail
-        nmcli -t -f ipv4.dhcp-send-hostname connection show "{{ item }}" | cut -d: -f2
-      args:
-        executable: /bin/bash
-      register: connection_dhcp_hostname
+    - name: Verify | Query nmcli for each managed setting
+      ansible.builtin.command:
+        cmd: 'nmcli -t -f {{ item.key | quote }} connection show {{ item.conn_name | quote }}'
+      register: verify_settings_query
       changed_when: false
-      failed_when: false
-      loop: "{{ dhcp_hostname_disabled_connections }}"
-      when: dhcp_hostname_disabled_connections | length > 0
+      loop: "{{ verify_settings_entries | default([]) }}"
+      loop_control:
+        label: "{{ item.conn_name }}/{{ item.key }}"
 
-    - name: Verify | Assert connections have dhcp-send-hostname disabled
+    - name: Verify | Assert each managed setting matches inventory
+      vars:
+        bool_norm:
+          'yes': '1'
+          'true': '1'
+          '1': '1'
+          'no': '0'
+          'false': '0'
+          '0': '0'
+          'default': '-1'
+          'unknown': '-1'
+          '-1': '-1'
+        current_raw: >-
+          {{ item.stdout | regex_replace('^[^:]+:', '')
+                         | regex_replace('\\\\(.)', '\\1') }}
+        desired_raw: "{{ item.item.value | string }}"
       ansible.builtin.assert:
         that:
           - >-
-            item.stdout | trim in ['no', '0', 'false']
-        fail_msg: Connection '{{ item.item }}' does not have dhcp-send-hostname disabled
-        success_msg: Connection '{{ item.item }}' correctly has dhcp-send-hostname disabled
-      loop: "{{ connection_dhcp_hostname.results | default([]) }}"
+            bool_norm.get(current_raw | lower, current_raw)
+            == bool_norm.get(desired_raw | lower, desired_raw)
+        fail_msg: >-
+          Connection '{{ item.item.conn_name }}' key '{{ item.item.key }}'
+          expected '{{ desired_raw }}' but nmcli stored '{{ current_raw }}'
+        success_msg: >-
+          Connection '{{ item.item.conn_name }}' key '{{ item.item.key }}'
+          correctly set to '{{ desired_raw }}'
+      loop: "{{ verify_settings_query.results | default([]) }}"
       loop_control:
-        label: "{{ item.item }}"
-      when:
-        - dhcp_hostname_disabled_connections | length > 0
-        - item.rc == 0
+        label: "{{ item.item.conn_name }}/{{ item.item.key }}"
 
     #
     # Polkit Verification

--- a/roles/networkmanager/tasks/connections.yml
+++ b/roles/networkmanager/tasks/connections.yml
@@ -26,7 +26,6 @@
     type: ethernet
     conn_name: "{{ item.key }}"
     ifname: "{{ item.value.ifname | default(omit) }}"
-    mac: "{{ item.value.mac | default(omit) }}"
     ip4: "{{ item.value.ip4 | default(omit) }}"
     gw4: "{{ item.value.gw4 | default(omit) }}"
     gw4_ignore_auto: "{{ item.value.gw4_ignore_auto | default(omit) }}"
@@ -80,28 +79,6 @@
   loop_control:
     label: "{{ item.key }}"
   register: ethernet_connections_result
-
-# `community.general.nmcli` persists profile changes but does not push them to
-# the live interface state. `nmcli device reapply` applies most settings
-# (incl. ipv4.dns-search) without disrupting the active connection. "Device
-# not active" / "not found" are expected for connections whose device is down
-# or absent — silently ignored.
-
-- name: Connections | Reapply ethernet device for live changes
-  ansible.builtin.command:
-    cmd: 'nmcli device reapply {{ item.item.value.ifname }}'
-  loop: "{{ ethernet_connections_result.results | default([]) }}"
-  loop_control:
-    label: "{{ item.item.key }}"
-  when:
-    - item.changed | default(false)
-    - item.item.value.ifname is defined
-  register: __nm_reapply_eth
-  changed_when: false
-  failed_when:
-    - __nm_reapply_eth.rc | default(0) != 0
-    - "'not active' not in (__nm_reapply_eth.stderr | default(''))"
-    - "'not found' not in (__nm_reapply_eth.stderr | default(''))"
 
 - name: Connections | Force NetworkManager WiFi scan before creating WiFi connections
   ansible.builtin.shell: |
@@ -185,167 +162,96 @@
     label: "{{ item.key }}"
   register: wifi_connections_result
 
-- name: Connections | Reapply WiFi device for live changes
-  ansible.builtin.command:
-    cmd: 'nmcli device reapply {{ item.item.value.ifname }}'
-  loop: "{{ wifi_connections_result.results | default([]) }}"
-  loop_control:
-    label: "{{ item.item.key }}"
-  when:
-    - item.changed | default(false)
-    - item.item.value.ifname is defined
-  register: __nm_reapply_wifi
-  changed_when: false
-  failed_when:
-    - __nm_reapply_wifi.rc | default(0) != 0
-    - "'not active' not in (__nm_reapply_wifi.stderr | default(''))"
-    - "'not found' not in (__nm_reapply_wifi.stderr | default(''))"
+# Generic settings dict: a single check + modify + reapply pipeline for any
+# nmcli-native key. Replaces the per-setting check+modify pairs that used to
+# live here (cloned-mac, ipv4.dhcp-send-hostname, ipv6.dhcp-send-hostname).
+# Any setting the user puts in `connection.settings:` is queried, diffed
+# against the current stored value, and applied with one `nmcli connection
+# modify` per connection.
 
-- name: Connections | Check current WiFi cloned-mac-address
-  ansible.builtin.shell: |
-    set -o pipefail
-    nmcli -t -f 802-11-wireless.cloned-mac-address connection show "{{ item.key }}" | cut -d: -f2
-  args:
-    executable: /bin/bash
-  loop: "{{ networkmanager_connections.wifi | dict2items }}"
+- name: Connections | Flatten settings into (conn, ifname, key, value) entries
+  ansible.builtin.set_fact:
+    __nm_settings_flat: >-
+      {{ __nm_settings_flat | default([])
+         + (item.value.settings | dict2items
+            | map('combine', {
+                'conn_name': item.key,
+                'ifname': item.value.ifname | default('')
+              })
+            | list) }}
+  loop: >-
+    {{ (networkmanager_connections.ethernet | default({}) | dict2items)
+       + (networkmanager_connections.wifi | default({}) | dict2items) }}
   loop_control:
     label: "{{ item.key }}"
   when:
-    - item.value.state | default("present") == "present"
-    - item.value.mac is defined
-  register: current_wifi_cloned_mac
-  changed_when: false
-  failed_when: false
+    - item.value.state | default('present') == 'present'
+    - item.value.settings | default({}) | length > 0
 
-- name: Connections | Set WiFi cloned-mac-address
+# Per-key query (rather than `-f all`) — NetworkManager 1.50+ omits
+# deprecated properties from `-f all` output (e.g. `ipv4.dhcp-send-hostname`,
+# now superseded by `dhcp-send-hostname-v2`). Asking for the exact key the
+# user listed always works, deprecated or not.
+- name: Connections | Query current value for each managed setting
   ansible.builtin.command:
-    cmd: >-
-      nmcli connection modify "{{ item.item.key }}"
-      802-11-wireless.cloned-mac-address
-      "{{ item.item.value.mac }}"
-  loop: "{{ current_wifi_cloned_mac.results | default([]) }}"
+    cmd: 'nmcli -t -f {{ item.key | quote }} connection show {{ item.conn_name | quote }}'
+  loop: "{{ __nm_settings_flat | default([]) }}"
   loop_control:
-    label: "{{ item.item.key }}"
-  when:
-    - not item.skipped | default(false)
-    - item.stdout | trim != item.item.value.mac
+    label: "{{ item.conn_name }}/{{ item.key }}"
+  register: __nm_settings_query
+  changed_when: false
+  # nmcli may fail if NetworkManager is not running or the key is unknown
+  failed_when: false
+  check_mode: false
+
+# Two preprocessing steps before comparing stored vs desired:
+#   1. nmcli -t mode prefixes literal `\` and `:` in values with a backslash;
+#      unescape with regex `\\(.)` -> `\1` so MAC addresses (and any value
+#      containing colons) compare correctly.
+#   2. nmcli normalizes ternary-boolean inputs on store: writing "yes"
+#      results in stored value "1", "no" -> "0", "default" -> "-1".
+#      Map both sides through the same lookup table so the user can write
+#      either form interchangeably and idempotence still holds.
+- name: Connections | Compute settings delta (entries needing change)
+  vars:
+    __nm_bool_norm:
+      'yes': '1'
+      'true': '1'
+      '1': '1'
+      'no': '0'
+      'false': '0'
+      '0': '0'
+      'default': '-1'
+      'unknown': '-1'
+      '-1': '-1'
+    __nm_current_raw: >-
+      {{ item.stdout | default('')
+         | regex_replace('^[^:]+:', '')
+         | regex_replace('\\\\(.)', '\\1') }}
+    __nm_desired_raw: "{{ item.item.value | string }}"
+  ansible.builtin.set_fact:
+    __nm_settings_delta: >-
+      {{ __nm_settings_delta | default([])
+         + ([item.item] if __nm_bool_norm.get(__nm_current_raw | lower, __nm_current_raw)
+                        != __nm_bool_norm.get(__nm_desired_raw | lower, __nm_desired_raw)
+            else []) }}
+  loop: "{{ __nm_settings_query.results | default([]) }}"
+  loop_control:
+    label: "{{ item.item.conn_name }}/{{ item.item.key }}"
+
+- name: Connections | Apply settings delta per connection
+  ansible.builtin.command:
+    argv: >-
+      {{ ['nmcli', 'connection', 'modify', item.0]
+         + (item.1 | map(attribute='key')
+                   | zip(item.1 | map(attribute='value') | map('string') | list)
+                   | flatten | list) }}
+  loop: "{{ __nm_settings_delta | default([]) | groupby('conn_name') }}"
+  loop_control:
+    label: "{{ item.0 }}"
   changed_when: true
   notify: Reload NetworkManager connections
-  register: wifi_cloned_mac_result
-
-- name: Connections | Reapply WiFi device after cloned-mac change
-  ansible.builtin.command:
-    cmd: 'nmcli device reapply {{ item.item.item.value.ifname }}'
-  loop: "{{ wifi_cloned_mac_result.results | default([]) }}"
-  loop_control:
-    label: "{{ item.item.item.key }}"
-  when:
-    - item.changed | default(false)
-    - item.item.item.value.ifname is defined
-  register: __nm_reapply_mac
-  changed_when: false
-  failed_when:
-    - __nm_reapply_mac.rc | default(0) != 0
-    - "'not active' not in (__nm_reapply_mac.stderr | default(''))"
-    - "'not found' not in (__nm_reapply_mac.stderr | default(''))"
-
-- name: Connections | Check current ipv4.dhcp-send-hostname for connections
-  ansible.builtin.shell: |
-    set -o pipefail
-    nmcli -t -f ipv4.dhcp-send-hostname connection show "{{ item.key }}" | cut -d: -f2
-  args:
-    executable: /bin/bash
-  loop: "{{ ((networkmanager_connections.ethernet | dict2items) + (networkmanager_connections.wifi | dict2items)) }}"
-  loop_control:
-    label: "{{ item.key }}"
-  when:
-    - item.value.state | default("present") == "present"
-    - item.value.dhcp_send_hostname_ipv4 is defined
-  register: current_ipv4_dhcp_send_hostname
-  changed_when: false
-  # nmcli may fail if NetworkManager is not running or no connections exist
-  failed_when: false
-
-- name: Connections | Set ipv4.dhcp-send-hostname for connections
-  ansible.builtin.command:
-    cmd: >-
-      nmcli connection modify "{{ item.item.key }}"
-      ipv4.dhcp-send-hostname
-      "{{ '1' if item.item.value.dhcp_send_hostname_ipv4 else '0' }}"
-  loop: "{{ current_ipv4_dhcp_send_hostname.results | default([]) }}"
-  loop_control:
-    label: "{{ item.item.key }}"
-  when:
-    - not item.skipped | default(false)
-    - item.stdout | trim != ('1' if item.item.value.dhcp_send_hostname_ipv4 else '0')
-  changed_when: true
-  notify: Reload NetworkManager connections
-  register: ipv4_dhcp_send_hostname_result
-
-- name: Connections | Reapply device after ipv4.dhcp-send-hostname change
-  ansible.builtin.command:
-    cmd: 'nmcli device reapply {{ item.item.item.value.ifname }}'
-  loop: "{{ ipv4_dhcp_send_hostname_result.results | default([]) }}"
-  loop_control:
-    label: "{{ item.item.item.key }}"
-  when:
-    - item.changed | default(false)
-    - item.item.item.value.ifname is defined
-  register: __nm_reapply_dhcp4
-  changed_when: false
-  failed_when:
-    - __nm_reapply_dhcp4.rc | default(0) != 0
-    - "'not active' not in (__nm_reapply_dhcp4.stderr | default(''))"
-    - "'not found' not in (__nm_reapply_dhcp4.stderr | default(''))"
-
-- name: Connections | Check current ipv6.dhcp-send-hostname for connections
-  ansible.builtin.shell: |
-    set -o pipefail
-    nmcli -t -f ipv6.dhcp-send-hostname connection show "{{ item.key }}" | cut -d: -f2
-  args:
-    executable: /bin/bash
-  loop: "{{ ((networkmanager_connections.ethernet | dict2items) + (networkmanager_connections.wifi | dict2items)) }}"
-  loop_control:
-    label: "{{ item.key }}"
-  when:
-    - item.value.state | default("present") == "present"
-    - item.value.dhcp_send_hostname_ipv6 is defined
-  register: current_ipv6_dhcp_send_hostname
-  changed_when: false
-  # nmcli may fail if NetworkManager is not running or no connections exist
-  failed_when: false
-
-- name: Connections | Set ipv6.dhcp-send-hostname for connections
-  ansible.builtin.command:
-    cmd: >-
-      nmcli connection modify "{{ item.item.key }}"
-      ipv6.dhcp-send-hostname
-      "{{ '1' if item.item.value.dhcp_send_hostname_ipv6 else '0' }}"
-  loop: "{{ current_ipv6_dhcp_send_hostname.results | default([]) }}"
-  loop_control:
-    label: "{{ item.item.key }}"
-  when:
-    - not item.skipped | default(false)
-    - item.stdout | trim != ('1' if item.item.value.dhcp_send_hostname_ipv6 else '0')
-  changed_when: true
-  notify: Reload NetworkManager connections
-  register: ipv6_dhcp_send_hostname_result
-
-- name: Connections | Reapply device after ipv6.dhcp-send-hostname change
-  ansible.builtin.command:
-    cmd: 'nmcli device reapply {{ item.item.item.value.ifname }}'
-  loop: "{{ ipv6_dhcp_send_hostname_result.results | default([]) }}"
-  loop_control:
-    label: "{{ item.item.item.key }}"
-  when:
-    - item.changed | default(false)
-    - item.item.item.value.ifname is defined
-  register: __nm_reapply_dhcp6
-  changed_when: false
-  failed_when:
-    - __nm_reapply_dhcp6.rc | default(0) != 0
-    - "'not active' not in (__nm_reapply_dhcp6.stderr | default(''))"
-    - "'not found' not in (__nm_reapply_dhcp6.stderr | default(''))"
+  register: __nm_settings_modify_result
 
 - name: Connections | Ensure NetworkManager VPN connections exist
   community.general.nmcli:
@@ -559,6 +465,7 @@
     - not item.skipped | default(false)
     - item.stdout | trim != item.item.ansible_facts.vpn_uuids_for_connection
   changed_when: true
+  register: __nm_eth_secondaries_result
 
 - name: Connections | Build VPN UUID list for WiFi connections
   ansible.builtin.set_fact:
@@ -606,3 +513,81 @@
     - not item.skipped | default(false)
     - item.stdout | trim != item.item.ansible_facts.vpn_uuids_for_connection
   changed_when: true
+  register: __nm_wifi_secondaries_result
+
+# `community.general.nmcli` and direct `nmcli connection modify` calls persist
+# profile changes but do not push them to the live interface state. `nmcli
+# device reapply` applies most settings (incl. ipv4.dns-search, cloned-mac,
+# dhcp-send-hostname) without disrupting the active connection. "Device not
+# active" / "not found" are expected when the device is down or absent and
+# are silently ignored. We collect changed ifnames from every modify site,
+# dedup, and reapply each device exactly once.
+
+- name: Connections | Collect ifnames needing reapply (ethernet configure)
+  ansible.builtin.set_fact:
+    __nm_reapply_ifnames: >-
+      {{ __nm_reapply_ifnames | default([])
+         + ([item.item.value.ifname] if (item.changed | default(false)
+                                         and item.item.value.ifname is defined)
+            else []) }}
+  loop: "{{ ethernet_connections_result.results | default([]) }}"
+  loop_control:
+    label: "{{ item.item.key }}"
+
+- name: Connections | Collect ifnames needing reapply (wifi configure)
+  ansible.builtin.set_fact:
+    __nm_reapply_ifnames: >-
+      {{ __nm_reapply_ifnames | default([])
+         + ([item.item.value.ifname] if (item.changed | default(false)
+                                         and item.item.value.ifname is defined)
+            else []) }}
+  loop: "{{ wifi_connections_result.results | default([]) }}"
+  loop_control:
+    label: "{{ item.item.key }}"
+
+- name: Connections | Collect ifnames needing reapply (settings modify)
+  ansible.builtin.set_fact:
+    __nm_reapply_ifnames: >-
+      {{ __nm_reapply_ifnames | default([])
+         + ([item.item.1[0].ifname] if (item.changed | default(false)
+                                        and item.item.1[0].ifname | length > 0)
+            else []) }}
+  loop: "{{ __nm_settings_modify_result.results | default([]) }}"
+  loop_control:
+    label: "{{ item.item.0 }}"
+
+- name: Connections | Collect ifnames needing reapply (ethernet secondaries)
+  ansible.builtin.set_fact:
+    __nm_reapply_ifnames: >-
+      {{ __nm_reapply_ifnames | default([])
+         + ([item.item.item.item.value.ifname]
+            if (item.changed | default(false)
+                and item.item.item.item.value.ifname is defined)
+            else []) }}
+  loop: "{{ __nm_eth_secondaries_result.results | default([]) }}"
+  loop_control:
+    label: "{{ item.item.item.item.key | default('') }}"
+
+- name: Connections | Collect ifnames needing reapply (wifi secondaries)
+  ansible.builtin.set_fact:
+    __nm_reapply_ifnames: >-
+      {{ __nm_reapply_ifnames | default([])
+         + ([item.item.item.item.value.ifname]
+            if (item.changed | default(false)
+                and item.item.item.item.value.ifname is defined)
+            else []) }}
+  loop: "{{ __nm_wifi_secondaries_result.results | default([]) }}"
+  loop_control:
+    label: "{{ item.item.item.item.key | default('') }}"
+
+- name: Connections | Reapply NetworkManager devices for live changes
+  ansible.builtin.command:
+    cmd: 'nmcli device reapply {{ item }}'
+  loop: "{{ __nm_reapply_ifnames | default([]) | unique | list }}"
+  register: __nm_reapply_result
+  changed_when: false
+  failed_when:
+    - __nm_reapply_result.rc | default(0) != 0
+    - "'not active' not in (__nm_reapply_result.stderr | default(''))"
+    - "'not activated' not in (__nm_reapply_result.stderr | default(''))"
+    - "'not found' not in (__nm_reapply_result.stderr | default(''))"


### PR DESCRIPTION
## Summary

Replaces the three hardcoded per-setting check+modify+reapply pairs in `tasks/connections.yml` with a single generic pipeline driven by a `settings:` dict on each connection. Any nmcli-native key (`802-11-wireless.cloned-mac-address`, `ipv4.dhcp-send-hostname`, `connection.metered`, …) works without role changes.

The five inline reapply tasks from #154 are consolidated into one device-deduplicated accumulator reapply at the end of the play. Adds `MIGRATION.md` at the collection root as the v2.0.0 upgrade guide landing page.

## Implementation notes

- **Per-key nmcli query** (not `-f all`): NetworkManager 1.50+ omits deprecated properties from `-f all` (e.g. the legacy `ipv4.dhcp-send-hostname`, now superseded by `dhcp-send-hostname-v2`). Asking for the exact user-supplied key always works, deprecated or not.
- **Ternary-boolean normalization**: nmcli stores `*.dhcp-send-hostname` and similar ternary booleans as integers (`1`/`0`/`-1`) internally even though the CLI accepts `yes`/`no`/`default`. A lookup table normalizes both sides before comparison so the user can write either form.

## Breaking changes

Three per-connection fields are removed; migrate to the new `settings:` dict:

| Old field | New `settings:` key |
|-----------|---------------------|
| `mac: "..."` | `802-11-wireless.cloned-mac-address` (WiFi) / `802-3-ethernet.cloned-mac-address` (Ethernet) |
| `dhcp_send_hostname_ipv4: <bool>` | `ipv4.dhcp-send-hostname: "yes"`/`"no"` |
| `dhcp_send_hostname_ipv6: <bool>` | `ipv6.dhcp-send-hostname: "yes"`/`"no"` |

See [MIGRATION.md](https://github.com/marcstraube/ansible-collection-common/blob/refactor/networkmanager-generic-settings/MIGRATION.md) for before/after inventory snippets.

## Test plan

- [x] `molecule test -p networkmanager-archlinux` — full sequence green (idempotence 0 changed, verify 51 ok)
- [x] `molecule test -p networkmanager-debian-trixie` — full sequence green (idempotence 0 changed)
- [x] `molecule test -p networkmanager-rocky-9` — full sequence green (idempotence 0 changed)
- [x] `molecule test -p networkmanager-rocky-10` — full sequence green (idempotence 0 changed)
- [x] `ansible-lint` clean (production profile)
- [x] Live `--check --diff` against a real workstation with migrated inventory — `0 changed`, idempotent on existing NM state
- [ ] End-to-end live verification on a clean install before v2.0.0 release (issue stays open until done)

## Side fixes

- `.vagrant/` added to `.gitignore` (per-platform molecule machine state was untracked)
- `.secrets.baseline` re-aligned to detect-secrets v1.4.0 format (pre-commit pin is `v1.4.0` but PR #145 had written a 1.5.0 baseline; tracking issue to follow)

References #153