### PR TITLE
ci(pre-commit): bump detect-secrets to v1.5.0 to match baseline format

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -72,7 +72,7 @@ repos:
   # SECRETS DETECTION
   # =============================================================================
   - repo: https://github.com/Yelp/detect-secrets
-    rev: v1.4.0
+    rev: v1.5.0
     hooks:
       - id: detect-secrets
         name: Detect secrets

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,5 +1,5 @@
 {
-  "version": "1.4.0",
+  "version": "1.5.0",
   "plugins_used": [
     {
       "name": "ArtifactoryDetector"


### PR DESCRIPTION
## Summary

Bumps the `Yelp/detect-secrets` pre-commit hook pin from `v1.4.0` to `v1.5.0` so it matches the baseline format already in `.secrets.baseline` (regenerated with detect-secrets 1.5.0 in #145).

With the v1.4.0 pin, every `pre-commit run` against a baseline-touching change rewrote the baseline's `version` field back to `1.4.0` and exited 3 ("baseline file was updated"), failing commits without any actual secret findings.

## Changes

- `.pre-commit-config.yaml`: `Yelp/detect-secrets` rev `v1.4.0` → `v1.5.0`
- `.secrets.baseline`: `version` `1.4.0` → `1.5.0` (header only)

`pre-commit autoupdate` also flagged ansible-lint (v26.3.0 → v26.4.0) and yamllint (v1.35.1 → v1.38.0); those are deliberately out of this PR and will be addressed before the v2.0.0 release.

## Test plan

- [x] `pre-commit run detect-secrets --all-files` exits clean with no diff on `.secrets.baseline`
- [x] This commit was created normally (`-S`) with no false-positive baseline rewrite

Closes #158