### PR TITLE
ci(release-please): date (unreleased) MIGRATION.md heading on release PR

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -23,8 +23,70 @@ jobs:
           private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
 
       - uses: googleapis/release-please-action@v5.0.0
+        id: release
         with:
           token: ${{ steps.app-token.outputs.token }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
           target-branch: main
+
+      # Rewrite the `## vX.Y.Z (unreleased)` heading in MIGRATION.md to
+      # `## vX.Y.Z - YYYY-MM-DD` on the open release PR. release-please
+      # itself does not own MIGRATION.md, so without this step the
+      # heading would have to be dated by hand on every release.
+      #
+      # No-op when MIGRATION.md is absent, the heading is already dated,
+      # or the version release-please picked does not have a matching
+      # (unreleased) heading. Commit goes through the contents API so it
+      # is attributed to and verified as the release bot.
+      - name: Date (unreleased) section in MIGRATION.md
+        if: ${{ steps.release.outputs.pr }}
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          REPO: ${{ github.repository }}
+          PR_DATA: ${{ steps.release.outputs.pr }}
+        run: |
+          set -euo pipefail
+
+          PR_BRANCH=$(jq -r '.headBranchName' <<< "$PR_DATA")
+          NEW_VERSION=$(gh api "repos/${REPO}/contents/.release-please-manifest.json?ref=${PR_BRANCH}" \
+            --jq '.content' | base64 -d | jq -r '.["."]')
+          DATE=$(date -u +%Y-%m-%d)
+
+          echo "Release PR branch: ${PR_BRANCH}"
+          echo "Release version:   v${NEW_VERSION}"
+          echo "Date stamp:        ${DATE}"
+
+          # Pull MIGRATION.md from the PR branch (404 here means no
+          # MIGRATION.md at this revision — treat as a no-op).
+          if ! RESP=$(gh api "repos/${REPO}/contents/MIGRATION.md?ref=${PR_BRANCH}" 2>/dev/null); then
+            echo "MIGRATION.md not present on ${PR_BRANCH} — nothing to do."
+            exit 0
+          fi
+
+          OLD_CONTENT=$(jq -r '.content' <<< "$RESP" | base64 -d)
+          FILE_SHA=$(jq -r '.sha' <<< "$RESP")
+
+          PATTERN="## v${NEW_VERSION} (unreleased)"
+          REPLACEMENT="## v${NEW_VERSION} - ${DATE}"
+
+          if ! grep -Fq "$PATTERN" <<< "$OLD_CONTENT"; then
+            echo "No '${PATTERN}' heading in MIGRATION.md — already dated or version mismatch."
+            exit 0
+          fi
+
+          NEW_CONTENT=$(awk -v p="$PATTERN" -v r="$REPLACEMENT" \
+            '{if ($0 == p) print r; else print}' <<< "$OLD_CONTENT")
+
+          if [ "$OLD_CONTENT" = "$NEW_CONTENT" ]; then
+            echo "Rewrite produced identical content — nothing to commit."
+            exit 0
+          fi
+
+          NEW_B64=$(printf '%s\n' "$NEW_CONTENT" | base64 -w 0)
+
+          gh api -X PUT "repos/${REPO}/contents/MIGRATION.md" \
+            -f message="docs: date v${NEW_VERSION} migration section" \
+            -f content="${NEW_B64}" \
+            -f sha="${FILE_SHA}" \
+            -f branch="${PR_BRANCH}"


### PR DESCRIPTION
## Summary

Adds a step to `.github/workflows/release-please.yml` that dates the `## vX.Y.Z (unreleased)` heading in `MIGRATION.md` whenever release-please opens or updates a release PR.

Without this, the heading must be edited by hand on every release — easy to forget. The step runs against the release PR branch, uses the GitHub contents API (so the commit is attributed to the same release bot release-please uses), and is a no-op when:

- `MIGRATION.md` does not exist on the PR branch
- The `## vX.Y.Z (unreleased)` heading is not present (already dated or version mismatch)
- The rewrite produces identical content (idempotent)

## Implementation notes

- Uses the existing release-please action `pr` output to detect when a release PR has been opened/updated.
- Pulls the version from `.release-please-manifest.json` on the PR branch (the only authoritative source for the version release-please picked).
- Uses `awk` for exact-line replacement so the heading is rewritten only when it matches verbatim (no partial-match risk).
- Commits via `gh api -X PUT /contents/MIGRATION.md` so the change is verified under the release-bot app identity, consistent with how release-please itself commits.

## Test plan

- [x] `yamllint`, `ansible-lint`, and the rest of the pre-commit suite pass on the workflow file
- [x] Smoke-tested the `awk` rewrite locally against the actual `MIGRATION.md`: produces the expected single-line diff
- [x] No-op verified locally for version mismatch (`grep -Fq` returns no match → `exit 0` path)
- [x] No-op verified locally for already-dated content (second pass produces identical output)
- [ ] End-to-end verification: only reachable at the next release-please trigger; the workflow change is logic-only and small enough that the live run will be the final check

Closes #161