### PR TITLE
fix(aide): empty package on Arch (Layer-1 no-op) instead of continue-on-error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -251,12 +251,6 @@ jobs:
     runs-on: ubuntu-latest
     needs: [lint, markdown-lint, yaml-lint, detect-changes]
     if: needs.detect-changes.outputs.has_roles == 'true'
-    # AIDE 0.19.3 (latest upstream) fails to build against nettle 4.0 due to
-    # a digest() API break — see https://github.com/aide/aide/issues/218.
-    # Upstream aide is in maintenance mode, no fix released. Allow only the
-    # aide matrix entry to fail so unrelated regressions still gate CI.
-    # Revert this to false once upstream lands a fix.
-    continue-on-error: ${{ matrix.role == 'aide' }}
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.detect-changes.outputs.matrix) }}

--- a/roles/aide/README.md
+++ b/roles/aide/README.md
@@ -15,22 +15,28 @@ EL 10) automatically through OS-specific variable files.
 
 ## Supported Platforms
 
-| Platform                  | Notes                        |
-|---------------------------|------------------------------|
-| Arch Linux                | AUR, requires `aur_builder`¹ |
-| Debian Trixie             | Uses `_aide` user            |
-| EL 9 (Rocky, Alma, RHEL)  | AIDE 0.16, legacy directives |
-| EL 10 (Rocky, Alma, RHEL) | AIDE 0.18+                   |
+| Platform                  | Notes                                |
+|---------------------------|--------------------------------------|
+| Arch Linux                | Currently no-op (see below)¹         |
+| Debian Trixie             | Uses `_aide` user                    |
+| EL 9 (Rocky, Alma, RHEL)  | AIDE 0.16, legacy directives         |
+| EL 10 (Rocky, Alma, RHEL) | AIDE 0.18+                           |
 
 Other distributions in the same os_family (EndeavourOS, Manjaro, Ubuntu, Mint,
 Fedora) should work but are not actively tested. Use distro-specific vars
 overrides if needed.
 
-¹ As of 2026-05, AIDE 0.19.3 fails to build on Arch Linux against the new
-`nettle 4.0` due to a `digest()` API break in `src/md.c`. Existing
-installations remain functional, but fresh AUR builds abort. Upstream:
-[aide/aide#218](https://github.com/aide/aide/issues/218). Re-enable tracked
-in #126.
+¹ As of 2026-05, AIDE 0.19.3 fails to build on Arch Linux against `nettle 4.0`
+due to a `digest()` API break in `src/md.c`. Upstream AIDE is in maintenance
+mode and no fix has been released. Upstream tracking:
+[aide/aide#218](https://github.com/aide/aide/issues/218).
+
+The role is a Layer-1 no-op on Arch — `__aide_package` is empty in
+`vars/Archlinux.yml`, `main.yml` guards downstream tasks on a non-empty
+package, and the install task therefore skips. Existing AIDE installations
+remain functional (the role only installs/reconciles; it does not uninstall).
+The drift-detection workflow (#169) re-checks AUR availability on a schedule
+and opens an issue when the package becomes installable again.
 
 ## Role Variables
 

--- a/roles/aide/molecule/default/verify.yml
+++ b/roles/aide/molecule/default/verify.yml
@@ -4,6 +4,21 @@
   gather_facts: true
 
   tasks:
+    - name: Verify | Load OS-specific variables
+      ansible.builtin.include_vars: '{{ item }}'
+      with_first_found:
+        - files:
+            - '{{ ansible_facts["distribution"] }}-{{ ansible_facts["distribution_major_version"] }}.yml'
+            - '{{ ansible_facts["os_family"] }}-{{ ansible_facts["distribution_major_version"] }}.yml'
+            - '{{ ansible_facts["distribution"] }}.yml'
+            - '{{ ansible_facts["os_family"] }}.yml'
+          paths:
+            - '../../vars'
+
+    - name: Verify | Skip host when AIDE is a Layer-1 no-op on this platform
+      ansible.builtin.meta: end_host
+      when: __aide_package | default('') | length == 0
+
     #
     # Package and Binary Verification
     #

--- a/roles/aide/tasks/install.yml
+++ b/roles/aide/tasks/install.yml
@@ -27,7 +27,9 @@
     state: present
   retries: 3
   delay: 5
-  when: not (__aide_aur | bool)
+  when:
+    - not (__aide_aur | bool)
+    - __aide_package | length > 0
 
 - name: Install | Ensure AIDE directories exist
   ansible.builtin.file:

--- a/roles/aide/tasks/main.yml
+++ b/roles/aide/tasks/main.yml
@@ -31,7 +31,9 @@
 
 - name: Main | Import install tasks
   ansible.builtin.import_tasks: install.yml
-  when: aide_enabled | bool
+  when:
+    - aide_enabled | bool
+    - __aide_package | default('') | length > 0
   tags:
     - aide
     - aide:install
@@ -43,28 +45,36 @@
       tags:
         - aide
         - aide:install
-  when: aide_enabled | bool
+  when:
+    - aide_enabled | bool
+    - __aide_package | default('') | length > 0
   tags:
     - aide
     - aide:install
 
 - name: Main | Import configure tasks
   ansible.builtin.import_tasks: configure.yml
-  when: aide_enabled | bool
+  when:
+    - aide_enabled | bool
+    - __aide_package | default('') | length > 0
   tags:
     - aide
     - aide:configure
 
 - name: Main | Import database tasks
   ansible.builtin.import_tasks: database.yml
-  when: aide_enabled | bool
+  when:
+    - aide_enabled | bool
+    - __aide_package | default('') | length > 0
   tags:
     - aide
     - aide:database
 
 - name: Main | Import schedule tasks
   ansible.builtin.import_tasks: schedule.yml
-  when: aide_enabled | bool
+  when:
+    - aide_enabled | bool
+    - __aide_package | default('') | length > 0
   tags:
     - aide
     - aide:schedule

--- a/roles/aide/vars/Archlinux.yml
+++ b/roles/aide/vars/Archlinux.yml
@@ -1,8 +1,18 @@
 ---
-__aide_package: 'aide'
+# AIDE 0.19.3 fails to build on Arch Linux against nettle 4.0 due to a
+# digest() API break in src/md.c (since ~2026-05-11). Upstream AIDE is
+# in maintenance mode; no fix released. See:
+#   https://github.com/aide/aide/issues/218
+# Layer-1 no-op: empty package + AUR path disabled. The role's main.yml
+# guards downstream tasks on `__aide_package | length > 0`, so the
+# whole role becomes a no-op on Arch until upstream ships a nettle-4.0
+# compatible release. Re-availability tracked by the drift-detection
+# workflow (#169).
+__aide_package: ''
 
-# AIDE is only available in the AUR on Arch Linux
-__aide_aur: true
+# AIDE is only available in the AUR on Arch Linux — AUR path disabled
+# while the PKGBUILD is unbuildable (see above).
+__aide_aur: false
 
 __aide_aur_packages:
   aide:


### PR DESCRIPTION
## Summary

AIDE 0.19.3 fails to build on Arch since nettle 4.0 landed (digest() API break, https://github.com/aide/aide/issues/218). Upstream is in maintenance mode. Previous handling — `continue-on-error: true` on the aide CI matrix entry — hid the failure in CI but did not protect end users: running the role on a fresh Arch host still aborted at the AUR install task.

Migrate to the project's standard Layer-1 pattern:

- `roles/aide/vars/Archlinux.yml`: `__aide_package: ''` and `__aide_aur: false`, with a comment linking to upstream issue 218.
- `roles/aide/tasks/main.yml`: gate every import (install / btrfs / configure / database / schedule) on `__aide_package | length > 0`.
- `roles/aide/tasks/install.yml`: add the same gate to the official-repos install task (defensive — the AUR-path gate already covers Arch).
- `roles/aide/molecule/default/verify.yml`: `meta: end_host` early when the package is empty, so the 40 verify assertions run only where AIDE is actually installable.
- `roles/aide/README.md`: Supported Platforms row reflects no-op behavior; footnote points at the drift workflow (#169) for re-availability tracking.
- `.github/workflows/ci.yml`: drop `continue-on-error: ${{ matrix.role == 'aide' }}` — the CI job is expected to be green now.

End users on Arch get a clean no-op rather than a crash; Debian / Rocky paths are unchanged.

## Test plan

- [x] ansible-lint production profile clean
- [x] yamllint clean
- [x] markdownlint clean
- [x] molecule test on Arch local — 1 scenario successful
- [x] CI green on all 4 platforms (Arch, Debian Trixie, Rocky 9, Rocky 10) — Arch must now actually pass, the other three must continue passing

Closes #168