### PR TITLE
fix(ci): provision aur_builder user in drift probe before sudo

### DIFF
--- a/.github/workflows/drift-detection.yml
+++ b/.github/workflows/drift-detection.yml
@@ -88,11 +88,16 @@ jobs:
                 # AUR probe: clone + makepkg --syncdeps. --skippgpcheck
                 # avoids per-package PGP setup. The build only needs to
                 # *complete* — we discard the artifact.
-                # The marcstraube/archlinux-ansible image already ships
-                # an aur_builder user wired up for sudo-less makepkg.
+                # The Arch image does not ship a build user; provision
+                # one inline (makepkg refuses to run as root). The
+                # wheel-group sudoers entry lets makepkg --syncdeps
+                # install build-time deps via pacman.  # pragma: allowlist secret
                 PROBE='set -euo pipefail
                 pacman -Sy --noconfirm >/dev/null
-                pacman -S --needed --noconfirm git base-devel >/dev/null
+                pacman -S --needed --noconfirm git base-devel sudo >/dev/null
+                id aur_builder >/dev/null 2>&1 || useradd -m -G wheel aur_builder
+                printf "%%wheel ALL=(ALL) NOPASSWD: ALL\n" > /etc/sudoers.d/wheel-nopw  # pragma: allowlist secret
+                chmod 0440 /etc/sudoers.d/wheel-nopw
                 rm -rf /tmp/aur-probe
                 sudo -u aur_builder -- bash -c "
                   git clone --depth=1 https://aur.archlinux.org/$PKG.git /tmp/aur-probe &&

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -112,6 +112,15 @@
     }
   ],
   "results": {
+    ".github/workflows/drift-detection.yml": [
+      {
+        "type": "Secret Keyword",
+        "filename": ".github/workflows/drift-detection.yml",
+        "hashed_secret": "b91eb3b9b8183ecd9790464b2831fdc42df58b16",
+        "is_verified": false,
+        "line_number": 83
+      }
+    ],
     "release-please-config.json": [
       {
         "type": "Hex High Entropy String",
@@ -308,5 +317,5 @@
       }
     ]
   },
-  "generated_at": "2026-05-20T18:01:19Z"
+  "generated_at": "2026-05-22T06:41:20Z"
 }


### PR DESCRIPTION
## Summary

Follow-up fix on PR #171's drift-detection workflow. The first manual `workflow_dispatch` run (26272388482) exposed that the AUR probe assumed an `aur_builder` user pre-existed in `marcstraube/archlinux-ansible:latest` — it does not (the user is created by molecule's `prepare.yml`, not the image). The probe step exited with `sudo: unknown user aur_builder` and never attempted `makepkg`. Probe step exited 0 via `continue-on-error`, recorded "unavailable", and the workflow looked green — but it was a *false negative*: when AIDE becomes buildable upstream again, the probe would still report "unavailable" because sudo fails first.

## Fix

Provision the build user inline in the probe script:

- `useradd -m -G wheel aur_builder` (idempotent — re-runs are no-ops)
- `printf '%wheel ALL=(ALL) NOPASSWD: ALL\n' > /etc/sudoers.d/wheel-nopw` so `makepkg --syncdeps` can install build-time deps via pacman
- `pacman -S sudo` added to the bootstrap step

The sudoers comment + write line both trigger detect-secrets' keyword detector; inline `# pragma: allowlist secret` plus the baseline entry cover both.

## Test plan

- [x] pre-commit clean (`.secrets.baseline` updated)
- [ ] post-merge `gh workflow run drift-detection.yml` — confirm AIDE/Arch probe actually attempts `makepkg`, build fails on the nettle-4.0 issue, probe records "unavailable", no issue opened