### PR TITLE
chore!: bump ansible-core minimum to 2.19 + forward-compat to 2.21

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -5,7 +5,7 @@
 Shared Ansible roles for all system types (desktops, laptops, servers).
 Multi-OS support: Arch Linux (primary), Debian Trixie, Rocky Linux 9/10.
 
-## Coding Standards (ansible-core 2.20+)
+## Coding Standards (ansible-core 2.19+)
 
 - **Facts:** `ansible_facts['os_family']` — never `ansible_os_family` (deprecated)
 - **Modules:** Always FQCN (`ansible.builtin.*`, `community.general.*`, `kewlfft.aur.*`)

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -5,7 +5,7 @@
 Shared Ansible roles for all system types (desktops, laptops, servers).
 Multi-OS support: Arch Linux (primary), Debian Trixie, Rocky Linux 9/10.
 
-## Coding Standards (ansible-core 2.17+)
+## Coding Standards (ansible-core 2.20+)
 
 - **Facts:** `ansible_facts['os_family']` — never `ansible_os_family` (deprecated)
 - **Modules:** Always FQCN (`ansible.builtin.*`, `community.general.*`, `kewlfft.aur.*`)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,13 +74,13 @@ jobs:
         run: yamllint -c .yamllint .
 
   # =============================================================================
-  # MOLECULE FORWARD-COMPATIBILITY (ansible-core 2.20, representative subset)
+  # MOLECULE FORWARD-COMPATIBILITY (ansible-core 2.21, representative subset)
   # Tests a diverse subset of roles on latest ansible-core to catch
   # deprecations and breaking changes early.
   # Only runs on push to main — not needed for every PR.
   # =============================================================================
   molecule-compat:
-    name: Compat ${{ matrix.role }} (ansible-2.20)
+    name: Compat ${{ matrix.role }} (ansible-2.21)
     runs-on: ubuntu-latest
     if: github.event_name == 'push'
     needs: [lint, markdown-lint, yaml-lint]
@@ -104,7 +104,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pip install "ansible-core~=2.20.0" \
+          pip install "ansible-core~=2.21.0" \
                       molecule \
                       molecule-plugins[podman] \
                       passlib

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ and instructions for contributing to this collection.
 ### Prerequisites
 
 - Python 3.13+
-- ansible-core >= 2.20
+- ansible-core >= 2.19
 - Podman (for Molecule tests)
 - Git
 - pre-commit

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ and instructions for contributing to this collection.
 ### Prerequisites
 
 - Python 3.13+
-- ansible-core >= 2.17
+- ansible-core >= 2.20
 - Podman (for Molecule tests)
 - Git
 - pre-commit

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -7,15 +7,21 @@ snippets. For the full list of changes per release, see
 
 ## v2.0.0 (unreleased)
 
-### Minimum ansible-core bumped from 2.17 to 2.20 (#173)
+### Minimum ansible-core bumped from 2.17 to 2.19 (#173)
 
 v2.0.0 unifies and raises the supported ansible-core floor. Previous
 v1.x state was inconsistent across surfaces (`meta/runtime.yml` declared
 `>=2.15.0` while READMEs and `galaxy.yml` claimed 2.17+); v2.0.0 aligns
-everything on **2.20.0** and bumps the CI forward-compat job to track
-2.21 one version ahead.
+everything on **2.19.0** and bumps the CI forward-compat job to track
+2.21 (latest stable) so it stays two versions above the floor.
 
-The 2.17 → 2.20 step does not change the install path for users on
+The floor stops at 2.19 rather than 2.20 because ansible-lint v26.4.0
+(latest at v2.0.0 release time) does not yet accept `>=2.20.0` in
+`meta/runtime.yml` — its `meta-runtime` rule only knows about 2.15
+through 2.19. Once ansible-lint catches up, a follow-up minor release
+will bump the floor to 2.20.
+
+The 2.17 → 2.19 step does not change the install path for users on
 RHEL 9 or Debian Bookworm — those distros' system `ansible-core` is
 older than 2.17 anyway, so a `pip install --user ansible-core` (or
 `pipx`) is the established workflow there. The bump just makes the
@@ -23,18 +29,18 @@ actually-supported floor honest.
 
 #### Required action
 
-Upgrade `ansible-core` to 2.20 or newer before installing this
+Upgrade `ansible-core` to 2.19 or newer before installing this
 collection's v2.0.0 release:
 
 ```bash
 # pip (system Python or venv)
-pip install --upgrade 'ansible-core>=2.20,<2.22'
+pip install --upgrade 'ansible-core>=2.19,<2.22'
 
 # pipx
 pipx upgrade --pip-args='--upgrade' ansible-core
 ```
 
-Distro packages currently shipping `ansible-core >= 2.20`:
+Distro packages currently shipping `ansible-core >= 2.19`:
 
 - Arch Linux: `extra/ansible-core`
 - Debian Trixie: `main/ansible-core`
@@ -44,7 +50,7 @@ Distro packages currently shipping `ansible-core >= 2.20`:
 If you pin `ansible-core` in a requirements file, set:
 
 ```text
-ansible-core>=2.20,<2.22
+ansible-core>=2.19,<2.22
 ```
 
 ### Deprecated v1.x variable renames removed (#60)

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -7,6 +7,46 @@ snippets. For the full list of changes per release, see
 
 ## v2.0.0 (unreleased)
 
+### Minimum ansible-core bumped from 2.17 to 2.20 (#173)
+
+v2.0.0 unifies and raises the supported ansible-core floor. Previous
+v1.x state was inconsistent across surfaces (`meta/runtime.yml` declared
+`>=2.15.0` while READMEs and `galaxy.yml` claimed 2.17+); v2.0.0 aligns
+everything on **2.20.0** and bumps the CI forward-compat job to track
+2.21 one version ahead.
+
+The 2.17 → 2.20 step does not change the install path for users on
+RHEL 9 or Debian Bookworm — those distros' system `ansible-core` is
+older than 2.17 anyway, so a `pip install --user ansible-core` (or
+`pipx`) is the established workflow there. The bump just makes the
+actually-supported floor honest.
+
+#### Required action
+
+Upgrade `ansible-core` to 2.20 or newer before installing this
+collection's v2.0.0 release:
+
+```bash
+# pip (system Python or venv)
+pip install --upgrade 'ansible-core>=2.20,<2.22'
+
+# pipx
+pipx upgrade --pip-args='--upgrade' ansible-core
+```
+
+Distro packages currently shipping `ansible-core >= 2.20`:
+
+- Arch Linux: `extra/ansible-core`
+- Debian Trixie: `main/ansible-core`
+- EPEL 10: `epel/ansible-core`
+- Fedora 41+: `fedora/ansible-core`
+
+If you pin `ansible-core` in a requirements file, set:
+
+```text
+ansible-core>=2.20,<2.22
+```
+
 ### Deprecated v1.x variable renames removed (#60)
 
 27 roles had v1.x variable names kept as deprecated aliases throughout

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ user management, editors, and more.
 
 ## Requirements
 
-- ansible-core >= 2.20
+- ansible-core >= 2.19
 
 ## Included Roles
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ user management, editors, and more.
 
 ## Requirements
 
-- ansible-core >= 2.17
+- ansible-core >= 2.20
 
 ## Included Roles
 

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -9,7 +9,7 @@ description: >-
   42 shared Ansible roles for multi-OS infrastructure management. Covers base
   system, security hardening, networking, package management, user management,
   editors, and more. Supports Arch Linux, Debian Trixie, and Rocky Linux 9/10.
-  Built for ansible-core 2.20+.
+  Built for ansible-core 2.19+.
 license_file: LICENSE
 tags:
   - linux

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -6,10 +6,10 @@ readme: README.md
 authors:
   - Marc Straube <email@marcstraube.de>
 description: >-
-  37 shared Ansible roles for multi-OS infrastructure management. Covers base
+  42 shared Ansible roles for multi-OS infrastructure management. Covers base
   system, security hardening, networking, package management, user management,
   editors, and more. Supports Arch Linux, Debian Trixie, and Rocky Linux 9/10.
-  Built for ansible-core 2.17+.
+  Built for ansible-core 2.20+.
 license_file: LICENSE
 tags:
   - linux

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,5 +1,5 @@
 ---
-requires_ansible: '>=2.20.0'
+requires_ansible: '>=2.19.0'
 action_groups:
   marcstraube:
     - community.general.*

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,5 +1,5 @@
 ---
-requires_ansible: '>=2.15.0'
+requires_ansible: '>=2.20.0'
 action_groups:
   marcstraube:
     - community.general.*

--- a/roles/aide/meta/main.yml
+++ b/roles/aide/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   author: Marc Straube
   description: Configure AIDE file integrity monitoring
   license: MIT
-  min_ansible_version: '2.17'
+  min_ansible_version: '2.20'
 
   platforms:
     - name: ArchLinux

--- a/roles/aide/meta/main.yml
+++ b/roles/aide/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   author: Marc Straube
   description: Configure AIDE file integrity monitoring
   license: MIT
-  min_ansible_version: '2.20'
+  min_ansible_version: '2.19'
 
   platforms:
     - name: ArchLinux

--- a/roles/ansible/meta/main.yml
+++ b/roles/ansible/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   author: Marc Straube
   description: Install Ansible, Molecule testing framework, container drivers and linting tools
   license: MIT
-  min_ansible_version: '2.20'
+  min_ansible_version: '2.19'
 
   platforms:
     - name: ArchLinux

--- a/roles/ansible/meta/main.yml
+++ b/roles/ansible/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   author: Marc Straube
   description: Install Ansible, Molecule testing framework, container drivers and linting tools
   license: MIT
-  min_ansible_version: '2.17'
+  min_ansible_version: '2.20'
 
   platforms:
     - name: ArchLinux

--- a/roles/apparmor/meta/main.yml
+++ b/roles/apparmor/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   author: Marc Straube
   description: Configure AppArmor mandatory access control
   license: MIT
-  min_ansible_version: '2.17'
+  min_ansible_version: '2.20'
 
   platforms:
     - name: ArchLinux

--- a/roles/apparmor/meta/main.yml
+++ b/roles/apparmor/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   author: Marc Straube
   description: Configure AppArmor mandatory access control
   license: MIT
-  min_ansible_version: '2.20'
+  min_ansible_version: '2.19'
 
   platforms:
     - name: ArchLinux

--- a/roles/auditd/meta/main.yml
+++ b/roles/auditd/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   author: Marc Straube
   description: Configure auditd for system auditing and compliance
   license: MIT
-  min_ansible_version: '2.17'
+  min_ansible_version: '2.20'
 
   platforms:
     - name: ArchLinux

--- a/roles/auditd/meta/main.yml
+++ b/roles/auditd/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   author: Marc Straube
   description: Configure auditd for system auditing and compliance
   license: MIT
-  min_ansible_version: '2.20'
+  min_ansible_version: '2.19'
 
   platforms:
     - name: ArchLinux

--- a/roles/avahi/meta/main.yml
+++ b/roles/avahi/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   author: Marc Straube
   description: Configure Avahi mDNS/DNS-SD service discovery
   license: MIT
-  min_ansible_version: '2.17'
+  min_ansible_version: '2.20'
 
   platforms:
     - name: ArchLinux

--- a/roles/avahi/meta/main.yml
+++ b/roles/avahi/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   author: Marc Straube
   description: Configure Avahi mDNS/DNS-SD service discovery
   license: MIT
-  min_ansible_version: '2.20'
+  min_ansible_version: '2.19'
 
   platforms:
     - name: ArchLinux

--- a/roles/base/meta/main.yml
+++ b/roles/base/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   author: Marc Straube
   description: Base system configuration (locale, timezone, hostname, keyboard, kernel, bootloader, systemd)
   license: MIT
-  min_ansible_version: '2.20'
+  min_ansible_version: '2.19'
 
   platforms:
     - name: ArchLinux

--- a/roles/base/meta/main.yml
+++ b/roles/base/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   author: Marc Straube
   description: Base system configuration (locale, timezone, hostname, keyboard, kernel, bootloader, systemd)
   license: MIT
-  min_ansible_version: '2.17'
+  min_ansible_version: '2.20'
 
   platforms:
     - name: ArchLinux

--- a/roles/chrony/meta/main.yml
+++ b/roles/chrony/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   author: Marc Straube
   description: Configure chrony NTP time synchronization
   license: MIT
-  min_ansible_version: '2.17'
+  min_ansible_version: '2.20'
 
   platforms:
     - name: ArchLinux

--- a/roles/chrony/meta/main.yml
+++ b/roles/chrony/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   author: Marc Straube
   description: Configure chrony NTP time synchronization
   license: MIT
-  min_ansible_version: '2.20'
+  min_ansible_version: '2.19'
 
   platforms:
     - name: ArchLinux

--- a/roles/clamav/meta/main.yml
+++ b/roles/clamav/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   author: Marc Straube
   description: Ansible role for ClamAV antivirus (clamd, freshclam, milter)
   license: MIT
-  min_ansible_version: '2.17'
+  min_ansible_version: '2.20'
 
   platforms:
     - name: ArchLinux

--- a/roles/clamav/meta/main.yml
+++ b/roles/clamav/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   author: Marc Straube
   description: Ansible role for ClamAV antivirus (clamd, freshclam, milter)
   license: MIT
-  min_ansible_version: '2.20'
+  min_ansible_version: '2.19'
 
   platforms:
     - name: ArchLinux

--- a/roles/docker/meta/main.yml
+++ b/roles/docker/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   author: Marc Straube
   description: Install and configure Docker CE container runtime with daemon management
   license: MIT
-  min_ansible_version: '2.20'
+  min_ansible_version: '2.19'
 
   platforms:
     - name: ArchLinux

--- a/roles/docker/meta/main.yml
+++ b/roles/docker/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   author: Marc Straube
   description: Install and configure Docker CE container runtime with daemon management
   license: MIT
-  min_ansible_version: '2.17'
+  min_ansible_version: '2.20'
 
   platforms:
     - name: ArchLinux

--- a/roles/editors/meta/main.yml
+++ b/roles/editors/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   author: Marc Straube
   description: Install and configure text editors (nano, vim, neovim)
   license: MIT
-  min_ansible_version: '2.17'
+  min_ansible_version: '2.20'
 
   platforms:
     - name: ArchLinux

--- a/roles/editors/meta/main.yml
+++ b/roles/editors/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   author: Marc Straube
   description: Install and configure text editors (nano, vim, neovim)
   license: MIT
-  min_ansible_version: '2.20'
+  min_ansible_version: '2.19'
 
   platforms:
     - name: ArchLinux

--- a/roles/energy_management/meta/main.yml
+++ b/roles/energy_management/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   author: Marc Straube
   description: Energy management for desktops and laptops (logind, sleep, PPD/TLP, battery, backlight)
   license: MIT
-  min_ansible_version: '2.20'
+  min_ansible_version: '2.19'
 
   platforms:
     - name: ArchLinux

--- a/roles/energy_management/meta/main.yml
+++ b/roles/energy_management/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   author: Marc Straube
   description: Energy management for desktops and laptops (logind, sleep, PPD/TLP, battery, backlight)
   license: MIT
-  min_ansible_version: '2.17'
+  min_ansible_version: '2.20'
 
   platforms:
     - name: ArchLinux

--- a/roles/fail2ban/meta/main.yml
+++ b/roles/fail2ban/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   author: Marc Straube
   description: Ansible role for Fail2ban intrusion prevention
   license: MIT
-  min_ansible_version: '2.17'
+  min_ansible_version: '2.20'
 
   platforms:
     - name: ArchLinux

--- a/roles/fail2ban/meta/main.yml
+++ b/roles/fail2ban/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   author: Marc Straube
   description: Ansible role for Fail2ban intrusion prevention
   license: MIT
-  min_ansible_version: '2.20'
+  min_ansible_version: '2.19'
 
   platforms:
     - name: ArchLinux

--- a/roles/firejail/meta/main.yml
+++ b/roles/firejail/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   author: Marc Straube
   description: Configure Firejail application sandboxing
   license: MIT
-  min_ansible_version: '2.17'
+  min_ansible_version: '2.20'
   platforms:
     - name: ArchLinux
       versions:

--- a/roles/firejail/meta/main.yml
+++ b/roles/firejail/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   author: Marc Straube
   description: Configure Firejail application sandboxing
   license: MIT
-  min_ansible_version: '2.20'
+  min_ansible_version: '2.19'
   platforms:
     - name: ArchLinux
       versions:

--- a/roles/firewalld/meta/main.yml
+++ b/roles/firewalld/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   author: Marc Straube
   description: Configure firewalld zones, services, ports, and rich rules
   license: MIT
-  min_ansible_version: '2.20'
+  min_ansible_version: '2.19'
 
   platforms:
     - name: ArchLinux

--- a/roles/firewalld/meta/main.yml
+++ b/roles/firewalld/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   author: Marc Straube
   description: Configure firewalld zones, services, ports, and rich rules
   license: MIT
-  min_ansible_version: '2.17'
+  min_ansible_version: '2.20'
 
   platforms:
     - name: ArchLinux

--- a/roles/fonts/meta/main.yml
+++ b/roles/fonts/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   author: Marc Straube
   description: Install and configure system fonts
   license: MIT
-  min_ansible_version: '2.17'
+  min_ansible_version: '2.20'
 
   platforms:
     - name: ArchLinux

--- a/roles/fonts/meta/main.yml
+++ b/roles/fonts/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   author: Marc Straube
   description: Install and configure system fonts
   license: MIT
-  min_ansible_version: '2.20'
+  min_ansible_version: '2.19'
 
   platforms:
     - name: ArchLinux

--- a/roles/gnupg/meta/main.yml
+++ b/roles/gnupg/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   description: Configure GnuPG for encryption and signing
   license: MIT
 
-  min_ansible_version: '2.17'
+  min_ansible_version: '2.20'
 
   platforms:
     - name: ArchLinux

--- a/roles/gnupg/meta/main.yml
+++ b/roles/gnupg/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   description: Configure GnuPG for encryption and signing
   license: MIT
 
-  min_ansible_version: '2.20'
+  min_ansible_version: '2.19'
 
   platforms:
     - name: ArchLinux

--- a/roles/graphics/meta/main.yml
+++ b/roles/graphics/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   author: Marc Straube
   description: Install GPU drivers, Vulkan, video acceleration, and hybrid graphics
   license: MIT
-  min_ansible_version: '2.20'
+  min_ansible_version: '2.19'
 
   platforms:
     - name: ArchLinux

--- a/roles/graphics/meta/main.yml
+++ b/roles/graphics/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   author: Marc Straube
   description: Install GPU drivers, Vulkan, video acceleration, and hybrid graphics
   license: MIT
-  min_ansible_version: '2.17'
+  min_ansible_version: '2.20'
 
   platforms:
     - name: ArchLinux

--- a/roles/hardening/meta/main.yml
+++ b/roles/hardening/meta/main.yml
@@ -6,7 +6,7 @@ galaxy_info:
     and filesystem mount hardening
   license: MIT
 
-  min_ansible_version: '2.20'
+  min_ansible_version: '2.19'
 
   platforms:
     - name: ArchLinux

--- a/roles/hardening/meta/main.yml
+++ b/roles/hardening/meta/main.yml
@@ -6,7 +6,7 @@ galaxy_info:
     and filesystem mount hardening
   license: MIT
 
-  min_ansible_version: '2.17'
+  min_ansible_version: '2.20'
 
   platforms:
     - name: ArchLinux

--- a/roles/hardware_tokens/meta/main.yml
+++ b/roles/hardware_tokens/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   description: Configure hardware security tokens (NitroKey, YubiKey, FIDO2, smart cards)
   license: MIT
 
-  min_ansible_version: '2.17'
+  min_ansible_version: '2.20'
 
   platforms:
     - name: ArchLinux

--- a/roles/hardware_tokens/meta/main.yml
+++ b/roles/hardware_tokens/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   description: Configure hardware security tokens (NitroKey, YubiKey, FIDO2, smart cards)
   license: MIT
 
-  min_ansible_version: '2.20'
+  min_ansible_version: '2.19'
 
   platforms:
     - name: ArchLinux

--- a/roles/logrotate/meta/main.yml
+++ b/roles/logrotate/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   description: Manage logrotate global configuration, custom drop-in configs, and systemd timer
   license: MIT
 
-  min_ansible_version: '2.20'
+  min_ansible_version: '2.19'
 
   platforms:
     - name: ArchLinux

--- a/roles/logrotate/meta/main.yml
+++ b/roles/logrotate/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   description: Manage logrotate global configuration, custom drop-in configs, and systemd timer
   license: MIT
 
-  min_ansible_version: '2.17'
+  min_ansible_version: '2.20'
 
   platforms:
     - name: ArchLinux

--- a/roles/lynis/meta/main.yml
+++ b/roles/lynis/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   author: Marc Straube
   description: Install and configure Lynis for automated security auditing
   license: MIT
-  min_ansible_version: '2.17'
+  min_ansible_version: '2.20'
 
   platforms:
     - name: ArchLinux

--- a/roles/lynis/meta/main.yml
+++ b/roles/lynis/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   author: Marc Straube
   description: Install and configure Lynis for automated security auditing
   license: MIT
-  min_ansible_version: '2.20'
+  min_ansible_version: '2.19'
 
   platforms:
     - name: ArchLinux

--- a/roles/multiplexer/meta/main.yml
+++ b/roles/multiplexer/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   author: Marc Straube
   description: Install and configure terminal multiplexers (tmux, zellij)
   license: MIT
-  min_ansible_version: '2.17'
+  min_ansible_version: '2.20'
 
   platforms:
     - name: ArchLinux

--- a/roles/multiplexer/meta/main.yml
+++ b/roles/multiplexer/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   author: Marc Straube
   description: Install and configure terminal multiplexers (tmux, zellij)
   license: MIT
-  min_ansible_version: '2.20'
+  min_ansible_version: '2.19'
 
   platforms:
     - name: ArchLinux

--- a/roles/networkmanager/meta/main.yml
+++ b/roles/networkmanager/meta/main.yml
@@ -5,7 +5,7 @@ galaxy_info:
     Manage NetworkManager daemon configuration, connections,
     and dispatcher scripts
   license: MIT
-  min_ansible_version: '2.20'
+  min_ansible_version: '2.19'
   platforms:
     - name: ArchLinux
       versions:

--- a/roles/networkmanager/meta/main.yml
+++ b/roles/networkmanager/meta/main.yml
@@ -5,7 +5,7 @@ galaxy_info:
     Manage NetworkManager daemon configuration, connections,
     and dispatcher scripts
   license: MIT
-  min_ansible_version: '2.17'
+  min_ansible_version: '2.20'
   platforms:
     - name: ArchLinux
       versions:

--- a/roles/nodejs/meta/main.yml
+++ b/roles/nodejs/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   author: Marc Straube
   description: Install and configure Node.js runtime via system packages, NodeSource repository, or nvm
   license: MIT
-  min_ansible_version: '2.17'
+  min_ansible_version: '2.20'
 
   platforms:
     - name: ArchLinux

--- a/roles/nodejs/meta/main.yml
+++ b/roles/nodejs/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   author: Marc Straube
   description: Install and configure Node.js runtime via system packages, NodeSource repository, or nvm
   license: MIT
-  min_ansible_version: '2.20'
+  min_ansible_version: '2.19'
 
   platforms:
     - name: ArchLinux

--- a/roles/openssh/meta/main.yml
+++ b/roles/openssh/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   author: Marc Straube
   description: Install and configure OpenSSH server and client with security hardening
   license: MIT
-  min_ansible_version: '2.20'
+  min_ansible_version: '2.19'
 
   platforms:
     - name: ArchLinux

--- a/roles/openssh/meta/main.yml
+++ b/roles/openssh/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   author: Marc Straube
   description: Install and configure OpenSSH server and client with security hardening
   license: MIT
-  min_ansible_version: '2.17'
+  min_ansible_version: '2.20'
 
   platforms:
     - name: ArchLinux

--- a/roles/package_management/meta/main.yml
+++ b/roles/package_management/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   author: Marc Straube
   description: Configure package managers and repositories for ArchLinux, Debian/Ubuntu, and RHEL/Fedora/Rocky
   license: MIT
-  min_ansible_version: '2.20'
+  min_ansible_version: '2.19'
 
   platforms:
     - name: ArchLinux

--- a/roles/package_management/meta/main.yml
+++ b/roles/package_management/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   author: Marc Straube
   description: Configure package managers and repositories for ArchLinux, Debian/Ubuntu, and RHEL/Fedora/Rocky
   license: MIT
-  min_ansible_version: '2.17'
+  min_ansible_version: '2.20'
 
   platforms:
     - name: ArchLinux

--- a/roles/pam_hardening/meta/main.yml
+++ b/roles/pam_hardening/meta/main.yml
@@ -6,7 +6,7 @@ galaxy_info:
     password quality (pwquality), account lockout (faillock), session limits,
     access control, umask, password aging, and optional TOTP 2FA.
   license: MIT
-  min_ansible_version: '2.17'
+  min_ansible_version: '2.20'
 
   platforms:
     - name: ArchLinux

--- a/roles/pam_hardening/meta/main.yml
+++ b/roles/pam_hardening/meta/main.yml
@@ -6,7 +6,7 @@ galaxy_info:
     password quality (pwquality), account lockout (faillock), session limits,
     access control, umask, password aging, and optional TOTP 2FA.
   license: MIT
-  min_ansible_version: '2.20'
+  min_ansible_version: '2.19'
 
   platforms:
     - name: ArchLinux

--- a/roles/php/meta/main.yml
+++ b/roles/php/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   author: Marc Straube
   description: Install and manage multiple PHP versions with FPM and Composer support
   license: MIT
-  min_ansible_version: '2.17'
+  min_ansible_version: '2.20'
 
   platforms:
     - name: ArchLinux

--- a/roles/php/meta/main.yml
+++ b/roles/php/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   author: Marc Straube
   description: Install and manage multiple PHP versions with FPM and Composer support
   license: MIT
-  min_ansible_version: '2.20'
+  min_ansible_version: '2.19'
 
   platforms:
     - name: ArchLinux

--- a/roles/pki/meta/main.yml
+++ b/roles/pki/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   author: Marc Straube
   description: PKI certificate and key infrastructure management (CA, server/client certs, DH params)
   license: MIT
-  min_ansible_version: '2.17'
+  min_ansible_version: '2.20'
 
   platforms:
     - name: ArchLinux

--- a/roles/pki/meta/main.yml
+++ b/roles/pki/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   author: Marc Straube
   description: PKI certificate and key infrastructure management (CA, server/client certs, DH params)
   license: MIT
-  min_ansible_version: '2.20'
+  min_ansible_version: '2.19'
 
   platforms:
     - name: ArchLinux

--- a/roles/podman/meta/main.yml
+++ b/roles/podman/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   author: Marc Straube
   description: Install and configure Podman container runtime with rootless support and Docker compatibility
   license: MIT
-  min_ansible_version: '2.20'
+  min_ansible_version: '2.19'
 
   platforms:
     - name: ArchLinux

--- a/roles/podman/meta/main.yml
+++ b/roles/podman/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   author: Marc Straube
   description: Install and configure Podman container runtime with rootless support and Docker compatibility
   license: MIT
-  min_ansible_version: '2.17'
+  min_ansible_version: '2.20'
 
   platforms:
     - name: ArchLinux

--- a/roles/python/meta/main.yml
+++ b/roles/python/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   author: Marc Straube
   description: Install and configure Python, pip, pipx, and venv
   license: MIT
-  min_ansible_version: '2.17'
+  min_ansible_version: '2.20'
 
   platforms:
     - name: ArchLinux

--- a/roles/python/meta/main.yml
+++ b/roles/python/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   author: Marc Straube
   description: Install and configure Python, pip, pipx, and venv
   license: MIT
-  min_ansible_version: '2.20'
+  min_ansible_version: '2.19'
 
   platforms:
     - name: ArchLinux

--- a/roles/resolved/meta/main.yml
+++ b/roles/resolved/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   author: Marc Straube
   description: Manage systemd-resolved DNS resolver
   license: MIT
-  min_ansible_version: '2.20'
+  min_ansible_version: '2.19'
 
   platforms:
     - name: ArchLinux

--- a/roles/resolved/meta/main.yml
+++ b/roles/resolved/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   author: Marc Straube
   description: Manage systemd-resolved DNS resolver
   license: MIT
-  min_ansible_version: '2.17'
+  min_ansible_version: '2.20'
 
   platforms:
     - name: ArchLinux

--- a/roles/restic/meta/main.yml
+++ b/roles/restic/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   author: Marc Straube
   description: Configure restic backup with systemd timers
   license: MIT
-  min_ansible_version: '2.20'
+  min_ansible_version: '2.19'
 
   platforms:
     - name: ArchLinux

--- a/roles/restic/meta/main.yml
+++ b/roles/restic/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   author: Marc Straube
   description: Configure restic backup with systemd timers
   license: MIT
-  min_ansible_version: '2.17'
+  min_ansible_version: '2.20'
 
   platforms:
     - name: ArchLinux

--- a/roles/rkhunter/meta/main.yml
+++ b/roles/rkhunter/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   author: Marc Straube
   description: Install and configure rkhunter for rootkit detection
   license: MIT
-  min_ansible_version: '2.17'
+  min_ansible_version: '2.20'
 
   platforms:
     - name: ArchLinux

--- a/roles/rkhunter/meta/main.yml
+++ b/roles/rkhunter/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   author: Marc Straube
   description: Install and configure rkhunter for rootkit detection
   license: MIT
-  min_ansible_version: '2.20'
+  min_ansible_version: '2.19'
 
   platforms:
     - name: ArchLinux

--- a/roles/shell/meta/main.yml
+++ b/roles/shell/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   author: Marc Straube
   description: Install and configure shells (Zsh, Fish, Bash) and Starship prompt
   license: MIT
-  min_ansible_version: '2.17'
+  min_ansible_version: '2.20'
 
   platforms:
     - name: ArchLinux

--- a/roles/shell/meta/main.yml
+++ b/roles/shell/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   author: Marc Straube
   description: Install and configure shells (Zsh, Fish, Bash) and Starship prompt
   license: MIT
-  min_ansible_version: '2.20'
+  min_ansible_version: '2.19'
 
   platforms:
     - name: ArchLinux

--- a/roles/snmp/meta/main.yml
+++ b/roles/snmp/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   author: Marc Straube
   description: Install and configure Net-SNMP agent (snmpd)
   license: MIT
-  min_ansible_version: '2.20'
+  min_ansible_version: '2.19'
 
   platforms:
     - name: ArchLinux

--- a/roles/snmp/meta/main.yml
+++ b/roles/snmp/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   author: Marc Straube
   description: Install and configure Net-SNMP agent (snmpd)
   license: MIT
-  min_ansible_version: '2.17'
+  min_ansible_version: '2.20'
 
   platforms:
     - name: ArchLinux

--- a/roles/sudo/meta/main.yml
+++ b/roles/sudo/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   author: Marc Straube
   description: Configure sudo with security hardening and granular access control
   license: MIT
-  min_ansible_version: '2.20'
+  min_ansible_version: '2.19'
 
   platforms:
     - name: ArchLinux

--- a/roles/sudo/meta/main.yml
+++ b/roles/sudo/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   author: Marc Straube
   description: Configure sudo with security hardening and granular access control
   license: MIT
-  min_ansible_version: '2.17'
+  min_ansible_version: '2.20'
 
   platforms:
     - name: ArchLinux

--- a/roles/sysctl/meta/main.yml
+++ b/roles/sysctl/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   description: Configure kernel parameters via sysctl with preset profiles
   license: MIT
 
-  min_ansible_version: '2.17'
+  min_ansible_version: '2.20'
 
   platforms:
     - name: ArchLinux

--- a/roles/sysctl/meta/main.yml
+++ b/roles/sysctl/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   description: Configure kernel parameters via sysctl with preset profiles
   license: MIT
 
-  min_ansible_version: '2.20'
+  min_ansible_version: '2.19'
 
   platforms:
     - name: ArchLinux

--- a/roles/unbound/meta/main.yml
+++ b/roles/unbound/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   author: Marc Straube
   description: Configure Unbound DNS resolver with DNSSEC, DNS-over-TLS, and blocklists
   license: MIT
-  min_ansible_version: '2.20'
+  min_ansible_version: '2.19'
 
   platforms:
     - name: ArchLinux

--- a/roles/unbound/meta/main.yml
+++ b/roles/unbound/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   author: Marc Straube
   description: Configure Unbound DNS resolver with DNSSEC, DNS-over-TLS, and blocklists
   license: MIT
-  min_ansible_version: '2.17'
+  min_ansible_version: '2.20'
 
   platforms:
     - name: ArchLinux

--- a/roles/users/meta/main.yml
+++ b/roles/users/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   author: Marc Straube
   description: Manage system users, groups, and SSH keys
   license: MIT
-  min_ansible_version: '2.17'
+  min_ansible_version: '2.20'
 
   platforms:
     - name: ArchLinux

--- a/roles/users/meta/main.yml
+++ b/roles/users/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   author: Marc Straube
   description: Manage system users, groups, and SSH keys
   license: MIT
-  min_ansible_version: '2.20'
+  min_ansible_version: '2.19'
 
   platforms:
     - name: ArchLinux

--- a/roles/utils/meta/main.yml
+++ b/roles/utils/meta/main.yml
@@ -5,7 +5,7 @@ galaxy_info:
     Install common system utilities (monitors, file transfer,
     file managers, system info, fun terminal tools)
   license: MIT
-  min_ansible_version: '2.20'
+  min_ansible_version: '2.19'
 
   platforms:
     - name: ArchLinux

--- a/roles/utils/meta/main.yml
+++ b/roles/utils/meta/main.yml
@@ -5,7 +5,7 @@ galaxy_info:
     Install common system utilities (monitors, file transfer,
     file managers, system info, fun terminal tools)
   license: MIT
-  min_ansible_version: '2.17'
+  min_ansible_version: '2.20'
 
   platforms:
     - name: ArchLinux

--- a/roles/wireguard/meta/main.yml
+++ b/roles/wireguard/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   author: Marc Straube
   description: Configure WireGuard VPN tunnels with multi-interface support
   license: MIT
-  min_ansible_version: '2.20'
+  min_ansible_version: '2.19'
 
   platforms:
     - name: ArchLinux

--- a/roles/wireguard/meta/main.yml
+++ b/roles/wireguard/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   author: Marc Straube
   description: Configure WireGuard VPN tunnels with multi-interface support
   license: MIT
-  min_ansible_version: '2.17'
+  min_ansible_version: '2.20'
 
   platforms:
     - name: ArchLinux


### PR DESCRIPTION
## Summary

Unifies and raises the supported ansible-core floor across all six surfaces, plus the CI forward-compat matrix. Closes #173.

## Surface coverage

- `meta/runtime.yml`: `'>=2.15.0'` (stale pre-1.0 leftover) → `'>=2.19.0'`
- `galaxy.yml`: description "ansible-core 2.17+" → "2.19+" (bonus: stale "37 shared Ansible roles" → 42 actual count)
- `README.md` Requirements: 2.17 → 2.19
- `CONTRIBUTING.md` Prerequisites: 2.17 → 2.19
- `.claude/CLAUDE.md` heading: 2.17+ → 2.19+
- `roles/*/meta/main.yml`: `'min_ansible_version: 2.17'` → `'2.19'` (all 42 roles)
- `.github/workflows/ci.yml`: Compat matrix `ansible-2.20` → `ansible-2.21` (forward-compat stays above the new floor)

## Why floor at 2.19 (not 2.20)

ansible-core 2.20 was released 2026-05-18. ansible-lint v26.4.0 (latest at PR time) still rejects `>=2.20.0` in `meta/runtime.yml` — its `meta-runtime` rule only accepts 2.15-2.19. Floor stays at 2.19 for now; bump to 2.20 tracked in follow-up #175 for when upstream tooling catches up.

## Why breaking

ansible-core minimum is a contract change. Inventories that pin `ansible-core==2.17` (or use RHEL 9 / Debian Bookworm system ansible) need to upgrade. The required-action section in `MIGRATION.md` spells out the pip / pipx / distro paths.

## Test plan

- [x] `pre-commit run --all-files` clean (ansible-lint, yamllint, markdownlint, detect-secrets all green)
- [x] Full CI matrix green on the bump branch (verified after the 2.20→2.19 fixup commit)

Closes #173