### PR TITLE
v2.0.0 release polish: README example + galaxy.yml build_ignore

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ ansible-galaxy collection install git+https://github.com/marcstraube/ansible-col
 # requirements.yml
 collections:
   - name: marcstraube.common
-    version: ">=1.0.0"
+    version: ">=2.0.0"
 ```
 
 ## Usage

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -29,15 +29,24 @@ homepage: https://github.com/marcstraube/ansible-collection-common
 issues: https://github.com/marcstraube/ansible-collection-common/issues
 build_ignore:
   - '*.tar.gz'
+  - .ansible
+  - .ansible-lint
+  - .claude
   - .git
   - .github
+  - .gitignore
   - .gitlab-ci.yml
-  - .ansible
-  - .claude
+  - .markdownlint-cli2.yaml
+  - .markdownlint.yml
+  - .pre-commit-config.yaml
+  - .release-please-manifest.json
+  - .secrets.baseline
   - .venv
+  - .yamllint
   - '*.pyc'
   - __pycache__
   - roles/*/molecule
+  - version.txt
 dependencies:
   community.general: '>=8.0.0'
   community.crypto: '>=2.9.0'


### PR DESCRIPTION
## Summary

Closes #176.

Two small polish items uncovered during v2.0.0 pre-release review.

- `README.md` example `requirements.yml` snippet now advertises `>=2.0.0` instead of `>=1.0.0` so users landing on the v2.0.0 README see the just-released floor in the example.
- `galaxy.yml` `build_ignore` extended to exclude dev-only configuration files from the published tarball: `.ansible-lint`, `.gitignore`, `.markdownlint-cli2.yaml`, `.markdownlint.yml`, `.pre-commit-config.yaml`, `.release-please-manifest.json`, `.secrets.baseline`, `.yamllint`, and `version.txt`. The list is also re-sorted alphabetically.

## Test plan

- [x] `pre-commit run --files README.md galaxy.yml` clean
- [x] `ansible-galaxy collection build` produces a tarball that contains only collection metadata + README/CHANGELOG/MIGRATION/CONTRIBUTING/LICENSE + meta/molecule/playbooks/release-please-config/roles + auto-generated FILES.json/MANIFEST.json. All listed dev configs are absent.
- [x] All 42 roles still present in the tarball
- [ ] PR CI green (separate run on GitHub)