### PR TITLE
fix(base): default base_bootloader per OS (grub on RHEL/Debian, systemd-boot on Arch)

### DIFF
--- a/roles/base/README.md
+++ b/roles/base/README.md
@@ -88,13 +88,17 @@ overrides if needed.
 
 | Variable                         | Default          | Description                                  |
 |----------------------------------|------------------|----------------------------------------------|
-| `base_bootloader`                | `'systemd-boot'` | Bootloader: systemd-boot, grub, none         |
+| `base_bootloader`                | OS-aware (\*)    | Bootloader: systemd-boot, grub, none         |
 | `base_grub_timeout`              | `5`              | GRUB menu timeout (seconds)                  |
 | `base_grub_default`              | `'0'`            | Default GRUB menu entry                      |
 | `base_kernel_parameters`         | `[]`             | Kernel params for GRUB_CMDLINE_LINUX_DEFAULT |
 | `base_systemd_boot_timeout`      | `3`              | systemd-boot loader timeout (seconds)        |
 | `base_systemd_boot_console_mode` | `'max'`          | systemd-boot console mode                    |
 | `base_systemd_boot_editor`       | `false`          | Allow boot parameter editing (security risk) |
+
+(\*) `base_bootloader` defaults to `grub` on Debian and RHEL-family
+distributions, and to `systemd-boot` on Arch Linux (set via
+`vars/<OS>.yml`).
 
 ### Packages
 

--- a/roles/base/defaults/main.yml
+++ b/roles/base/defaults/main.yml
@@ -115,7 +115,10 @@ base_microcode: 'auto'
 #
 
 # Bootloader type: systemd-boot, grub, none
-base_bootloader: 'systemd-boot'
+# Default is OS-aware via vars/<OS>.yml:
+#   Arch Linux       → systemd-boot
+#   Debian, RHEL-fam → grub
+base_bootloader: '{{ __base_default_bootloader | default("systemd-boot") }}'
 
 # GRUB timeout in seconds
 base_grub_timeout: 5

--- a/roles/base/vars/Archlinux.yml
+++ b/roles/base/vars/Archlinux.yml
@@ -13,3 +13,6 @@ __base_default_packages:
   - 'zip'
 
 __base_dialog_package: 'dialog'
+
+# Default bootloader (Arch installer ships systemd-boot as the modern choice)
+__base_default_bootloader: 'systemd-boot'

--- a/roles/base/vars/Debian.yml
+++ b/roles/base/vars/Debian.yml
@@ -13,3 +13,6 @@ __base_default_packages:
   - 'zip'
 
 __base_dialog_package: 'dialog'
+
+# Default bootloader (Debian ships GRUB by default)
+__base_default_bootloader: 'grub'

--- a/roles/base/vars/RedHat.yml
+++ b/roles/base/vars/RedHat.yml
@@ -17,3 +17,6 @@ __base_locale_packages:
   - 'glibc-langpack-en'
 
 __base_dialog_package: 'dialog'
+
+# Default bootloader (RHEL-family ships GRUB by default)
+__base_default_bootloader: 'grub'


### PR DESCRIPTION
## Summary

- `base_bootloader` now defaults to `grub` on Debian / RHEL-family and to `systemd-boot` on Arch Linux, instead of unconditionally `systemd-boot`.
- Implemented via `__base_default_bootloader` in each `vars/<OS>.yml`, consumed by `defaults/main.yml` with a `systemd-boot` fallback for unrecognised distributions.
- README updated.

Closes #179

## Why

On a fresh Rocky 9 host without inventory override, `Bootloader | Configure systemd-boot loader.conf` writes `/boot/loader/loader.conf` while the actual GRUB tasks are skipped. The role's documented intent is to configure the host's bootloader; the previous default did the opposite on RHEL/Debian.

## Test plan

- [x] `ansible-lint roles/base/` → 0 failures
- [x] `molecule test -p base-rocky-9` → green (existing test sets `base_bootloader: 'none'`, default-resolution exercised via `include_vars` lookup)
- [x] `molecule test -p base-archlinux` → green (no regression for systemd-boot path)