### PR TITLE
fix(hardening): preserve existing /tmp instead of force-converting to tmpfs

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -5,6 +5,36 @@ breaking changes adds a section here with before/after inventory
 snippets. For the full list of changes per release, see
 [CHANGELOG.md](CHANGELOG.md).
 
+## v2.0.1 (unreleased)
+
+### `hardening` — `/tmp` is no longer auto-converted to tmpfs
+
+The `/tmp` entry in `hardening_fs_mounts` is now only applied when the
+current `/tmp` is already a tmpfs. On hosts where `/tmp` lives on the
+root filesystem, on a BTRFS subvolume, or on another non-tmpfs mount,
+the entry is skipped instead of silently masking the existing `/tmp`
+contents with a fresh tmpfs.
+
+The previous default could break running services (`noexec` on `/tmp`
+prevents tools like `npm` from executing scripts there) and would
+hide files already on `/tmp` from any process that opened them after
+the remount.
+
+#### Required action
+
+Hosts that should still get `/tmp` converted to tmpfs — typically
+fresh-install or installer workflows where `/tmp` is known to be
+empty — need to opt in:
+
+```yaml
+# inventory: group_vars / host_vars
+hardening_fs_tmp_force_tmpfs: true
+```
+
+Hosts where `/tmp` is already tmpfs (e.g. Arch Linux with the
+default systemd `tmp.mount`) are unaffected — the hardened mount
+options are still applied.
+
 ## v2.0.0 - 2026-05-22
 
 ### Minimum ansible-core bumped from 2.17 to 2.19 (#173)

--- a/roles/hardening/README.md
+++ b/roles/hardening/README.md
@@ -69,10 +69,19 @@ overrides if needed.
 
 ### Filesystem Mounts
 
-| Variable                           | Default            | Description             |
-|------------------------------------|--------------------|-------------------------|
-| `hardening_fs_mounts`              | `/tmp`, `/dev/shm` | Mount entries to harden |
-| `hardening_fs_vartmp_bind_enabled` | `true`             | Bind /var/tmp to /tmp   |
+| Variable                           | Default            | Description                                       |
+|------------------------------------|--------------------|---------------------------------------------------|
+| `hardening_fs_mounts`              | `/tmp`, `/dev/shm` | Mount entries to harden                           |
+| `hardening_fs_vartmp_bind_enabled` | `true`             | Bind /var/tmp to /tmp                             |
+| `hardening_fs_tmp_force_tmpfs`     | `false`            | Force /tmp → tmpfs even when /tmp is not tmpfs    |
+
+The `/tmp` entry in `hardening_fs_mounts` is only applied when the current
+`/tmp` is already a tmpfs (e.g. systemd `tmp.mount` on Arch). On systems
+where `/tmp` lives on the root filesystem, on a BTRFS subvolume, or on a
+dedicated non-tmpfs partition, the entry is skipped to avoid masking
+existing data or breaking services that hold open files there. Set
+`hardening_fs_tmp_force_tmpfs: true` to opt in — appropriate for fresh
+installs where `/tmp` is known to be empty.
 
 ## Tags
 

--- a/roles/hardening/defaults/main.yml
+++ b/roles/hardening/defaults/main.yml
@@ -122,3 +122,10 @@ hardening_fs_mounts:
 
 # Enable /var/tmp bind mount to /tmp (inherits /tmp mount options)
 hardening_fs_vartmp_bind_enabled: true
+
+# Force /tmp conversion to tmpfs even when the current /tmp is not tmpfs
+# (e.g. /tmp on /, BTRFS subvolume, dedicated /tmp partition).
+# DANGER: enabling this on a running system masks existing /tmp contents
+# and can break services that hold open files there. Intended for fresh
+# installs where /tmp is known to be empty.
+hardening_fs_tmp_force_tmpfs: false

--- a/roles/hardening/molecule/default/converge.yml
+++ b/roles/hardening/molecule/default/converge.yml
@@ -5,6 +5,10 @@
 
   vars:
     hardening_enabled: true
+    # Molecule VMs are fresh installs with an empty /tmp on the root
+    # filesystem. Opt in to the tmpfs conversion so the /tmp mount-option
+    # verification covers the force-tmpfs path.
+    hardening_fs_tmp_force_tmpfs: true
 
   tasks:
     - name: Converge | Include hardening role  # noqa: role-name[path]

--- a/roles/hardening/tasks/filesystem.yml
+++ b/roles/hardening/tasks/filesystem.yml
@@ -3,32 +3,31 @@
 # chicken-and-egg problem where mounting /tmp destroys the Ansible
 # module payload that was extracted there.
 
-# Auto-detect /tmp mount type to avoid breaking non-tmpfs mounts
-# (e.g. BTRFS subvolumes with their own security options)
+# Auto-detect /tmp mount type. Without explicit opt-in, only existing tmpfs
+# /tmp mounts are reconfigured. Converting a non-tmpfs /tmp (e.g. /tmp on /,
+# or a BTRFS subvolume) would silently mask existing files and can break
+# running services, so it is gated behind hardening_fs_tmp_force_tmpfs.
 - name: Filesystem | Detect current /tmp mount
   ansible.builtin.command:
-    cmd: findmnt -n -o TARGET,FSTYPE /tmp
+    cmd: findmnt -n -o FSTYPE /tmp
   register: __hardening_tmp_findmnt
   changed_when: false
   failed_when: false
   check_mode: false
 
-- name: Filesystem | Parse /tmp mount info
+- name: Filesystem | Parse /tmp fstype
   ansible.builtin.set_fact:
-    __hardening_tmp_is_separate: >-
-      {{ __hardening_tmp_findmnt.rc == 0 and
-         (__hardening_tmp_findmnt.stdout.split()[0] | default('')) == '/tmp' }}
     __hardening_tmp_fstype: >-
-      {{ __hardening_tmp_findmnt.stdout.split()[1] | default('')
+      {{ __hardening_tmp_findmnt.stdout | trim
          if __hardening_tmp_findmnt.rc == 0 else '' }}
 
-- name: Filesystem | Skip /tmp if already mounted as non-tmpfs
+- name: Filesystem | Skip /tmp unless already tmpfs (or force opt-in)
   ansible.builtin.set_fact:
     hardening_fs_mounts: >-
       {{ hardening_fs_mounts | rejectattr('path', 'equalto', '/tmp') | list }}
   when:
-    - __hardening_tmp_is_separate | bool
-    - __hardening_tmp_fstype not in ['tmpfs', '']
+    - __hardening_tmp_fstype != 'tmpfs'
+    - not (hardening_fs_tmp_force_tmpfs | bool)
 
 - name: Filesystem | Configure mount entries in fstab
   ansible.posix.mount:

--- a/roles/hardening/tasks/filesystem.yml
+++ b/roles/hardening/tasks/filesystem.yml
@@ -41,6 +41,9 @@
     label: '{{ item.path }}'
   register: __hardening_fstab_result
 
+# Skip in check mode: the prior ansible.posix.mount task only registers
+# the fstab change (does not write it), so `mount` would fail with
+# "can't find in /etc/fstab".
 - name: Filesystem | Mount or remount entries
   ansible.builtin.raw: >-
     if findmnt -n {{ item.item.path }} > /dev/null 2>&1; then
@@ -51,8 +54,8 @@
   loop: '{{ __hardening_fstab_result.results }}'
   loop_control:
     label: '{{ item.item.path }}'
+  when: not ansible_check_mode
   changed_when: false
-  check_mode: false
 
 - name: Filesystem | Configure /var/tmp bind mount in fstab
   ansible.posix.mount:
@@ -69,6 +72,7 @@
     if ! findmnt -n /var/tmp > /dev/null 2>&1; then
       mount /var/tmp;
     fi
-  when: hardening_fs_vartmp_bind_enabled | bool
+  when:
+    - hardening_fs_vartmp_bind_enabled | bool
+    - not ansible_check_mode
   changed_when: false
-  check_mode: false


### PR DESCRIPTION
## Summary

- `roles/hardening/tasks/filesystem.yml` now only applies the `/tmp` tmpfs entry when the current `/tmp` is already a tmpfs, or when the new `hardening_fs_tmp_force_tmpfs` opt-in is set.
- New default `hardening_fs_tmp_force_tmpfs: false` in `roles/hardening/defaults/main.yml`.
- Molecule converge sets `hardening_fs_tmp_force_tmpfs: true` because the test VMs ship with `/tmp` on `/`; this keeps existing `/tmp` mount-option verification meaningful.
- README and MIGRATION.md document the new variable and the behaviour matrix.

Closes #181

## Why

Previously, on a host where `/tmp` lives on `/` (the default on RHEL-family and Debian), running the hardening role would write a `tmpfs … noexec` line to `/etc/fstab` and remount `/tmp`. Existing files on `/tmp` would be masked, services holding open files there could break, and `noexec` would break tooling that executes scripts from `/tmp`.

## Behaviour matrix

| Current /tmp                          | Before               | After                        |
|---------------------------------------|----------------------|------------------------------|
| tmpfs (Arch `tmp.mount`, /tmp on tmpfs) | reconfigured         | reconfigured                 |
| Separate non-tmpfs (BTRFS subvol, …)  | skipped              | skipped                      |
| Part of `/` (RHEL/Debian default)     | converted to tmpfs   | skipped (unless force opt-in) |

## Required action for users relying on the previous default

Set `hardening_fs_tmp_force_tmpfs: true` in inventory for hosts where the previous auto-conversion of `/tmp` to tmpfs was wanted (typically fresh-install / installer playbooks). See MIGRATION.md for the v2.0.1 entry.

## Test plan

- [x] `ansible-lint roles/hardening/` → 0 failures
- [x] `molecule test -p hardening-rocky-9` → green (with `force_tmpfs: true` in converge, simulating fresh install)
- [x] `molecule test -p hardening-archlinux` → green (Arch `/tmp` is already tmpfs, force path unchanged)

### Coverage gap

The molecule scenario does not yet exercise the default-skip path (force off + /tmp on /). A second scenario for this is a sensible follow-up — same pattern as the open multi-mode molecule coverage tracker.