### PR TITLE
fix(resolved): skip service and symlink tasks when systemd-resolved unit is missing

### DIFF
--- a/roles/resolved/tasks/service.yml
+++ b/roles/resolved/tasks/service.yml
@@ -1,10 +1,21 @@
 ---
+# Check whether systemd-resolved is actually installed. In check mode the
+# preceding install task only simulates the package install, so without
+# this gate the service/symlink tasks would fail on hosts that don't
+# already have the systemd-resolved unit file.
+- name: Service | Check if systemd-resolved unit is installed
+  ansible.builtin.stat:
+    path: '/usr/lib/systemd/system/{{ __resolved_service_name }}'
+  register: __resolved_service_unit
+  check_mode: false
+
 - name: Service | Manage systemd-resolved service
   ansible.builtin.systemd_service:
     name: '{{ __resolved_service_name }}'
     enabled: "{{ resolved_service_enabled | bool }}"
     state: "{{ resolved_service_enabled | bool | ternary('started', 'stopped') }}"
     daemon_reload: true
+  when: __resolved_service_unit.stat.exists
 
 - name: Service | Manage resolv.conf symlink
   ansible.builtin.file:
@@ -15,3 +26,4 @@
   when:
     - resolved_manage_resolv_conf | bool
     - resolved_service_enabled | bool
+    - __resolved_service_unit.stat.exists


### PR DESCRIPTION
## Summary

- Add an `ansible.builtin.stat` on `/usr/lib/systemd/system/{{ __resolved_service_name }}` at the top of `service.yml`, registered into `__resolved_service_unit` and always run (`check_mode: false`).
- Gate the `Service | Manage systemd-resolved service` task on `__resolved_service_unit.stat.exists`.
- Gate the `Service | Manage resolv.conf symlink` task on the same condition (in addition to the existing `resolved_manage_resolv_conf` / `resolved_service_enabled` checks).

Closes #184

## Why

In check mode the preceding `install.yml` only simulates the package install. On hosts where `systemd-resolved` is not already present (e.g. a fresh Rocky 9 install), the service task then fails with `Could not find the requested service systemd-resolved.service`. Real runs are unaffected — by the time `service.yml` runs, `install.yml` has placed the unit file.

## Behaviour matrix

| Mode  | Unit installed before run | Behaviour                                |
|-------|---------------------------|------------------------------------------|
| real  | no                        | install installs → stat true → service starts |
| real  | yes                       | install no-op → stat true → service managed   |
| check | yes                       | stat true → systemd_service shows would-changes |
| check | no                        | stat false → service/symlink **skipped (was: failed)** |

## Test plan

- [x] `ansible-lint roles/resolved/` → 0 failures
- [x] `molecule test -p resolved-rocky-9` → green (unit installed by install.yml, stat true)
- [x] `molecule test -p resolved-archlinux` → green