### PR TITLE
fix(gnupg): make paperkey a Layer-1 no-op on EL (not in EPEL 9/10)

### DIFF
--- a/.github/drift-targets.yml
+++ b/.github/drift-targets.yml
@@ -24,3 +24,11 @@ targets:
     package: aide
     source: aur
     vars_file: vars/Archlinux.yml
+  - role: gnupg
+    platform: rocky-9
+    package: paperkey
+    vars_file: vars/RedHat.yml
+  - role: gnupg
+    platform: rocky-10
+    package: paperkey
+    vars_file: vars/RedHat.yml

--- a/roles/gnupg/README.md
+++ b/roles/gnupg/README.md
@@ -16,12 +16,19 @@ daemon configuration, and keyserver management.
 
 ## Supported Platforms
 
-| Platform                  | Notes                                     |
-|---------------------------|-------------------------------------------|
-| Arch Linux                | GnuPG 2.4+, includes GUI tools (Seahorse) |
-| Debian Trixie             | GnuPG 2.2+, includes GUI tools (Seahorse) |
-| EL 9 (Rocky, Alma, RHEL)  | GnuPG 2.3+                                |
-| EL 10 (Rocky, Alma, RHEL) | GnuPG 2.4+                                |
+| Platform                  | Notes                                                          |
+|---------------------------|----------------------------------------------------------------|
+| Arch Linux                | GnuPG 2.4+, includes GUI tools (Seahorse)                      |
+| Debian Trixie             | GnuPG 2.2+, includes GUI tools (Seahorse)                      |
+| EL 9 (Rocky, Alma, RHEL)  | GnuPG 2.3+; `paperkey` is not in EPEL — see CLI tools note (\*) |
+| EL 10 (Rocky, Alma, RHEL) | GnuPG 2.4+; `paperkey` is not in EPEL — see CLI tools note (\*) |
+
+(\*) `paperkey` (and `hopenpgp-tools`) are not packaged for EPEL 9/10,
+so `__gnupg_tools_packages` is empty on RHEL-family hosts and the
+"Install | Additional tools" task is a no-op there even when
+`gnupg_tools_enabled` is `true`. Users who need `paperkey` on EL must
+install it from source or a third-party COPR. Re-availability is
+probed weekly by the drift-detection workflow.
 
 Other distributions in the same os_family (EndeavourOS, Manjaro, Ubuntu, Mint,
 Fedora) should work but are not actively tested. Use distro-specific vars

--- a/roles/gnupg/tasks/install.yml
+++ b/roles/gnupg/tasks/install.yml
@@ -12,7 +12,9 @@
     state: present
   retries: 3
   delay: 5
-  when: gnupg_tools_enabled | default(true) | bool
+  when:
+    - gnupg_tools_enabled | default(true) | bool
+    - __gnupg_tools_packages | length > 0
 
 - name: Install | GUI packages
   ansible.builtin.package:

--- a/roles/gnupg/vars/RedHat.yml
+++ b/roles/gnupg/vars/RedHat.yml
@@ -2,8 +2,12 @@
 __gnupg_packages:
   - 'gnupg2'
 
-__gnupg_tools_packages:
-  - 'paperkey'
+# paperkey is not packaged for EPEL 9 or EPEL 10 (Fedora-only, see
+# https://packages.fedoraproject.org/pkgs/paperkey/paperkey/);
+# hopenpgp-tools (Haskell) is likewise absent. Layer-1 no-op: keep
+# the list empty so the install task in install.yml is a noop on EL.
+# Re-availability tracked by the drift-detection workflow (#169).
+__gnupg_tools_packages: []
 
 __gnupg_gui_packages:
   - 'pinentry-gtk'


### PR DESCRIPTION
## Summary

- `roles/gnupg/vars/RedHat.yml`: empty `__gnupg_tools_packages` with a comment explaining the EPEL gap.
- `roles/gnupg/tasks/install.yml`: guard the "Install | Additional tools" task with `__gnupg_tools_packages | length > 0`.
- `roles/gnupg/README.md`: note the EPEL gap and the no-op behaviour on RHEL-family.
- `.github/drift-targets.yml`: probe `paperkey` weekly on rocky-9 and rocky-10 so the entry is restored automatically if EPEL picks it up.

Closes #186

## Why

`paperkey` is Fedora-only. On every RHEL-family host with default `gnupg_tools_enabled: true`, the install task failed with:

```
"failures": ["No package paperkey available."]
```

The role's other tasks (main GnuPG install, gpg.conf, etc.) work fine on EL, so the role itself should keep functioning; only the optional tools install needs to be a no-op until upstream availability changes.

## Test plan

- [x] `ansible-lint roles/gnupg/` → 0 failures
- [x] `molecule test -p gnupg-rocky-9` → green (empty tools list, additional-tools task skipped)
- [x] `molecule test -p gnupg-rocky-10` → green