### PR TITLE
fix(docker): refresh dnf cache after repo add and skip install when repo missing

### DIFF
--- a/roles/docker/tasks/install.yml
+++ b/roles/docker/tasks/install.yml
@@ -45,6 +45,25 @@
          else 'centos' }}/docker-ce.repo
   args:
     creates: '/etc/yum.repos.d/docker-ce.repo'
+  register: __docker_dnf_repo
+  when: ansible_facts['os_family'] == 'RedHat'
+
+- name: Install | Refresh dnf cache after Docker repo change
+  ansible.builtin.dnf:
+    update_cache: true
+  when:
+    - ansible_facts['os_family'] == 'RedHat'
+    - __docker_dnf_repo is changed
+
+# Check that the Docker CE repo file is actually on disk before
+# touching the docker-ce packages. In check mode the add-repo
+# command above is not really executed, so without this gate the
+# package install tasks fail with "No package docker-ce available".
+- name: Install | Check Docker CE repo presence (RedHat)
+  ansible.builtin.stat:
+    path: '/etc/yum.repos.d/docker-ce.repo'
+  register: __docker_repo_stat
+  check_mode: false
   when: ansible_facts['os_family'] == 'RedHat'
 
 #
@@ -57,6 +76,9 @@
     state: present
   retries: 3
   delay: 5
+  when: >-
+    ansible_facts['os_family'] != 'RedHat'
+    or __docker_repo_stat.stat.exists
 
 - name: Install | Docker Compose plugin
   ansible.builtin.package:
@@ -64,7 +86,10 @@
     state: present
   retries: 3
   delay: 5
-  when: docker_compose_enabled | bool
+  when:
+    - docker_compose_enabled | bool
+    - ansible_facts['os_family'] != 'RedHat'
+      or __docker_repo_stat.stat.exists
 
 - name: Install | Docker Buildx plugin
   ansible.builtin.package:
@@ -72,7 +97,10 @@
     state: present
   retries: 3
   delay: 5
-  when: docker_buildx_enabled | bool
+  when:
+    - docker_buildx_enabled | bool
+    - ansible_facts['os_family'] != 'RedHat'
+      or __docker_repo_stat.stat.exists
 
 #
 # Directory and Group Setup


### PR DESCRIPTION
## Summary

- `roles/docker/tasks/install.yml`: register the `dnf config-manager --add-repo` task into `__docker_dnf_repo`.
- Add a `ansible.builtin.dnf: update_cache: true` task, gated on `__docker_dnf_repo is changed`, symmetric to the existing Debian `apt: update_cache: true` step.
- Add an `ansible.builtin.stat` on `/etc/yum.repos.d/docker-ce.repo` with `check_mode: false`.
- Gate the three package install tasks (docker, compose, buildx) on `__docker_repo_stat.stat.exists` for the RedHat branch only.

Closes #188

## Why

Two related gaps on RHEL-family hosts:

1. **Missing cache refresh.** The Debian path already runs `apt: update_cache: true` after `deb822_repository`. The RHEL path adds the Docker CE repo via `dnf config-manager` and then jumps straight to `package: docker-ce`. On a fresh host the dnf cache does not yet contain the new repo's metadata, so the install can fail with `No package docker-ce available`.

2. **Check-mode failure.** The add-repo task is `ansible.builtin.command` with `creates:`. In check mode the command is not actually executed, so on a host that does not already have Docker the follow-up `package: docker-ce` task fails:

```
"failures": ["No package docker-ce available.", "No package docker-ce-cli available.", "No package containerd.io available."]
```

## Behaviour matrix

| Mode  | Repo file present before run | Behaviour                                                |
|-------|------------------------------|----------------------------------------------------------|
| real  | no                           | add-repo writes file → cache refresh → package install   |
| real  | yes                          | add-repo skipped via `creates:` → cache refresh skipped → package install (no-op if already current) |
| check | yes                          | stat true → package install shows would-changes          |
| check | no                           | stat false → package install **skipped (was: failed)**   |

## Test plan

- [x] `ansible-lint roles/docker/` → 0 failures
- [x] `molecule test -p docker-rocky-9` → green
- [x] `molecule test -p docker-rocky-10` → green