### PR TITLE
fix(php): support AppStream and Remi on RHEL via php_redhat_repo

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -87,6 +87,51 @@ No action required for v2.1.0 — the deprecation is purely informational.
 
 ## v2.0.1 (unreleased)
 
+### `php` — RHEL default switched from Remi to AppStream
+
+Previously `roles/php/vars/RedHat.yml` shipped unconditional Remi-SCL
+package patterns (`php<XX>-php-cli`, `/etc/opt/remi/php<XX>/...`), but
+the role did not deploy the Remi repository. On any RHEL-family host
+without Remi pre-installed, the role failed with
+`No package php<XX>-php-cli available`.
+
+v2.0.1 introduces `php_redhat_repo` (`'appstream'` default, `'remi'`
+opt-in). AppStream uses the distro module streams and unversioned
+package names. Remi keeps the versioned `php<XX>-php-*` packages and
+`/etc/opt/remi/` paths for side-by-side installs.
+
+The Remi repository itself is not managed by the `php` role — it is
+multi-purpose (PHP, MariaDB, Redis, …) and lives in
+`marcstraube.common.package_management` under `dnf_remi_enabled`. The
+`php` role asserts the repo is on the host when
+`php_redhat_repo: 'remi'` is requested and fails with a hint otherwise.
+
+AppStream's `dnf module` streams are exclusive, so on `appstream` the
+role only accepts a single entry in `php_versions` (multi-version
+side-by-side requires `remi`). The role also asserts that the
+requested PHP version matches the active stream and fails with a hint
+otherwise.
+
+#### Required action
+
+Hosts that already had Remi installed and relied on the previous
+behaviour need both flags:
+
+```yaml
+# inventory: group_vars / host_vars
+dnf_remi_enabled: true            # marcstraube.common.package_management
+php_redhat_repo: 'remi'           # marcstraube.common.php
+```
+
+Hosts on AppStream get the default and need no inventory change, but
+the active module stream must match `php_versions[0].version`. To
+switch the active stream:
+
+```bash
+sudo dnf module reset -y php
+sudo dnf module enable -y php:8.2
+```
+
 ### `hardening` — `/tmp` is no longer auto-converted to tmpfs
 
 The `/tmp` entry in `hardening_fs_mounts` is now only applied when the

--- a/roles/php/README.md
+++ b/roles/php/README.md
@@ -23,12 +23,12 @@ and full FPM pool templates.
 
 ## Supported Platforms
 
-| Platform                   | Notes |
-|----------------------------|-------|
-| Arch Linux                 |       |
-| Debian Trixie              |       |
-| EL 9 (Rocky, Alma, RHEL)   |       |
-| EL 10 (Rocky, Alma, RHEL)  |       |
+| Platform                   | Notes                                                          |
+|----------------------------|----------------------------------------------------------------|
+| Arch Linux                 | Official repo for current PHP, AUR for legacy versions         |
+| Debian Trixie              | Sury repository (multi-version side-by-side)                   |
+| EL 9 (Rocky, Alma, RHEL)   | AppStream (default, single stream) or Remi (`php_redhat_repo`) |
+| EL 10 (Rocky, Alma, RHEL)  | AppStream (default, single stream) or Remi (`php_redhat_repo`) |
 
 Other distributions in the same os_family (EndeavourOS, Manjaro, Ubuntu, Mint,
 Fedora) should work but are not actively tested. Use distro-specific vars
@@ -50,10 +50,43 @@ overrides if needed.
 
 ### PHP Versions
 
-| Variable              | Default               | Description                               |
-|-----------------------|-----------------------|-------------------------------------------|
-| `php_versions`        | `[{version: '8.4'}]`  | PHP versions to install (list of dicts)   |
-| `php_default_version` | `'8.4'`               | Default PHP version for CLI               |
+| Variable              | Default                 | Description                                       |
+|-----------------------|-------------------------|---------------------------------------------------|
+| `php_versions`        | `[{version: 'auto'}]`   | PHP versions to install (list of dicts)           |
+| `php_default_version` | `'auto'`                | Default PHP version for CLI                       |
+| `php_redhat_repo`     | `'appstream'`           | RHEL repo: `appstream` (single) or `remi` (multi) |
+
+#### `php_redhat_repo` — AppStream vs. Remi
+
+| Aspect                 | `'appstream'` (default)                   | `'remi'`                                      |
+|------------------------|-------------------------------------------|-----------------------------------------------|
+| Source                 | Distro AppStream (`dnf module` streams)   | Remi Collet's third-party repo                |
+| Package names          | `php-cli`, `php-fpm`, `php-<ext>`         | `php<XX>-php-cli`, `php<XX>-php-<ext>`        |
+| Paths                  | `/etc/php.d`, `/etc/php-fpm.d`            | `/etc/opt/remi/php<XX>/...`                   |
+| Available versions     | 8.0, 8.1, 8.2 on Rocky 9 (one at a time)  | 5.6 through current stable, side-by-side      |
+| Update cadence         | RHEL lifecycle (conservative)             | Upstream release day                          |
+| Lifecycle              | Application-stream support window         | Upstream PHP support per minor                |
+| `php_versions` length  | Must be 1 (streams are exclusive)         | Multiple versions allowed                     |
+
+When `php_redhat_repo: 'appstream'` and `php_versions[0].version` differs
+from the active module stream, the role fails with a hint to either
+switch the stream (`sudo dnf module reset -y php && sudo dnf module enable
+-y php:<X.Y>`) or use Remi.
+
+When `php_redhat_repo: 'remi'`, the Remi repository must already be on
+the host. Remi is multi-purpose (PHP, MariaDB, Redis, …) and is managed
+by `marcstraube.common.package_management`, not by this role. Enable it
+in inventory:
+
+```yaml
+dnf_remi_enabled: true
+# Optional: pin the active PHP module stream (Remi's modular variant)
+dnf_remi_php_version: '8.2'
+```
+
+Then run the `package_management` role before this one. The PHP role
+asserts the Remi repo is present and fails fast with this hint
+otherwise.
 
 Each entry in `php_versions` supports:
 

--- a/roles/php/defaults/main.yml
+++ b/roles/php/defaults/main.yml
@@ -48,6 +48,24 @@ php_versions:
 # Use 'auto' to match the system-provided PHP version.
 php_default_version: 'auto'
 
+# RHEL/Rocky/Alma: choose the PHP source repository.
+#
+#   'appstream' (default): Distro AppStream PHP via dnf module streams.
+#                          Single PHP version per host (streams are exclusive).
+#                          Package names: php-cli, php-fpm, php-<ext>
+#                          Paths:         /etc/php.d/, /etc/php-fpm.d/
+#                          Conservative lifecycle, no third-party repo.
+#
+#   'remi':                Remi Collet's repository. Side-by-side multi-version
+#                          installs, newest PHP releases available immediately.
+#                          Package names: php<XX>-php-cli, php<XX>-php-<ext>
+#                          Paths:         /etc/opt/remi/php<XX>/...
+#                          Pulls in remi-release; recommended for hosts that
+#                          need several PHP versions in parallel.
+#
+# Ignored on Arch and Debian (those have only one upstream source each).
+php_redhat_repo: 'appstream'
+
 #
 # PHP Configuration (php.ini)
 #

--- a/roles/php/molecule/default/converge.yml
+++ b/roles/php/molecule/default/converge.yml
@@ -15,9 +15,11 @@
     php_composer_enabled: true
 
   pre_tasks:
-    # Multi-version: add second PHP version on Debian/RedHat
-    # Arch multi-version requires AUR and cannot be tested in containers
-    - name: Converge | Enable multi-version (Debian/RedHat)
+    # Multi-version: add second PHP version on Debian.
+    # RedHat multi-version requires the Remi opt-in (AppStream streams are
+    # exclusive) and is exercised in a separate scenario.
+    # Arch multi-version requires AUR and cannot be tested in containers.
+    - name: Converge | Enable multi-version (Debian)
       ansible.builtin.set_fact:
         php_versions:
           - version: 'auto'
@@ -30,7 +32,7 @@
               - curl
               - mbstring
             fpm: true
-      when: ansible_facts['os_family'] in ['Debian', 'RedHat']
+      when: ansible_facts['os_family'] == 'Debian'
 
   tasks:
     - name: Converge | Include php role  # noqa: role-name[path]

--- a/roles/php/molecule/default/verify.yml
+++ b/roles/php/molecule/default/verify.yml
@@ -107,9 +107,9 @@
         __verify_auto_fpm: 'php{{ __verify_system_ver }}-fpm'
       when: ansible_facts['os_family'] == 'Debian'
 
-    - name: Verify | Set auto FPM service name (RedHat)
+    - name: Verify | Set auto FPM service name (RedHat AppStream)
       ansible.builtin.set_fact:
-        __verify_auto_fpm: 'php{{ __verify_system_ver_compact }}-php-fpm'
+        __verify_auto_fpm: 'php-fpm'
       when: ansible_facts['os_family'] == 'RedHat'
 
     - name: Verify | Check auto FPM service
@@ -130,21 +130,18 @@
     # FPM service — second version (Debian/RedHat only)
     #
 
+    # Second version is only converged on Debian. RedHat multi-version
+    # requires Remi opt-in and is covered in a separate scenario.
     - name: Verify | Set second FPM service name (Debian)
       ansible.builtin.set_fact:
         __verify_second_fpm: 'php8.3-fpm'
       when: ansible_facts['os_family'] == 'Debian'
 
-    - name: Verify | Set second FPM service name (RedHat)
-      ansible.builtin.set_fact:
-        __verify_second_fpm: 'php83-php-fpm'
-      when: ansible_facts['os_family'] == 'RedHat'
-
     - name: Verify | Check second FPM service
       ansible.builtin.systemd_service:
         name: '{{ __verify_second_fpm }}'
       register: __verify_second_fpm_status
-      when: ansible_facts['os_family'] in ['Debian', 'RedHat']
+      when: ansible_facts['os_family'] == 'Debian'
 
     - name: Verify | Assert second FPM is active and enabled
       ansible.builtin.assert:
@@ -154,7 +151,7 @@
         fail_msg: >-
           {{ __verify_second_fpm }} not active/enabled:
           {{ __verify_second_fpm_status.status.ActiveState }}
-      when: ansible_facts['os_family'] in ['Debian', 'RedHat']
+      when: ansible_facts['os_family'] == 'Debian'
 
     #
     # Configuration — auto version
@@ -172,10 +169,10 @@
         __verify_auto_pool: '/etc/php/{{ __verify_system_ver }}/fpm/pool.d/www.conf'
       when: ansible_facts['os_family'] == 'Debian'
 
-    - name: Verify | Set auto config paths (RedHat)
+    - name: Verify | Set auto config paths (RedHat AppStream)
       ansible.builtin.set_fact:
-        __verify_auto_ini: '/etc/opt/remi/php{{ __verify_system_ver_compact }}/php.d/99-ansible.ini'
-        __verify_auto_pool: '/etc/opt/remi/php{{ __verify_system_ver_compact }}/php-fpm.d/www.conf'
+        __verify_auto_ini: '/etc/php.d/99-ansible.ini'
+        __verify_auto_pool: '/etc/php-fpm.d/www.conf'
       when: ansible_facts['os_family'] == 'RedHat'
 
     - name: Verify | Check auto php.ini drop-in exists
@@ -235,37 +232,31 @@
         __verify_second_pool: '/etc/php/8.3/fpm/pool.d/www.conf'
       when: ansible_facts['os_family'] == 'Debian'
 
-    - name: Verify | Set second config paths (RedHat)
-      ansible.builtin.set_fact:
-        __verify_second_ini: '/etc/opt/remi/php83/php.d/99-ansible.ini'
-        __verify_second_pool: '/etc/opt/remi/php83/php-fpm.d/www.conf'
-      when: ansible_facts['os_family'] == 'RedHat'
-
     - name: Verify | Check second php.ini drop-in exists
       ansible.builtin.stat:
         path: '{{ __verify_second_ini }}'
       register: __verify_second_ini_stat
-      when: ansible_facts['os_family'] in ['Debian', 'RedHat']
+      when: ansible_facts['os_family'] == 'Debian'
 
     - name: Verify | Assert second php.ini deployed
       ansible.builtin.assert:
         that:
           - __verify_second_ini_stat.stat.exists
         fail_msg: "Second version php.ini not found at {{ __verify_second_ini }}"
-      when: ansible_facts['os_family'] in ['Debian', 'RedHat']
+      when: ansible_facts['os_family'] == 'Debian'
 
     - name: Verify | Check second www.conf exists
       ansible.builtin.stat:
         path: '{{ __verify_second_pool }}'
       register: __verify_second_pool_stat
-      when: ansible_facts['os_family'] in ['Debian', 'RedHat']
+      when: ansible_facts['os_family'] == 'Debian'
 
     - name: Verify | Assert second www.conf deployed
       ansible.builtin.assert:
         that:
           - __verify_second_pool_stat.stat.exists
         fail_msg: "Second version www.conf not found at {{ __verify_second_pool }}"
-      when: ansible_facts['os_family'] in ['Debian', 'RedHat']
+      when: ansible_facts['os_family'] == 'Debian'
 
     #
     # Composer

--- a/roles/php/tasks/default_version.yml
+++ b/roles/php/tasks/default_version.yml
@@ -16,7 +16,11 @@
     path: '/usr/bin/php{{ __php_default_ver }}'
   when: __php_has_alternatives | bool
 
-- name: Default Version | Set default PHP symlink (RedHat)
+# AppStream ships /usr/bin/php directly (single active stream), so no
+# wrapper symlink is needed. Remi installs versioned executables
+# (/usr/bin/php82, /usr/bin/php83, ...) — link the inventory's default
+# version into /usr/local/bin/php for shell convenience.
+- name: Default Version | Set default PHP symlink (RedHat Remi)
   ansible.builtin.file:
     src: '/usr/bin/php{{ __php_default_ver_compact }}'
     dest: '/usr/local/bin/php'
@@ -24,7 +28,9 @@
     force: true
     owner: root
     group: root
-  when: ansible_facts['os_family'] == 'RedHat'
+  when:
+    - ansible_facts['os_family'] == 'RedHat'
+    - php_redhat_repo == 'remi'
 
 - name: Default Version | Set default PHP symlink (Arch AUR)
   ansible.builtin.file:

--- a/roles/php/tasks/install.yml
+++ b/roles/php/tasks/install.yml
@@ -30,6 +30,41 @@
     - ansible_facts['os_family'] == 'Debian'
     - __php_debian_repo_info.stdout | default('') | trim | length > 0
 
+# When php_redhat_repo: 'remi' is requested, the Remi repo itself must
+# already be on the host (deployed by marcstraube.common.package_management
+# via dnf_remi_enabled — Remi is multi-purpose and lives there, not here).
+- name: Install | Check Remi repo presence (RedHat)
+  ansible.builtin.command:
+    cmd: dnf repolist --enabled remi-safe
+  register: __php_remi_repolist
+  changed_when: false
+  failed_when: false
+  check_mode: false
+  when:
+    - ansible_facts['os_family'] == 'RedHat'
+    - php_redhat_repo == 'remi'
+
+- name: Install | Assert Remi repo is enabled when requested (RedHat)
+  ansible.builtin.assert:
+    that:
+      - "'remi-safe' in (__php_remi_repolist.stdout | default(''))"
+    fail_msg: |
+      php_redhat_repo is 'remi' but the Remi repository is not enabled
+      on this host. Remi is multi-purpose (PHP, MariaDB, Redis, ...) and
+      is managed by marcstraube.common.package_management — enable it
+      in inventory with:
+
+        dnf_remi_enabled: true
+
+      Optionally pin the active PHP module stream with:
+
+        dnf_remi_php_version: '8.2'
+
+      Then re-run the package_management role before this one.
+  when:
+    - ansible_facts['os_family'] == 'RedHat'
+    - php_redhat_repo == 'remi'
+
 - name: Install | Detect current RedHat PHP version
   ansible.builtin.shell:
     cmd: set -o pipefail && dnf info php-cli 2>/dev/null | grep -m1 '^Version' | grep -oP '\d+\.\d+'

--- a/roles/php/tasks/install_version.yml
+++ b/roles/php/tasks/install_version.yml
@@ -5,6 +5,21 @@
       {{ (__php_version_item.version == 'auto')
          | ternary(__php_system_version, __php_version_item.version) }}
 
+- name: Install Version | Validate AppStream version matches active stream
+  ansible.builtin.assert:
+    that:
+      - (__php_resolved_version | string) == (__php_system_version | string)
+    fail_msg: |
+      The active AppStream PHP module stream is {{ __php_system_version }},
+      but the inventory requested PHP {{ __php_resolved_version }}.
+      AppStream streams are exclusive — switch the active stream with
+      'sudo dnf module reset -y php && sudo dnf module enable -y php:{{ __php_resolved_version }}'
+      before re-running this role, or set php_redhat_repo: 'remi' to use
+      Remi side-by-side packages instead.
+  when:
+    - ansible_facts['os_family'] == 'RedHat'
+    - php_redhat_repo == 'appstream'
+
 - name: Install Version | Set version facts
   ansible.builtin.set_fact:
     __php_ver: '{{ __php_resolved_version }}'
@@ -33,6 +48,24 @@
   when:
     - ansible_facts['os_family'] == 'Archlinux'
     - __php_ver != __php_system_version
+
+# Override for Remi (RHEL multi-version side-by-side install).
+# vars/RedHat.yml ships AppStream defaults; switch to Remi naming +
+# paths when the inventory selects php_redhat_repo: 'remi'.
+- name: Install Version | Set RedHat Remi package patterns
+  ansible.builtin.set_fact:
+    __php_cli_package: 'php{{ __php_ver_compact }}-php-cli'
+    __php_fpm_package: 'php{{ __php_ver_compact }}-php-fpm'
+    __php_extension_prefix: 'php{{ __php_ver_compact }}-php-'
+    __php_fpm_service: 'php{{ __php_ver_compact }}-php-fpm'
+    __php_conf_dirs:
+      - '/etc/opt/remi/php{{ __php_ver_compact }}/php.d'
+    __php_fpm_pool_dir: '/etc/opt/remi/php{{ __php_ver_compact }}/php-fpm.d'
+    __php_fpm_listen_default: >-
+      /var/opt/remi/php{{ __php_ver_compact }}/run/php-fpm/www.sock
+  when:
+    - ansible_facts['os_family'] == 'RedHat'
+    - php_redhat_repo == 'remi'
 
 - name: Install Version | Build package list
   ansible.builtin.set_fact:

--- a/roles/php/tasks/main.yml
+++ b/roles/php/tasks/main.yml
@@ -24,6 +24,22 @@
   tags:
     - php
 
+- name: Main | Validate php_redhat_repo
+  ansible.builtin.assert:
+    that:
+      - php_redhat_repo in ['appstream', 'remi']
+      - (php_redhat_repo == 'remi') or (php_versions | length == 1)
+    fail_msg: |
+      php_redhat_repo must be 'appstream' or 'remi'.
+      AppStream dnf module streams are exclusive — only a single PHP
+      version per host. For multi-version installs set
+      php_redhat_repo: 'remi'.
+  when:
+    - php_enabled | bool
+    - ansible_facts['os_family'] == 'RedHat'
+  tags:
+    - php
+
 - name: Main | Import repository tasks
   ansible.builtin.import_tasks:
     file: repos.yml

--- a/roles/php/tasks/repos.yml
+++ b/roles/php/tasks/repos.yml
@@ -44,3 +44,10 @@
   when:
     - ansible_facts['os_family'] == 'Debian'
     - (__php_sury_repo is changed) or (__php_sury_ppa is changed)
+
+#
+# Remi (RHEL/Rocky/Alma): the Remi repository itself is multi-purpose
+# (PHP, MariaDB, Redis, …) and lives in marcstraube.common.package_management
+# under dnf_remi_enabled. The php role only validates that the repo is on
+# the host when php_redhat_repo: 'remi' is requested — see install.yml.
+#

--- a/roles/php/vars/RedHat.yml
+++ b/roles/php/vars/RedHat.yml
@@ -1,19 +1,79 @@
 ---
-# Remi SCL package name patterns (resolved at runtime via __php_ver_compact set in tasks)
-__php_cli_package: 'php{{ __php_ver_compact }}-php-cli'
-__php_fpm_package: 'php{{ __php_ver_compact }}-php-fpm'
-__php_extension_prefix: 'php{{ __php_ver_compact }}-php-'
-__php_fpm_service: 'php{{ __php_ver_compact }}-php-fpm'
+# AppStream PHP defaults (used when php_redhat_repo == 'appstream', the
+# default). Remi patterns are applied as overrides in install_version.yml
+# when php_redhat_repo == 'remi' — they need __php_ver_compact, which is
+# set per-version inside the install loop.
 
-# RHEL uses symlinks for default PHP version
+__php_cli_package: 'php-cli'
+__php_fpm_package: 'php-fpm'
+__php_extension_prefix: 'php-'
+__php_fpm_service: 'php-fpm'
+
+# RHEL does not use update-alternatives for PHP (single stream at a time)
 __php_has_alternatives: false
 
-# Configuration paths (version-dependent, resolved via __php_ver_compact)
+# AppStream paths
 __php_conf_dirs:
-  - '/etc/opt/remi/php{{ __php_ver_compact }}/php.d'
-__php_fpm_pool_dir: '/etc/opt/remi/php{{ __php_ver_compact }}/php-fpm.d'
-__php_fpm_listen_default: '/var/opt/remi/php{{ __php_ver_compact }}/run/php-fpm/www.sock'
+  - '/etc/php.d'
+  - '/etc/php-fpm.d'
+__php_fpm_pool_dir: '/etc/php-fpm.d'
+__php_fpm_listen_default: '/run/php-fpm/www.sock'
 
 # FPM pool defaults
 __php_fpm_default_user: 'apache'
 __php_fpm_default_group: 'apache'
+
+# Extension name mapping: generic name → RHEL AppStream package name.
+# Empty string = built into the php package (no separate package needed).
+# Missing keys fall back to '<__php_extension_prefix><name>'.
+__php_extension_map:
+  # Built into the core php package on AppStream
+  curl: ''
+  mbstring: ''
+  openssl: ''
+  json: ''
+  tokenizer: ''
+  ctype: ''
+  session: ''
+  fileinfo: ''
+  filter: ''
+  iconv: ''
+  pcre: ''
+  pdo: ''
+  phar: ''
+  # Naming differences vs. generic extension names
+  mysql: 'php-mysqlnd'
+  mysqli: 'php-mysqlnd'
+  mysqlnd: 'php-mysqlnd'
+  pdo_mysql: 'php-mysqlnd'
+  dom: 'php-xml'
+  simplexml: 'php-xml'
+  xmlreader: 'php-xml'
+  xmlwriter: 'php-xml'
+  xsl: 'php-xml'
+  # Separate AppStream packages
+  bcmath: 'php-bcmath'
+  dba: 'php-dba'
+  enchant: 'php-enchant'
+  gd: 'php-gd'
+  gmp: 'php-gmp'
+  intl: 'php-intl'
+  ldap: 'php-ldap'
+  odbc: 'php-odbc'
+  opcache: 'php-opcache'
+  pdo_sqlite: 'php-pdo'
+  pgsql: 'php-pgsql'
+  process: 'php-process'
+  snmp: 'php-snmp'
+  soap: 'php-soap'
+  sodium: 'php-sodium'
+  sqlite: 'php-pdo'
+  xml: 'php-xml'
+  zip: 'php-pecl-zip'
+  # PECL extensions (in EPEL or AppStream)
+  apcu: 'php-pecl-apcu'
+  imagick: 'php-pecl-imagick'
+  memcached: 'php-pecl-memcache'
+  mongodb: 'php-pecl-mongodb'
+  redis: 'php-pecl-redis'
+  xdebug: 'php-pecl-xdebug3'


### PR DESCRIPTION
## Summary

- Introduce `php_redhat_repo` (`'appstream'` default, `'remi'` opt-in) in `roles/php/defaults/main.yml`.
- `roles/php/vars/RedHat.yml`: AppStream defaults (unversioned package names, `/etc/php.d`, `/etc/php-fpm.d`) plus a RHEL-side `__php_extension_map`.
- `roles/php/tasks/install_version.yml`: per-version Remi overrides when `php_redhat_repo: 'remi'`; assert active AppStream module stream equals the requested version.
- `roles/php/tasks/install.yml`: assert Remi repo is on the host when requested (the repo is multi-purpose and managed by `marcstraube.common.package_management` via `dnf_remi_enabled`, not by the `php` role).
- `roles/php/tasks/main.yml`: assert `php_redhat_repo in {appstream, remi}` and AppStream uses a single `php_versions` entry.
- `roles/php/tasks/default_version.yml`: `/usr/local/bin/php` symlink only on Remi (AppStream provides `/usr/bin/php`).
- Molecule converge tests AppStream single-version on RedHat. Multi-version Remi scenario is a follow-up.
- README + MIGRATION.md updated.

Closes #190

## Why

Previously `vars/RedHat.yml` shipped Remi-SCL package patterns unconditionally on every RHEL-family host but the role did not deploy or check for the Remi repository. Stock Rocky/Alma/RHEL installs (AppStream only) failed at install time with `No package php<XX>-php-cli available`.

## Behaviour matrix (RHEL)

| `php_redhat_repo` | Repo source                    | Package names         | Paths                          | Multi-version | Requires                 |
|-------------------|--------------------------------|-----------------------|--------------------------------|---------------|--------------------------|
| `'appstream'`     | distro dnf module streams      | `php-cli`, `php-fpm`  | `/etc/php.d`, `/etc/php-fpm.d` | No (1 stream) | nothing                  |
| `'remi'`          | Remi (via `package_management`)| `php<XX>-php-cli`     | `/etc/opt/remi/php<XX>/...`    | Yes           | `dnf_remi_enabled: true` |

## Required action (breaking)

Inventories that previously relied on Remi being implicitly active need both flags:

```yaml
dnf_remi_enabled: true            # marcstraube.common.package_management
php_redhat_repo: 'remi'           # marcstraube.common.php
```

See the v2.0.1 entry in MIGRATION.md.

## Test plan

- [x] `ansible-lint roles/php/` → 0 failures
- [x] `molecule test -p php-rocky-9`  → green (AppStream single-version)
- [x] `molecule test -p php-rocky-10` → green (AppStream single-version)
- [x] `molecule test -p php-debian-trixie` → green (Sury multi-version, unchanged)
- [x] `molecule test -p php-archlinux` → green (Arch repo, unchanged)
- [ ] Remi multi-version scenario on RedHat: follow-up (no Remi opt-in pre-installed in current test setup; tracked as `project_php_role_tests.md`).