### PR TITLE
feat(package_management): apt_non_free toggle for Debian default sources

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -5,6 +5,29 @@ breaking changes adds a section here with before/after inventory
 snippets. For the full list of changes per release, see
 [CHANGELOG.md](CHANGELOG.md).
 
+## v2.1.0 (unreleased)
+
+### `package_management` — `apt_non_free_enabled` toggle (Debian)
+
+`roles/package_management` gains two new Debian-only toggles:
+
+- `apt_non_free_enabled` (default `false`) — adds `non-free` to the
+  Components line of `/etc/apt/sources.list.d/debian.sources`.
+- `apt_non_free_firmware_enabled` (default `false`) — adds
+  `non-free-firmware` (split from non-free since Bookworm).
+
+The role reads the current Components line from the deb822-format
+default sources file (Trixie+) and only appends the requested
+components — existing entries are preserved, no overwrite.
+
+No action required for inventories upgrading to v2.1.0 — the toggles
+default to `false` and the existing main-only sources behaviour is
+unchanged.
+
+Users who previously enabled the non-free component out-of-band via
+custom `apt_custom_repos` entries can now switch to the toggle for
+the same effect and benefit from idempotent Components-line management.
+
 ## v2.0.1 (unreleased)
 
 ### `hardening` — `/tmp` is no longer auto-converted to tmpfs

--- a/roles/package_management/README.md
+++ b/roles/package_management/README.md
@@ -129,10 +129,12 @@ overrides if needed.
 
 ### Debian/Ubuntu - Repositories
 
-| Variable                          | Default | Description                           |
-|-----------------------------------|---------|---------------------------------------|
-| `apt_backports_enabled`           | `false` | Enable Debian Backports               |
-| `apt_custom_repos`                | `[]`    | Custom repository definitions         |
+| Variable                              | Default | Description                                                              |
+|---------------------------------------|---------|--------------------------------------------------------------------------|
+| `apt_backports_enabled`               | `false` | Enable Debian Backports                                                  |
+| `apt_non_free_enabled`                | `false` | Append `non-free` to Components in default Debian deb822 sources         |
+| `apt_non_free_firmware_enabled`       | `false` | Append `non-free-firmware` to Components in default Debian deb822 sources |
+| `apt_custom_repos`                    | `[]`    | Custom repository definitions                                            |
 
 ### RHEL/Rocky - DNF
 

--- a/roles/package_management/defaults/main.yml
+++ b/roles/package_management/defaults/main.yml
@@ -511,6 +511,16 @@ apt_preferences: []
 # Enable Debian Backports (Debian only)
 apt_backports_enabled: false
 
+# Enable the 'non-free' component in the default Debian sources
+# (Debian only — Ubuntu has multiverse, not addressed by this toggle).
+# Adds 'non-free' to the Components line of
+# /etc/apt/sources.list.d/debian.sources (deb822 format on Trixie+).
+apt_non_free_enabled: false
+
+# Enable the 'non-free-firmware' component (Debian only, since Bookworm).
+# Required for proprietary firmware blobs separated from non-free in 2023.
+apt_non_free_firmware_enabled: false
+
 # PPAs to add (Ubuntu only)
 # Example: ['ppa:ondrej/php', 'ppa:graphics-drivers/ppa']
 apt_ppas: []

--- a/roles/package_management/molecule/default/converge.yml
+++ b/roles/package_management/molecule/default/converge.yml
@@ -37,6 +37,8 @@
     apt_unattended_upgrades_enabled: false
     apt_apt_file_enabled: true
     apt_needrestart_enabled: true
+    apt_non_free_enabled: true
+    apt_non_free_firmware_enabled: true
 
     # RedHat/Fedora specific
     dnf_fastestmirror: true

--- a/roles/package_management/molecule/default/verify.yml
+++ b/roles/package_management/molecule/default/verify.yml
@@ -154,6 +154,19 @@
           register: apt_lists
           failed_when: not apt_lists.stat.exists
 
+        - name: Verify | Read default Debian sources Components line
+          ansible.builtin.shell:
+            cmd: "grep -m1 '^Components:' /etc/apt/sources.list.d/debian.sources"
+          register: components_line
+          changed_when: false
+
+        - name: Verify | Assert non-free + non-free-firmware applied
+          ansible.builtin.assert:
+            that:
+              - "'non-free' in components_line.stdout"
+              - "'non-free-firmware' in components_line.stdout"
+            fail_msg: "Components line missing non-free entries: {{ components_line.stdout }}"
+
     #
     # RedHat/Fedora Verification
     #

--- a/roles/package_management/tasks/debian/repos.yml
+++ b/roles/package_management/tasks/debian/repos.yml
@@ -1,5 +1,45 @@
 ---
 #
+# Default Debian sources — Components management (Debian only)
+#
+# The deb822-format default sources file (Trixie+ ships
+# /etc/apt/sources.list.d/debian.sources) contains multiple Components
+# lines (one per stanza: main, security, sometimes updates). Both
+# toggles below append idempotently to every Components line whose
+# value does not already contain the requested term.
+#
+
+- name: Repos | Stat default Debian sources file (deb822)
+  ansible.builtin.stat:
+    path: /etc/apt/sources.list.d/debian.sources
+  register: __apt_debian_sources
+  when: ansible_facts['distribution'] == 'Debian'
+
+- name: Repos | Add non-free to every Components line
+  ansible.builtin.replace:
+    path: /etc/apt/sources.list.d/debian.sources
+    # Match a Components: line that does NOT already contain a
+    # bare 'non-free' (excluding 'non-free-firmware').
+    regexp: '^(Components:(?!.*\bnon-free(?!-firmware)\b).*)$'
+    replace: '\1 non-free'
+  when:
+    - ansible_facts['distribution'] == 'Debian'
+    - __apt_debian_sources.stat.exists | default(false)
+    - apt_non_free_enabled | bool
+  notify: 'apt configuration changed'
+
+- name: Repos | Add non-free-firmware to every Components line
+  ansible.builtin.replace:
+    path: /etc/apt/sources.list.d/debian.sources
+    regexp: '^(Components:(?!.*\bnon-free-firmware\b).*)$'
+    replace: '\1 non-free-firmware'
+  when:
+    - ansible_facts['distribution'] == 'Debian'
+    - __apt_debian_sources.stat.exists | default(false)
+    - apt_non_free_firmware_enabled | bool
+  notify: 'apt configuration changed'
+
+#
 # Backports (Debian only)
 #
 


### PR DESCRIPTION
## Summary

Two new Debian-only toggles in `roles/package_management/defaults/main.yml`:

- `apt_non_free_enabled` (default `false`) — appends `non-free` to every Components line in `/etc/apt/sources.list.d/debian.sources`.
- `apt_non_free_firmware_enabled` (default `false`) — appends `non-free-firmware` (split from non-free since Bookworm).

Implementation in `tasks/debian/repos.yml` uses `ansible.builtin.replace` with a negative-lookahead regex, so each Components line is only modified when it doesn't already contain the term. Idempotent across re-runs.

Closes #194

## Why

The default Debian sources stay on `main` only — `non-free`/`non-free-firmware` had to be added via `apt_custom_repos` until now. Multi-purpose components belong in `package_management` per the existing repo-classification convention; #193 (utils archive section) needs `non-free` on Debian for `unrar`.

## Behaviour

- Debian only (deb822 default sources). Ubuntu uses `multiverse` with a different layout and is not addressed.
- Both stanzas (main + security) are updated.
- Re-runs are no-ops (negative-lookahead prevents duplicate appends).
- Existing components in the line are preserved.

## Test plan

- [x] `ansible-lint roles/package_management/` → 0 failures
- [x] `molecule test -p package-management-debian-trixie` → green; verify asserts `non-free` + `non-free-firmware` in Components after converge.
- [x] `molecule test -p package-management-rocky-9` → green (no-op on RedHat).

## Follow-up

After this PR + #193 (utils archive section) merge, a small commit will flip `utils/vars/Debian.yml` from `__utils_archive_unrar: ''` to `'unrar'`, completing the unrar-on-Debian story.