### PR TITLE
feat(utils): add Archive / Compression section

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -28,6 +28,63 @@ Users who previously enabled the non-free component out-of-band via
 custom `apt_custom_repos` entries can now switch to the toggle for
 the same effect and benefit from idempotent Components-line management.
 
+### `utils` — new Archive / Compression section
+
+`roles/utils/defaults/main.yml` gains a dedicated archive section with
+eight new toggles:
+
+| Toggle                          | Default |
+|---------------------------------|---------|
+| `utils_archive_tar_enabled`     | `true`  |
+| `utils_archive_zstd_enabled`    | `true`  |
+| `utils_archive_zip_enabled`     | `true`  |
+| `utils_archive_unzip_enabled`   | `true`  |
+| `utils_archive_p7zip_enabled`   | `false` |
+| `utils_archive_unrar_enabled`   | `false` |
+| `utils_archive_atool_enabled`   | `false` |
+| `utils_archive_pigz_enabled`    | `false` |
+
+Notes per toggle:
+
+- `tar` — POSIX `tar`. Required on RHEL minimal; Arch and Debian ship
+  it in their base image (install is a no-op there).
+- `zstd` — Modern fast compressor. Default Arch package format, used
+  by `mkinitcpio`, `makepkg`, `btrfs send/receive`.
+- `zip`, `unzip` — see deprecation notice below.
+- `p7zip` — 7-Zip clone. RHEL pulls `p7zip` + `p7zip-plugins` from EPEL.
+- `unrar` — RAR extractor.
+  - Arch: built from AUR via `aur_builder`.
+  - Debian: lives in non-free; set `apt_non_free_enabled: true` in
+    `marcstraube.common.package_management`.
+  - RHEL: lives in RPM Fusion non-free; set
+    `dnf_rpmfusion_nonfree_enabled: true` in
+    `marcstraube.common.package_management`.
+- `atool` — Universal archive frontend (dispatches to
+  tar/zip/7z/zstd/unrar/...). Not in EPEL 10 (entry blank there).
+- `pigz` — Parallel gzip implementation.
+
+The toggles are additive — no existing behaviour changes for inventories
+that simply upgrade. Users explicitly disabling `utils_enabled` are
+unaffected.
+
+#### Deprecation: `zip` / `unzip` in `base`
+
+`zip` and `unzip` are currently in `__base_default_packages` for all
+three distros AND now in `utils_archive_*` (both default `true`). The
+duplication is idempotent. In **v3.0.0**, both packages will be removed
+from `base`; deployments relying on them must either keep
+`utils_enabled: true` (default) **or** add the packages to
+`base_extra_packages`:
+
+```yaml
+# Required only if you set utils_enabled: false
+base_extra_packages:
+  - zip
+  - unzip
+```
+
+No action required for v2.1.0 — the deprecation is purely informational.
+
 ## v2.0.1 (unreleased)
 
 ### `hardening` — `/tmp` is no longer auto-converted to tmpfs

--- a/roles/base/vars/Archlinux.yml
+++ b/roles/base/vars/Archlinux.yml
@@ -9,6 +9,9 @@ __base_default_packages:
   - 'curl'
   - 'rsync'
   - 'tree'
+  # DEPRECATED in v2.1.0 — moved to marcstraube.common.utils archive
+  # section (utils_archive_zip_enabled / utils_archive_unzip_enabled,
+  # both default true). Will be removed from base in v3.0.0.
   - 'unzip'
   - 'zip'
 

--- a/roles/base/vars/Debian.yml
+++ b/roles/base/vars/Debian.yml
@@ -9,6 +9,9 @@ __base_default_packages:
   - 'curl'
   - 'rsync'
   - 'tree'
+  # DEPRECATED in v2.1.0 — moved to marcstraube.common.utils archive
+  # section (utils_archive_zip_enabled / utils_archive_unzip_enabled,
+  # both default true). Will be removed from base in v3.0.0.
   - 'unzip'
   - 'zip'
 

--- a/roles/base/vars/RedHat.yml
+++ b/roles/base/vars/RedHat.yml
@@ -9,6 +9,9 @@ __base_default_packages:
   - 'curl'
   - 'rsync'
   - 'tree'
+  # DEPRECATED in v2.1.0 — moved to marcstraube.common.utils archive
+  # section (utils_archive_zip_enabled / utils_archive_unzip_enabled,
+  # both default true). Will be removed from base in v3.0.0.
   - 'unzip'
   - 'zip'
 

--- a/roles/utils/README.md
+++ b/roles/utils/README.md
@@ -103,6 +103,19 @@ All other tools use the same package name on every supported distro.
 |--------------------------------|---------|------------------------|
 | `utils_transfer_rsync_enabled` | `true`  | Fast file copying tool |
 
+### Archive / Compression
+
+| Variable                       | Default | Description                                                  |
+|--------------------------------|---------|--------------------------------------------------------------|
+| `utils_archive_tar_enabled`    | `true`  | POSIX tar (required on RHEL minimal; no-op on Arch/Debian)   |
+| `utils_archive_zstd_enabled`   | `true`  | Modern fast compressor (.zst, default Arch package format)   |
+| `utils_archive_zip_enabled`    | `true`  | zip — deprecated in `base`, will move here exclusively in v3 |
+| `utils_archive_unzip_enabled`  | `true`  | unzip — deprecated in `base`, will move here exclusively in v3 |
+| `utils_archive_p7zip_enabled`  | `false` | 7-Zip clone (RHEL: pulls p7zip + p7zip-plugins via EPEL)     |
+| `utils_archive_unrar_enabled`  | `false` | RAR extractor (Arch: AUR; Debian: needs `apt_non_free_enabled`; RHEL: needs `dnf_rpmfusion_nonfree_enabled`) |
+| `utils_archive_atool_enabled`  | `false` | Universal archive frontend (Arch/Debian/EL9; not in EPEL 10) |
+| `utils_archive_pigz_enabled`   | `false` | Parallel gzip                                                |
+
 ### File Managers
 
 | Variable                       | Default | Description                            |

--- a/roles/utils/defaults/main.yml
+++ b/roles/utils/defaults/main.yml
@@ -100,6 +100,54 @@ utils_net_arp_scan_enabled: false
 utils_transfer_rsync_enabled: true
 
 #
+# Archive / Compression
+#
+
+# tar — POSIX tar archive tool.
+# Required on RHEL minimal installs (Arch & Debian ship it in the
+# base image and the package install is a no-op there).
+utils_archive_tar_enabled: true
+
+# zstd — modern, fast compressor (.zst).
+# Default Arch package format and used by mkinitcpio, makepkg,
+# btrfs send/receive, etc.
+utils_archive_zstd_enabled: true
+
+# zip — universal compressed archive format
+# DEPRECATION: also present in marcstraube.common.base default
+# packages (v2.0.x); v3.0.0 will remove it there and rely on this
+# toggle exclusively.
+utils_archive_zip_enabled: true
+
+# unzip — counterpart to zip
+# DEPRECATION: also present in marcstraube.common.base default
+# packages (v2.0.x); v3.0.0 will remove it there and rely on this
+# toggle exclusively.
+utils_archive_unzip_enabled: true
+
+# p7zip — 7-Zip clone (.7z high-compression archives).
+# RHEL: in EPEL as p7zip + p7zip-plugins (both pulled in together).
+utils_archive_p7zip_enabled: false
+
+# unrar — extract proprietary RAR archives.
+#   Arch: pulled from AUR — requires `aur_helper` set in
+#         marcstraube.common.package_management (default 'paru').
+#   Debian: lives in non-free — requires
+#           `apt_non_free_enabled: true` in
+#           marcstraube.common.package_management.
+#   RHEL: lives in RPM Fusion non-free — requires
+#           `dnf_rpmfusion_nonfree_enabled: true` in
+#           marcstraube.common.package_management.
+utils_archive_unrar_enabled: false
+
+# atool — universal archive frontend that dispatches to
+# tar/zip/7z/zstd/unrar/... based on file type.
+utils_archive_atool_enabled: false
+
+# pigz — parallel gzip, scales gzip across CPU cores.
+utils_archive_pigz_enabled: false
+
+#
 # File Managers
 #
 

--- a/roles/utils/molecule/default/converge.yml
+++ b/roles/utils/molecule/default/converge.yml
@@ -36,6 +36,16 @@
     # File transfer
     utils_transfer_rsync_enabled: true
 
+    # Archive / compression
+    utils_archive_tar_enabled: true
+    utils_archive_zstd_enabled: true
+    utils_archive_zip_enabled: true
+    utils_archive_unzip_enabled: true
+    utils_archive_p7zip_enabled: true
+    utils_archive_atool_enabled: true
+    utils_archive_pigz_enabled: true
+    # unrar omitted — Arch AUR-only, Debian non-free, RHEL unavailable
+
     # File managers
     utils_filemgr_mc_enabled: true
     utils_filemgr_vifm_enabled: true

--- a/roles/utils/tasks/install.yml
+++ b/roles/utils/tasks/install.yml
@@ -29,6 +29,14 @@
           (utils_net_xh_enabled | bool)            | ternary(__utils_net_xh, ''),
           (utils_net_arp_scan_enabled | bool)      | ternary(__utils_net_arp_scan, ''),
           (utils_transfer_rsync_enabled | bool)    | ternary(__utils_transfer_rsync, ''),
+          (utils_archive_tar_enabled | bool)       | ternary(__utils_archive_tar, ''),
+          (utils_archive_zstd_enabled | bool)      | ternary(__utils_archive_zstd, ''),
+          (utils_archive_zip_enabled | bool)       | ternary(__utils_archive_zip, ''),
+          (utils_archive_unzip_enabled | bool)     | ternary(__utils_archive_unzip, ''),
+          (utils_archive_p7zip_enabled | bool)     | ternary(__utils_archive_p7zip, ''),
+          (utils_archive_unrar_enabled | bool)     | ternary(__utils_archive_unrar, ''),
+          (utils_archive_atool_enabled | bool)     | ternary(__utils_archive_atool, ''),
+          (utils_archive_pigz_enabled | bool)      | ternary(__utils_archive_pigz, ''),
           (utils_filemgr_mc_enabled | bool)        | ternary(__utils_filemgr_mc, ''),
           (utils_filemgr_vifm_enabled | bool)      | ternary(__utils_filemgr_vifm, ''),
           (utils_filemgr_ranger_enabled | bool)    | ternary(__utils_filemgr_ranger, ''),
@@ -57,7 +65,7 @@
           (utils_fun_pokemon_colorscripts_enabled | bool) | ternary(__utils_fun_pokemon_colorscripts, ''),
           (utils_fun_pokemonsay_enabled | bool)    | ternary(__utils_fun_pokemonsay, ''),
           (utils_fun_hollywood_enabled | bool)     | ternary(__utils_fun_hollywood, ''),
-        ] | reject('equalto', '') | list
+        ] | flatten | reject('equalto', '') | list
       }}
 
 - name: Install | Utils packages
@@ -91,7 +99,9 @@
         ((utils_fun_pokemonsay_enabled | bool) | ternary(
           __utils_aur_packages.pokemonsay | default([]), [])) +
         ((utils_fun_hollywood_enabled | bool) | ternary(
-          __utils_aur_packages.hollywood | default([]), []))
+          __utils_aur_packages.hollywood | default([]), [])) +
+        ((utils_archive_unrar_enabled | bool) | ternary(
+          __utils_aur_packages.archive_unrar | default([]), []))
       }}
   when: ansible_facts['os_family'] == 'Archlinux'
 

--- a/roles/utils/vars/Archlinux.yml
+++ b/roles/utils/vars/Archlinux.yml
@@ -29,6 +29,13 @@ __utils_net_netcat: 'openbsd-netcat'
 __utils_net_xh: 'xh'
 
 #
+# Archive / Compression
+#
+
+__utils_archive_p7zip: 'p7zip'
+__utils_archive_unrar: ''  # AUR only
+
+#
 # File Managers
 #
 
@@ -85,3 +92,5 @@ __utils_aur_packages:
     - pokemonsay-git
   hollywood:
     - hollywood
+  archive_unrar:
+    - unrar

--- a/roles/utils/vars/Debian.yml
+++ b/roles/utils/vars/Debian.yml
@@ -23,6 +23,18 @@ __utils_net_netcat: 'netcat-openbsd'
 __utils_net_xh: 'xh'
 
 #
+# Archive / Compression
+#
+
+# p7zip-full pulls in the full 7z command (the p7zip package alone
+# only ships the limited 7zr binary on Debian).
+__utils_archive_p7zip: 'p7zip-full'
+# unrar lives in Debian non-free. Enable the component via
+# marcstraube.common.package_management's apt_non_free_enabled toggle
+# (default false) — then this entry installs the package directly.
+__utils_archive_unrar: 'unrar'
+
+#
 # File Managers
 #
 

--- a/roles/utils/vars/RedHat-9.yml
+++ b/roles/utils/vars/RedHat-9.yml
@@ -28,6 +28,19 @@ __utils_net_xh: ''  # not in Rocky
 __utils_net_httpie: ''  # EPEL 9 package has unsatisfiable CRB-only dependency
 
 #
+# Archive / Compression
+# (Same as RedHat.yml — RHEL-9 vars override the os_family file
+# entirely when present, so archive entries are repeated here.)
+#
+
+__utils_archive_p7zip:
+  - 'p7zip'
+  - 'p7zip-plugins'
+# unrar from RPM Fusion non-free — requires
+# dnf_rpmfusion_nonfree_enabled in marcstraube.common.package_management.
+__utils_archive_unrar: 'unrar'
+
+#
 # File Managers
 #
 

--- a/roles/utils/vars/RedHat.yml
+++ b/roles/utils/vars/RedHat.yml
@@ -27,6 +27,22 @@ __utils_net_httpie: ''  # not in EPEL 10
 __utils_net_arp_scan: ''  # not in EPEL 10
 
 #
+# Archive / Compression
+#
+
+# p7zip on EPEL ships in two packages — p7zip (7zr) plus p7zip-plugins
+# (full 7z, 7za with all codecs). Install both.
+__utils_archive_p7zip:
+  - 'p7zip'
+  - 'p7zip-plugins'
+# unrar lives in RPM Fusion non-free (not in EPEL). Enable the repo
+# via marcstraube.common.package_management's dnf_rpmfusion_nonfree_enabled
+# toggle (default false); then this entry installs the package directly.
+__utils_archive_unrar: 'unrar'
+# atool is not packaged for EPEL 10 (EPEL 9 has it — see RedHat-9.yml).
+__utils_archive_atool: ''
+
+#
 # File Managers
 #
 

--- a/roles/utils/vars/main.yml
+++ b/roles/utils/vars/main.yml
@@ -48,6 +48,20 @@ __utils_net_arp_scan: 'arp-scan'
 __utils_transfer_rsync: 'rsync'
 
 #
+# Archive / Compression
+# Tools available on all distros (or with distro override below).
+#
+
+__utils_archive_tar: 'tar'
+__utils_archive_zstd: 'zstd'
+__utils_archive_zip: 'zip'
+__utils_archive_unzip: 'unzip'
+__utils_archive_atool: 'atool'
+__utils_archive_pigz: 'pigz'
+# p7zip + unrar have differing package names across distros — see
+# Archlinux.yml, Debian.yml, RedHat.yml, RedHat-9.yml.
+
+#
 # File Managers
 #
 


### PR DESCRIPTION
## Summary

New toggle group in `roles/utils/defaults/main.yml` with eight entries:

| Toggle                          | Default |
|---------------------------------|---------|
| `utils_archive_tar_enabled`     | `true`  |
| `utils_archive_zstd_enabled`    | `true`  |
| `utils_archive_zip_enabled`     | `true`  |
| `utils_archive_unzip_enabled`   | `true`  |
| `utils_archive_p7zip_enabled`   | `false` |
| `utils_archive_unrar_enabled`   | `false` |
| `utils_archive_atool_enabled`   | `false` |
| `utils_archive_pigz_enabled`    | `false` |

Distro-specific overrides in `vars/<OS>.yml`:

- RHEL `p7zip` splits into `p7zip` + `p7zip-plugins` (list, so `install.yml` now flattens the assembled package list before `reject('equalto', '')`).
- `unrar`:
  - Arch: pulled from AUR via the existing `__utils_aur_packages` dict (`install.yml`'s AUR loop is extended for the toggle).
  - Debian: lives in non-free — requires `apt_non_free_enabled: true` in `marcstraube.common.package_management` (#194 / #195).
  - RHEL: lives in RPM Fusion non-free — requires `dnf_rpmfusion_nonfree_enabled: true` in `marcstraube.common.package_management` (toggle already present in main).
- `atool` is missing from EPEL 10 (EPEL 9 retains it via `RedHat-9.yml`).

Closes #193

## Why

`utils` had no archive/compression category. `tar` was missing from `base` defaults on RHEL (Arch/Debian ship it in base, RHEL minimal does not), `zstd` had no toggle despite being the default Arch package format, and `p7zip`/`unrar`/`atool`/`pigz` required per-host `base_extra_packages` entries.

## Deprecation: `zip` / `unzip` in `base`

`zip` and `unzip` stay in `__base_default_packages` for v2.1.0 (idempotent doubled) with a `# DEPRECATED in v2.1.0` comment. They will be removed from `base` in v3.0.0; users disabling `utils_enabled` then need `base_extra_packages: [zip, unzip]`.

## Behaviour

- Additive — no existing behaviour changes for inventories that simply upgrade.
- `utils_enabled: false` inventories are unaffected.
- All `utils_archive_*` toggles respect the same enable/disable pattern as the rest of `utils_*`.

## Test plan

- [x] `ansible-lint roles/utils/` → 0 failures
- [x] `molecule test -p utils-archlinux` → green (unrar AUR path not exercised; toggle false in converge)
- [x] `molecule test -p utils-debian-trixie` → green
- [x] `molecule test -p utils-rocky-9` → green
- [x] `molecule test -p utils-rocky-10` → green (atool override to blank)