### PR TITLE
fix(nodejs): probe node/npm versions in check mode

### DIFF
--- a/roles/nodejs/tasks/verify.yml
+++ b/roles/nodejs/tasks/verify.yml
@@ -1,14 +1,19 @@
 ---
+# Read-only version probes — must also run in check mode so the
+# nodejs_installed_version fact is populated for downstream roles
+# (e.g. marcstraube.server.n8n asserts Node.js >= 22).
 - name: Verify | Check Node.js version
   ansible.builtin.command: node --version
   register: __nodejs_version_check
   changed_when: false
+  check_mode: false
   failed_when: __nodejs_version_check.rc != 0
 
 - name: Verify | Check npm version
   ansible.builtin.command: npm --version
   register: __nodejs_npm_version_check
   changed_when: false
+  check_mode: false
   failed_when: __nodejs_npm_version_check.rc != 0
 
 - name: Verify | Set nodejs_installed_version fact


### PR DESCRIPTION
## Summary

Add `check_mode: false` to the two `ansible.builtin.command` tasks in `roles/nodejs/tasks/verify.yml` (`node --version`, `npm --version`). Real runs are unaffected; check-mode dry-runs now produce a correct `nodejs_installed_version` fact and downstream assertions (notably `marcstraube.server.n8n`'s Node.js 22+ check) work as designed.

Closes #198

## Why

In check mode Ansible skips `command` tasks by default. The `set_fact` immediately after the version probe then uses an empty `stdout`, leaving `nodejs_installed_version` as the empty string. Any downstream role asserting against the version fails in check mode even on hosts where Node.js is installed correctly:

```
"n8n 2.x requires Node.js 22+. Found: ."
```

Same pattern as the existing check-mode-robustness fixes in `resolved` (#185), `hardening` (#183), and `docker` (#189).

## Test plan

- [x] `ansible-lint roles/nodejs/` → 0 failures
- [x] `molecule test -p nodejs-rocky-9` → green
- [x] Dry-run against a real Rocky 9 host with Node.js 22 + n8n installed: `n8n` role's Node.js assertion passes (previously failed with `Found: .`).