### PR TITLE
fix(php): split Arch extension map by official vs AUR layout

### DIFF
--- a/roles/php/README.md
+++ b/roles/php/README.md
@@ -226,6 +226,29 @@ The role detects the current PHP version in the Arch repos at runtime. If the
 requested version matches, official repo packages are used. Otherwise, AUR
 packages with the `php<ver>` prefix are installed (e.g., `php84`, `php84-fpm`).
 
+### Arch Extension Mapping (dual map)
+
+Arch ships PHP via two distinct package layouts that disagree on which
+extensions are built into the core package, which are split out, and on the
+prefix scheme. The role therefore keeps two separate extension maps in
+`vars/Archlinux.yml`:
+
+| Map                            | Active when              | Value semantics            |
+|--------------------------------|--------------------------|----------------------------|
+| `__php_extension_map_official` | requested == current PHP | Concrete package name      |
+| `__php_extension_map_aur`      | requested != current PHP | Suffix (prefix is applied) |
+
+Examples:
+
+- `pgsql` → `php-pgsql` (official) / `php84-pgsql` (AUR)
+- `xdebug` → `xdebug` (official) / `php84-xdebug` (AUR)
+
+In both maps an empty string `''` marks an extension as built into the core
+package (no separate sub-package installed). Extensions missing from the map
+fall back to `<prefix><name>`. A handful of extensions (`redis`, `mongodb`,
+`grpc`) are not shipped by the AUR `phpXX` bundle and will hit the fallback —
+override `php_versions[].extensions` or supply your own AUR PKGBUILD.
+
 ### Default Version Handling
 
 | OS     | Mechanism                                       |

--- a/roles/php/molecule/default/verify.yml
+++ b/roles/php/molecule/default/verify.yml
@@ -273,3 +273,60 @@
         that:
           - "'Composer' in __verify_composer.stdout"
         fail_msg: "Composer not found: {{ __verify_composer.stdout }}"
+
+    #
+    # AUR build-list logic (Arch only)
+    #
+    # The kewlfft.aur.aur module is not exercised in containers — but the
+    # extension-map selection and prefix application can still be validated
+    # by mirroring the install_version.yml build logic against the role's
+    # vars file. Catches regressions where the AUR map drifts from the
+    # phpXX-* package naming or the prefix stops being applied.
+
+    - name: Verify | Load Arch role vars (AUR build-list test)
+      ansible.builtin.include_vars:
+        file: '{{ playbook_dir }}/../../vars/Archlinux.yml'
+      when: ansible_facts['os_family'] == 'Archlinux'
+
+    - name: Verify | Build expected AUR package list
+      ansible.builtin.set_fact:
+        __verify_aur_packages: >-
+          {{ ['php84'] + ['php84-fpm'] +
+             _mapped_final +
+             (_unmapped | map('regex_replace', '^(.*)$', 'php84-' + '\1') | list) }}
+      vars:
+        _exts: [curl, mbstring, intl, pgsql, gd, imagick, xdebug, redis, json]
+        _map: '{{ __php_extension_map_aur }}'
+        _mapped_raw: "{{ _exts | select('in', _map) | map('extract', _map) | reject('equalto', '') | list }}"
+        _unmapped: "{{ _exts | reject('in', _map) | list }}"
+        _mapped_final: "{{ _mapped_raw | map('regex_replace', '^(.*)$', 'php84-' + '\\1') | list }}"
+      when: ansible_facts['os_family'] == 'Archlinux'
+
+    - name: Verify | Assert AUR build-list contains expected packages
+      ansible.builtin.assert:
+        that:
+          # Core
+          - "'php84' in __verify_aur_packages"
+          - "'php84-fpm' in __verify_aur_packages"
+          # Extensions split out of the phpXX bundle get the prefix applied
+          - "'php84-curl' in __verify_aur_packages"
+          - "'php84-mbstring' in __verify_aur_packages"
+          - "'php84-intl' in __verify_aur_packages"
+          - "'php84-pgsql' in __verify_aur_packages"
+          - "'php84-gd' in __verify_aur_packages"
+          - "'php84-imagick' in __verify_aur_packages"
+          - "'php84-xdebug' in __verify_aur_packages"
+          # Official-only package names must not leak into the AUR path
+          - "'php-curl' not in __verify_aur_packages"
+          - "'php-pgsql' not in __verify_aur_packages"
+          - "'php-gd' not in __verify_aur_packages"
+          - "'xdebug' not in __verify_aur_packages"
+          # Bundle-internal extensions (json) are skipped, not installed
+          - "'php84-json' not in __verify_aur_packages"
+          # Extensions missing from the AUR map (redis) fall back to the
+          # generic prefix rewrite — this is the documented behaviour.
+          - "'php84-redis' in __verify_aur_packages"
+        fail_msg: |
+          AUR build-list assertion failed.
+          Got: {{ __verify_aur_packages }}
+      when: ansible_facts['os_family'] == 'Archlinux'

--- a/roles/php/tasks/install_version.yml
+++ b/roles/php/tasks/install_version.yml
@@ -67,18 +67,43 @@
     - ansible_facts['os_family'] == 'RedHat'
     - php_redhat_repo == 'remi'
 
+# Select the active extension map. On Arch, the official `php` and AUR
+# `phpXX-*` package layouts disagree on what is split out, what is built-in,
+# and on the prefix scheme — they need separate maps. Other OSes use the
+# single map defined in their respective vars/ file.
+- name: Install Version | Select Arch AUR extension map
+  ansible.builtin.set_fact:
+    __php_extension_map: '{{ __php_extension_map_aur }}'
+  when:
+    - ansible_facts['os_family'] == 'Archlinux'
+    - __php_use_aur | bool
+
+- name: Install Version | Select Arch official extension map
+  ansible.builtin.set_fact:
+    __php_extension_map: '{{ __php_extension_map_official }}'
+  when:
+    - ansible_facts['os_family'] == 'Archlinux'
+    - not (__php_use_aur | bool)
+
+# Build the package list. On the Arch AUR path the map values are suffixes
+# and must be prefixed with __php_extension_prefix (e.g. 'php84-'); on every
+# other path the map values are full package names and are used verbatim.
 - name: Install Version | Build package list
   ansible.builtin.set_fact:
     __php_version_packages: >-
       {{ [__php_cli_package] +
          ((__php_version_item.fpm | default(true) | bool) | ternary([__php_fpm_package], [])) +
-         (_mapped | reject('equalto', '') | list) +
+         _mapped_final +
          (_unmapped | map('regex_replace', '^(.*)$', __php_extension_prefix + '\1') | list) }}
   vars:
     _map: "{{ __php_extension_map | default({}) }}"
     _exts: "{{ __php_version_item.extensions | default([]) }}"
-    _mapped: "{{ _exts | select('in', _map) | map('extract', _map) | list }}"
+    _mapped_raw: "{{ _exts | select('in', _map) | map('extract', _map) | reject('equalto', '') | list }}"
     _unmapped: "{{ _exts | reject('in', _map) | list }}"
+    _mapped_final: >-
+      {{ (__php_use_aur | default(false) | bool)
+         | ternary(_mapped_raw | map('regex_replace', '^(.*)$', __php_extension_prefix + '\1') | list,
+                   _mapped_raw) }}
 
 - name: Install Version | PHP packages
   ansible.builtin.package:

--- a/roles/php/vars/Archlinux.yml
+++ b/roles/php/vars/Archlinux.yml
@@ -20,16 +20,18 @@ __php_fpm_listen_default: '/run/php-fpm/php-fpm.sock'
 __php_fpm_default_user: 'http'
 __php_fpm_default_group: 'http'
 
-# Extension name mapping: generic name → Arch package name
-# Empty string = built into core php package (no separate package needed)
-# Missing keys use default: php-<name>
-__php_extension_map:
+# Extension mapping for the OFFICIAL Arch `php` package (current PHP version).
+# Values are concrete package names — used verbatim by the role.
+# Empty string '' = built into the core `php` package (no separate package).
+# Missing keys fall back to '<__php_extension_prefix><name>' (e.g. 'php-foo').
+__php_extension_map_official:
   curl: ''
   mbstring: ''
   xml: ''
   zip: ''
   intl: ''
   mysql: ''
+  mysqli: ''
   pdo_mysql: ''
   mysqlnd: ''
   json: ''
@@ -49,10 +51,23 @@ __php_extension_map:
   pdo: ''
   pdo_sqlite: ''
   bcmath: ''
+  bz2: ''
+  calendar: ''
+  dba: ''
   exif: ''
+  ffi: ''
   ftp: ''
   gettext: ''
+  gmp: ''
+  ldap: ''
+  pcntl: ''
+  posix: ''
+  shmop: ''
+  soap: ''
   sockets: ''
+  sysvmsg: ''
+  sysvsem: ''
+  sysvshm: ''
   opcache: ''
   gd: 'php-gd'
   imagick: 'php-imagick'
@@ -71,4 +86,80 @@ __php_extension_map:
   mongodb: 'php-mongodb'
   igbinary: 'php-igbinary'
   grpc: 'php-grpc'
+  xdebug: 'xdebug'
+
+# Extension mapping for AUR `phpXX-*` bundles (non-current PHP versions).
+# Values are SUFFIXES — the role prepends __php_extension_prefix (e.g. 'php84-').
+# Empty string '' = bundled into the AUR `phpXX` core package (no separate
+# sub-package — typical for json, pcre, session, filter, pdo_sqlite, ...).
+# Missing keys fall back to '<__php_extension_prefix><name>'. Note that
+# `phpXX-redis`, `phpXX-mongodb`, `phpXX-grpc` are not shipped by the
+# standard AUR phpXX bundle and will fail to install via this fallback.
+__php_extension_map_aur:
+  # Built into the AUR phpXX core package
+  json: ''
+  pcre: ''
+  session: ''
+  filter: ''
+  pdo_sqlite: ''
+  pdo_mysql: ''
+  mysqlnd: ''
+  # mysqli ships inside the phpXX-mysql sub-package alongside the legacy
+  # mysql extension; alias it so a `mysqli` entry installs the right one.
+  mysqli: 'mysql'
+  # Split as separate phpXX-* sub-packages
+  curl: 'curl'
+  mbstring: 'mbstring'
+  xml: 'xml'
+  zip: 'zip'
+  intl: 'intl'
+  mysql: 'mysql'
+  openssl: 'openssl'
+  tokenizer: 'tokenizer'
+  ctype: 'ctype'
+  fileinfo: 'fileinfo'
+  dom: 'dom'
+  simplexml: 'simplexml'
+  xmlreader: 'xmlreader'
+  xmlwriter: 'xmlwriter'
+  phar: 'phar'
+  iconv: 'iconv'
+  pdo: 'pdo'
+  bcmath: 'bcmath'
+  bz2: 'bz2'
+  calendar: 'calendar'
+  dba: 'dba'
+  exif: 'exif'
+  ffi: 'ffi'
+  firebird: 'firebird'
+  ftp: 'ftp'
+  gettext: 'gettext'
+  gmp: 'gmp'
+  imap: 'imap'
+  ldap: 'ldap'
+  pcntl: 'pcntl'
+  pdo_sqlsrv: 'pdo_sqlsrv'
+  posix: 'posix'
+  pspell: 'pspell'
+  shmop: 'shmop'
+  soap: 'soap'
+  sockets: 'sockets'
+  sysvmsg: 'sysvmsg'
+  sysvsem: 'sysvsem'
+  sysvshm: 'sysvshm'
+  opcache: 'opcache'
+  gd: 'gd'
+  imagick: 'imagick'
+  pgsql: 'pgsql'
+  sqlite: 'sqlite'
+  sodium: 'sodium'
+  tidy: 'tidy'
+  xsl: 'xsl'
+  snmp: 'snmp'
+  odbc: 'odbc'
+  enchant: 'enchant'
+  dblib: 'dblib'
+  apcu: 'apcu'
+  memcached: 'memcached'
+  igbinary: 'igbinary'
   xdebug: 'xdebug'


### PR DESCRIPTION
## Summary

Fixes the dual-layout bug in the PHP role's Arch extension map. The official `php` package and the AUR `phpXX-*` bundles disagree on what is built-in, what is split out, and on the prefix scheme, so a single map cannot serve both. Splits the map into `__php_extension_map_official` and `__php_extension_map_aur` and selects the active one per resolved version in `install_version.yml`.

## Changes

- `roles/php/vars/Archlinux.yml`: split into `__php_extension_map_official` (concrete package names) and `__php_extension_map_aur` (suffixes); add 13 missing entries to the official map and 17 to the AUR map, plus `mysqli: 'mysql'` alias for the AUR path.
- `roles/php/tasks/install_version.yml`: select the active map via `__php_use_aur`, apply `__php_extension_prefix` to mapped values on the AUR path.
- `roles/php/molecule/default/verify.yml`: assert the AUR build-list contains the prefix-applied package names and that official-only names do not leak into the AUR path.
- `roles/php/README.md`: document the dual-map convention.

## Test Plan

- [x] `molecule test -p php-archlinux` (incl. new AUR build-list assertions)
- [x] `molecule test -p php-debian-trixie`
- [x] `molecule test -p php-rocky-9`
- [x] `molecule test -p php-rocky-10`
- [x] `pre-commit run --files <changed files>` — all hooks green
- [x] `ansible-lint roles/php/` — passed
- [x] Every official-map package name verified with `pacman -Si <pkg>`
- [x] Every AUR-map suffix verified against the live `php84` AUR bundle via the AUR RPC API

Closes #200