### PR TITLE
feat(docker): make Wait-for-connection timeout configurable

### DIFF
--- a/roles/docker/README.md
+++ b/roles/docker/README.md
@@ -108,13 +108,22 @@ overrides if needed.
 
 ### Systemd Integration
 
-| Variable                | Default  | Description                           |
-|-------------------------|----------|---------------------------------------|
-| `docker_socket_enabled` | `true`   | Enable docker socket                  |
-| `docker_prune_enabled`  | `false`  | Enable system prune timer             |
-| `docker_prune_schedule` | `weekly` | Prune schedule (OnCalendar format)    |
-| `docker_prune_all`      | `true`   | Prune all unused images               |
-| `docker_prune_volumes`  | `true`   | Prune volumes during prune            |
+| Variable                                     | Default  | Description                                        |
+|----------------------------------------------|----------|----------------------------------------------------|
+| `docker_socket_enabled`                      | `true`   | Enable docker socket                               |
+| `docker_service_wait_for_connection_delay`   | `5`      | wait_for_connection delay (s) after Docker start   |
+| `docker_service_wait_for_connection_timeout` | `180`    | wait_for_connection timeout (s) after Docker start |
+| `docker_prune_enabled`                       | `false`  | Enable system prune timer                          |
+| `docker_prune_schedule`                      | `weekly` | Prune schedule (OnCalendar format)                 |
+| `docker_prune_all`                           | `true`   | Prune all unused images                            |
+| `docker_prune_volumes`                       | `true`   | Prune volumes during prune                         |
+
+> **HW-token-friendly tuning:** when the SSH key on the controller lives on
+> a hardware token, the Docker daemon restart can outlast the SSH
+> ControlMaster socket — re-authentication then needs a fresh PIN prompt
+> that the default 60 s `wait_for_connection` timeout may not survive. The
+> raised default of 180 s gives the PIN window room; set
+> `docker_service_wait_for_connection_timeout` higher on slow links.
 
 ## Tags
 

--- a/roles/docker/defaults/main.yml
+++ b/roles/docker/defaults/main.yml
@@ -165,6 +165,14 @@ docker_daemon_options: {}
 # Enable docker socket for on-demand activation
 docker_socket_enabled: true
 
+# wait_for_connection settings applied after a Docker (re)start. The 60 s
+# Ansible default can be too short when the SSH ControlMaster socket is torn
+# down by the daemon restart and the SSH key sits on a hardware token —
+# re-authentication needs a fresh PIN prompt, which often exceeds 60 s on
+# slow links. Raise the timeout or extend the delay to fit your environment.
+docker_service_wait_for_connection_delay: 5
+docker_service_wait_for_connection_timeout: 180
+
 # Enable system prune timer
 docker_prune_enabled: false
 

--- a/roles/docker/tasks/service.yml
+++ b/roles/docker/tasks/service.yml
@@ -14,8 +14,8 @@
 
 - name: Service | Wait for connection after Docker start  # noqa: no-handler
   ansible.builtin.wait_for_connection:
-    delay: 5
-    timeout: 60
+    delay: '{{ docker_service_wait_for_connection_delay }}'
+    timeout: '{{ docker_service_wait_for_connection_timeout }}'
   when: __docker_service_result.changed
 
 - name: Service | Deploy system prune timer


### PR DESCRIPTION
## Summary

After a Docker (re)start the role calls `wait_for_connection` with a hard-coded `delay: 5, timeout: 60`. 65 seconds is tight when the SSH ControlMaster socket is torn down by the daemon restart and the controller's SSH key sits on a hardware token — re-authentication needs a fresh PIN prompt, which can outlast the 60 s window and trip the task with `agent refused operation`.

## Changes

- `roles/docker/defaults/main.yml`: expose `docker_service_wait_for_connection_delay` (5) and `docker_service_wait_for_connection_timeout` (raised from 60 to 180); inventory can override either field.
- `roles/docker/tasks/service.yml`: wire the new variables into the `wait_for_connection` task.
- `roles/docker/README.md`: add the two variables to the Systemd Integration table and document the HW-token tuning rationale.

## Test Plan

- [x] `molecule test -p docker-archlinux`
- [x] `molecule test -p docker-debian-trixie`
- [x] `molecule test -p docker-rocky-9`
- [x] `molecule test -p docker-rocky-10`
- [x] `pre-commit run --files <changed files>` — all hooks green
- [x] `ansible-lint roles/docker/` — passed (via pre-commit)

Closes #165