### PR TITLE
ci: enforce MIGRATION.md update on breaking-change PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -284,17 +284,91 @@ jobs:
           ANSIBLE_FORCE_COLOR: '1'
 
   # =============================================================================
+  # MIGRATION DOC CHECK (PR only)
+  # Fails any PR whose commits include a Conventional-Commit breaking
+  # marker (`<type>!:` headline or `BREAKING CHANGE:` footer) without a
+  # MIGRATION.md change. Bypass: apply the `skip-migration-doc` label for
+  # purely informational breaking-change messages that do not warrant a
+  # migration entry (e.g. no-op removal of dead code).
+  # =============================================================================
+  migration-doc-check:
+    name: MIGRATION.md doc check
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - name: Enforce MIGRATION.md update on breaking-change PRs
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          BYPASS_LABEL: skip-migration-doc
+        run: |
+          set -euo pipefail
+
+          # Bypass via label
+          LABELS=$(gh pr view "$PR_NUMBER" -R "$REPO" --json labels \
+            --jq '.labels[].name')
+          if grep -Fxq "$BYPASS_LABEL" <<< "$LABELS"; then
+            echo "Bypass label '$BYPASS_LABEL' present — skipping check."
+            exit 0
+          fi
+
+          # All commit messages on the PR (headline + body), paginated.
+          COMMITS=$(gh api -X GET "repos/${REPO}/pulls/${PR_NUMBER}/commits" \
+            --paginate --jq '.[].commit.message')
+
+          # Conventional-Commit breaking marker:
+          # - `<type>!:` or `<type>(<scope>)!:` at the start of any line
+          # - `BREAKING CHANGE:` at the start of any line
+          if ! grep -qE '(^[a-z]+(\([^)]+\))?!:|^BREAKING CHANGE:)' <<< "$COMMITS"; then
+            echo "No breaking-change commits in this PR — nothing to enforce."
+            exit 0
+          fi
+
+          echo "Breaking-change commit detected. Checking MIGRATION.md diff…"
+
+          # All changed files on the PR, paginated.
+          FILES=$(gh api -X GET "repos/${REPO}/pulls/${PR_NUMBER}/files" \
+            --paginate --jq '.[].filename')
+
+          if grep -Fxq 'MIGRATION.md' <<< "$FILES"; then
+            echo "MIGRATION.md is modified — check passes."
+            exit 0
+          fi
+
+          echo "::error::Breaking-change PR must update MIGRATION.md."
+          cat <<'EOF'
+          Detected at least one breaking-change commit (Conventional-Commit
+          `!` marker or BREAKING CHANGE: footer) but MIGRATION.md is not
+          modified by this PR.
+
+          Action: add a sub-section under the persistent `## Unreleased`
+          heading in MIGRATION.md describing the breaking change and the
+          required inventory action. See the Migration Guide intro for the
+          convention.
+
+          Bypass: apply the `skip-migration-doc` label to this PR if the
+          breaking-change commit message is purely informational and does
+          not need a migration entry (e.g. no-op removal of dead code).
+          EOF
+          exit 1
+
+  # =============================================================================
   # CI GATE (single required check for branch protection)
   # =============================================================================
   ci-gate:
     name: CI Gate
     runs-on: ubuntu-latest
     if: always()
-    needs: [lint, markdown-lint, yaml-lint, build, molecule-compat, molecule-roles]
+    needs: [lint, markdown-lint, yaml-lint, build, molecule-compat, molecule-roles, migration-doc-check]
     steps:
       - name: Check required job results
         run: |
-          # molecule-roles may be skipped when no roles changed
+          # molecule-roles may be skipped when no roles changed;
+          # migration-doc-check is skipped on push to main (PR-only).
           results=(
             "${{ needs.lint.result }}"
             "${{ needs.markdown-lint.result }}"
@@ -302,6 +376,7 @@ jobs:
             "${{ needs.build.result }}"
             "${{ needs.molecule-compat.result }}"
             "${{ needs.molecule-roles.result }}"
+            "${{ needs.migration-doc-check.result }}"
           )
           for r in "${results[@]}"; do
             if [ "$r" = "failure" ] || [ "$r" = "cancelled" ]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -287,9 +287,9 @@ jobs:
   # MIGRATION DOC CHECK (PR only)
   # Fails any PR whose commits include a Conventional-Commit breaking
   # marker (`<type>!:` headline or `BREAKING CHANGE:` footer) without a
-  # MIGRATION.md change. Bypass: apply the `skip-migration-doc` label for
-  # purely informational breaking-change messages that do not warrant a
-  # migration entry (e.g. no-op removal of dead code).
+  # MIGRATION.md change. No bypass: the `!` marker is reserved for actual
+  # contract violations; if it was set incorrectly the commit message
+  # must be rewritten, not the gate skipped.
   # =============================================================================
   migration-doc-check:
     name: MIGRATION.md doc check
@@ -304,17 +304,8 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
-          BYPASS_LABEL: skip-migration-doc
         run: |
           set -euo pipefail
-
-          # Bypass via label
-          LABELS=$(gh pr view "$PR_NUMBER" -R "$REPO" --json labels \
-            --jq '.labels[].name')
-          if grep -Fxq "$BYPASS_LABEL" <<< "$LABELS"; then
-            echo "Bypass label '$BYPASS_LABEL' present — skipping check."
-            exit 0
-          fi
 
           # All commit messages on the PR (headline + body), paginated.
           COMMITS=$(gh api -X GET "repos/${REPO}/pulls/${PR_NUMBER}/commits" \
@@ -343,16 +334,19 @@ jobs:
           cat <<'EOF'
           Detected at least one breaking-change commit (Conventional-Commit
           `!` marker or BREAKING CHANGE: footer) but MIGRATION.md is not
-          modified by this PR.
+          modified by this PR. Pick one of the two paths:
 
-          Action: add a sub-section under the persistent `## Unreleased`
-          heading in MIGRATION.md describing the breaking change and the
-          required inventory action. See the Migration Guide intro for the
-          convention.
+          1. The `!` marker is correct — the change really breaks an
+             inventory contract. Add a sub-section under the persistent
+             `## Unreleased` heading in MIGRATION.md describing the change
+             and the required inventory action. See the Migration Guide
+             intro for the convention.
 
-          Bypass: apply the `skip-migration-doc` label to this PR if the
-          breaking-change commit message is purely informational and does
-          not need a migration entry (e.g. no-op removal of dead code).
+          2. The `!` marker is wrong — the change is additive, a no-op
+             removal of dead code, or merely implements documented intent.
+             Rewrite the commit message (`git rebase -i`, drop the `!`,
+             remove any `BREAKING CHANGE:` footer) and force-push. The `!`
+             marker is reserved strictly for actual contract violations.
           EOF
           exit 1
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -143,6 +143,13 @@ Always use generic placeholder data in commented examples:
    - `feat(chrony): add NTS support`
    - `fix(openssh): correct TLS configuration`
    - `refactor(users): simplify group management`
+5. **Breaking changes** — any PR with a `<type>!:` commit subject or a
+   `BREAKING CHANGE:` footer must add a sub-section under the persistent
+   `## Unreleased` heading in `MIGRATION.md` describing the change and
+   the required inventory action. CI enforces this; apply the
+   `skip-migration-doc` label to bypass for purely informational
+   breaking-change messages that do not warrant a migration entry
+   (e.g. no-op removal of dead code).
 
 ## License
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -143,13 +143,17 @@ Always use generic placeholder data in commented examples:
    - `feat(chrony): add NTS support`
    - `fix(openssh): correct TLS configuration`
    - `refactor(users): simplify group management`
-5. **Breaking changes** — any PR with a `<type>!:` commit subject or a
-   `BREAKING CHANGE:` footer must add a sub-section under the persistent
-   `## Unreleased` heading in `MIGRATION.md` describing the change and
-   the required inventory action. CI enforces this; apply the
-   `skip-migration-doc` label to bypass for purely informational
-   breaking-change messages that do not warrant a migration entry
-   (e.g. no-op removal of dead code).
+5. **Breaking changes** — the `!` marker (`<type>!:` headline or
+   `BREAKING CHANGE:` footer) is reserved strictly for actual inventory
+   contract violations. Additive features, no-op removals of dead code,
+   and changes that merely implement documented intent are **not**
+   breaking — they use plain `feat:` / `refactor:` / `fix:`.
+
+   Any PR that does carry the `!` marker must add a sub-section under
+   the persistent `## Unreleased` heading in `MIGRATION.md` describing
+   the change and the required inventory action. CI enforces this; if
+   the marker was set incorrectly, rewrite the commit message rather
+   than working around the gate.
 
 ## License
 


### PR DESCRIPTION
## Summary

Adds the CI gate proposed in #163 (originally surfaced in #157): every PR whose commits contain a Conventional-Commit breaking marker (`<type>!:` headline or `BREAKING CHANGE:` footer) must touch `MIGRATION.md`. Without enforcement the convention drifts — which is what caused the backfill problem in #157.

Deliberately no bypass label: the `!` marker is reserved strictly for actual inventory contract violations. If the marker was set incorrectly the commit message gets rewritten, not the gate skipped. The error message spells out both correction paths so contributors see them at the point of failure.

The check is wired into the existing `ci-gate` aggregator (the single required check pattern already used for `molecule-roles`), so no manual branch-protection / ruleset edit is needed for it to block merges.

## Changes

- `.github/workflows/ci.yml`: new `migration-doc-check` job (PR-only). Uses paginated `gh api` to read every commit message and every changed file, regex-matches the breaking marker, and fails if `MIGRATION.md` is not in the PR diff. Error message offers two correction paths (amend MIGRATION.md if the marker was correct; rebase to drop the marker if it was wrong). Added to `ci-gate` `needs:`.
- `CONTRIBUTING.md`: document the `!`-marker policy (strict — only for actual contract violations) and the breaking-change → MIGRATION.md convention under "Pull Request Process".

## Test Plan

- [x] Regex matrix-tested locally: matches `<type>!:`, `<type>(<scope>)!:`, `BREAKING CHANGE:`; ignores plain `fix:`, `feat:`, `docs:`, `refactor:`.
- [x] End-to-end against real PRs via `gh api .../pulls/<n>/commits`:
  - PR #203 (this cycle, non-breaking `docs(migration):`) — "no breaking commits", passes.
  - PR #195 (this cycle, `feat(package_management):`) — "no breaking commits", passes.
  - PR #118 (`refactor(firejail)!: …`) — breaking detected, would require MIGRATION.md.
  - PR #102 (`refactor!: Add NM-managed WireGuard …`) — breaking detected.
  - PR #92 (`refactor!: Remove multiplexer …`) — breaking detected.
- [x] `pre-commit run --files .github/workflows/ci.yml CONTRIBUTING.md` — all hooks green (yamllint, markdownlint, ansible-lint, secret-scan).

Closes #163