### PR TITLE
fix(templates): make ansible_managed reference safe under ansible-core 2.23+

### DIFF
--- a/roles/aide/templates/aide-check.service.j2
+++ b/roles/aide/templates/aide-check.service.j2
@@ -1,4 +1,4 @@
-{{ ansible_managed | comment }}
+{{ ansible_managed | default('Ansible managed') | comment }}
 
 [Unit]
 Description=AIDE File Integrity Check

--- a/roles/aide/templates/aide-check.sh.j2
+++ b/roles/aide/templates/aide-check.sh.j2
@@ -1,5 +1,5 @@
 #!/bin/bash
-{{ ansible_managed | comment }}
+{{ ansible_managed | default('Ansible managed') | comment }}
 
 set -euo pipefail
 

--- a/roles/aide/templates/aide-check.timer.j2
+++ b/roles/aide/templates/aide-check.timer.j2
@@ -1,4 +1,4 @@
-{{ ansible_managed | comment }}
+{{ ansible_managed | default('Ansible managed') | comment }}
 
 [Unit]
 Description=AIDE File Integrity Check Timer

--- a/roles/aide/templates/aide.conf.j2
+++ b/roles/aide/templates/aide.conf.j2
@@ -1,4 +1,4 @@
-{{ ansible_managed | comment }}
+{{ ansible_managed | default('Ansible managed') | comment }}
 #
 # AIDE Configuration - File Integrity Monitoring
 #

--- a/roles/apparmor/templates/tunables_custom.j2
+++ b/roles/apparmor/templates/tunables_custom.j2
@@ -1,4 +1,4 @@
-{{ ansible_managed | comment }}
+{{ ansible_managed | default('Ansible managed') | comment }}
 #
 # Custom AppArmor tunables managed by Ansible.
 # Placed in /etc/apparmor.d/tunables/custom so apparmor_parser picks them up

--- a/roles/auditd/templates/au-remote.conf.j2
+++ b/roles/auditd/templates/au-remote.conf.j2
@@ -1,4 +1,4 @@
-{{ ansible_managed | comment }}
+{{ ansible_managed | default('Ansible managed') | comment }}
 #
 # Remote Logging Plugin Configuration
 #

--- a/roles/auditd/templates/audisp-remote.conf.j2
+++ b/roles/auditd/templates/audisp-remote.conf.j2
@@ -1,4 +1,4 @@
-{{ ansible_managed | comment }}
+{{ ansible_managed | default('Ansible managed') | comment }}
 #
 # audisp-remote configuration
 #

--- a/roles/auditd/templates/audit.rules.j2
+++ b/roles/auditd/templates/audit.rules.j2
@@ -1,4 +1,4 @@
-{{ ansible_managed | comment }}
+{{ ansible_managed | default('Ansible managed') | comment }}
 ## Audit Rules
 
 ## Remove any existing rules

--- a/roles/auditd/templates/auditd.conf.j2
+++ b/roles/auditd/templates/auditd.conf.j2
@@ -1,4 +1,4 @@
-{{ ansible_managed | comment }}
+{{ ansible_managed | default('Ansible managed') | comment }}
 #
 # This file controls the configuration of the audit daemon
 #

--- a/roles/auditd/templates/syslog.conf.j2
+++ b/roles/auditd/templates/syslog.conf.j2
@@ -1,4 +1,4 @@
-{{ ansible_managed | comment }}
+{{ ansible_managed | default('Ansible managed') | comment }}
 #
 # Syslog Plugin Configuration
 #

--- a/roles/avahi/templates/avahi-daemon.conf.j2
+++ b/roles/avahi/templates/avahi-daemon.conf.j2
@@ -1,4 +1,4 @@
-{{ ansible_managed | comment }}
+{{ ansible_managed | default('Ansible managed') | comment }}
 #
 # See avahi-daemon.conf(5) for more information.
 

--- a/roles/base/templates/00-keyboard.conf.j2
+++ b/roles/base/templates/00-keyboard.conf.j2
@@ -1,4 +1,4 @@
-{{ ansible_managed | comment }}
+{{ ansible_managed | default('Ansible managed') | comment }}
 
 Section "InputClass"
     Identifier "system-keyboard"

--- a/roles/base/templates/coredump.conf.j2
+++ b/roles/base/templates/coredump.conf.j2
@@ -1,4 +1,4 @@
-{{ ansible_managed | comment }}
+{{ ansible_managed | default('Ansible managed') | comment }}
 
 [Coredump]
 Storage={{ base_coredump_storage }}

--- a/roles/base/templates/journald.conf.j2
+++ b/roles/base/templates/journald.conf.j2
@@ -1,4 +1,4 @@
-{{ ansible_managed | comment }}
+{{ ansible_managed | default('Ansible managed') | comment }}
 
 [Journal]
 SystemMaxUse={{ base_journald_max_use }}

--- a/roles/base/templates/loader.conf.j2
+++ b/roles/base/templates/loader.conf.j2
@@ -1,4 +1,4 @@
-{{ ansible_managed | comment }}
+{{ ansible_managed | default('Ansible managed') | comment }}
 
 timeout {{ base_systemd_boot_timeout }}
 console-mode {{ base_systemd_boot_console_mode }}

--- a/roles/base/templates/locale.conf.j2
+++ b/roles/base/templates/locale.conf.j2
@@ -1,4 +1,4 @@
-{{ ansible_managed | comment }}
+{{ ansible_managed | default('Ansible managed') | comment }}
 LANG={{ base_locale }}
 {% if base_locale_lc_ctype %}
 LC_CTYPE={{ base_locale_lc_ctype }}

--- a/roles/base/templates/machine-info.j2
+++ b/roles/base/templates/machine-info.j2
@@ -1,4 +1,4 @@
-{{ ansible_managed | comment }}
+{{ ansible_managed | default('Ansible managed') | comment }}
 {% if base_pretty_hostname %}
 PRETTY_HOSTNAME="{{ base_pretty_hostname }}"
 {% endif %}

--- a/roles/base/templates/timesyncd.conf.j2
+++ b/roles/base/templates/timesyncd.conf.j2
@@ -1,4 +1,4 @@
-{{ ansible_managed | comment }}
+{{ ansible_managed | default('Ansible managed') | comment }}
 
 [Time]
 {% if base_ntp_servers | length > 0 %}

--- a/roles/base/templates/vconsole.conf.j2
+++ b/roles/base/templates/vconsole.conf.j2
@@ -1,4 +1,4 @@
-{{ ansible_managed | comment }}
+{{ ansible_managed | default('Ansible managed') | comment }}
 KEYMAP={{ base_keymap }}
 {% if base_console_font %}
 FONT={{ base_console_font }}

--- a/roles/chrony/templates/chrony.conf.j2
+++ b/roles/chrony/templates/chrony.conf.j2
@@ -1,4 +1,4 @@
-{{ ansible_managed | comment }}
+{{ ansible_managed | default('Ansible managed') | comment }}
 #
 # chrony.conf — NTP client/server configuration
 # See chrony.conf(5) for details.

--- a/roles/clamav/templates/clamav-milter.conf.j2
+++ b/roles/clamav/templates/clamav-milter.conf.j2
@@ -1,4 +1,4 @@
-{{ ansible_managed | comment }}
+{{ ansible_managed | default('Ansible managed') | comment }}
 #
 # Clam AntiVirus - clamav-milter configuration file
 # See clamav-milter.conf(5) and https://docs.clamav.net/ for details.

--- a/roles/clamav/templates/clamd.conf.j2
+++ b/roles/clamav/templates/clamd.conf.j2
@@ -1,4 +1,4 @@
-{{ ansible_managed | comment }}
+{{ ansible_managed | default('Ansible managed') | comment }}
 #
 # Clam AntiVirus - clamd configuration file
 # See clamd.conf(5) and https://docs.clamav.net/ for details.

--- a/roles/clamav/templates/freshclam.conf.j2
+++ b/roles/clamav/templates/freshclam.conf.j2
@@ -1,4 +1,4 @@
-{{ ansible_managed | comment }}
+{{ ansible_managed | default('Ansible managed') | comment }}
 #
 # Clam AntiVirus - freshclam configuration file
 # See freshclam.conf(5) and https://docs.clamav.net/ for details.

--- a/roles/docker/templates/docker-prune.service.j2
+++ b/roles/docker/templates/docker-prune.service.j2
@@ -1,4 +1,4 @@
-{{ ansible_managed | comment }}
+{{ ansible_managed | default('Ansible managed') | comment }}
 #
 # Docker System Prune Service
 

--- a/roles/docker/templates/docker-prune.timer.j2
+++ b/roles/docker/templates/docker-prune.timer.j2
@@ -1,4 +1,4 @@
-{{ ansible_managed | comment }}
+{{ ansible_managed | default('Ansible managed') | comment }}
 #
 # Docker System Prune Timer
 

--- a/roles/editors/templates/editor.sh.j2
+++ b/roles/editors/templates/editor.sh.j2
@@ -1,5 +1,5 @@
 #!/bin/bash
-{{ ansible_managed | comment }}
+{{ ansible_managed | default('Ansible managed') | comment }}
 
 # Set default editor for all users
 export EDITOR={{ editors_default }}

--- a/roles/editors/templates/init.vim.j2
+++ b/roles/editors/templates/init.vim.j2
@@ -1,4 +1,4 @@
-{{ ansible_managed | comment(decoration='" ') }}
+{{ ansible_managed | default('Ansible managed') | comment(decoration='" ') }}
 " Neovim Global Configuration
 {% if editors_neovim_config.syntax_on | default(true) %}
 

--- a/roles/editors/templates/nanorc.j2
+++ b/roles/editors/templates/nanorc.j2
@@ -1,4 +1,4 @@
-{{ ansible_managed | comment }}
+{{ ansible_managed | default('Ansible managed') | comment }}
 
 # Nano Editor Configuration
 {% if editors_nano_config.set_autoindent | default(true) %}

--- a/roles/editors/templates/vimrc.j2
+++ b/roles/editors/templates/vimrc.j2
@@ -1,4 +1,4 @@
-{{ ansible_managed | comment(decoration='" ') }}
+{{ ansible_managed | default('Ansible managed') | comment(decoration='" ') }}
 " Vim Configuration
 
 " Basic settings

--- a/roles/energy_management/templates/backlight-udev.rules.j2
+++ b/roles/energy_management/templates/backlight-udev.rules.j2
@@ -1,4 +1,4 @@
-{{ ansible_managed | comment }}
+{{ ansible_managed | default('Ansible managed') | comment }}
 # Allow video group members to adjust backlight brightness
 ACTION=="add", SUBSYSTEM=="backlight", RUN+="/bin/chgrp video /sys/class/backlight/%k/brightness"
 ACTION=="add", SUBSYSTEM=="backlight", RUN+="/bin/chmod g+w /sys/class/backlight/%k/brightness"

--- a/roles/energy_management/templates/logind-energy.conf.j2
+++ b/roles/energy_management/templates/logind-energy.conf.j2
@@ -1,4 +1,4 @@
-{{ ansible_managed | comment }}
+{{ ansible_managed | default('Ansible managed') | comment }}
 # logind energy management drop-in
 # System type: {{ energy_management_system_type }}
 # NOTE: security.conf may override some of these settings (alphabetical merge)

--- a/roles/energy_management/templates/sleep-energy.conf.j2
+++ b/roles/energy_management/templates/sleep-energy.conf.j2
@@ -1,4 +1,4 @@
-{{ ansible_managed | comment }}
+{{ ansible_managed | default('Ansible managed') | comment }}
 # sleep energy management drop-in
 # System type: {{ energy_management_system_type }}
 

--- a/roles/energy_management/templates/tlp.conf.j2
+++ b/roles/energy_management/templates/tlp.conf.j2
@@ -1,4 +1,4 @@
-{{ ansible_managed | comment }}
+{{ ansible_managed | default('Ansible managed') | comment }}
 # TLP Configuration
 
 # CPU

--- a/roles/fail2ban/templates/jail.d/apache.local.j2
+++ b/roles/fail2ban/templates/jail.d/apache.local.j2
@@ -1,4 +1,4 @@
-{{ ansible_managed | comment }}
+{{ ansible_managed | default('Ansible managed') | comment }}
 {% if fail2ban_apache_auth_enabled %}
 
 # Apache web server jails

--- a/roles/fail2ban/templates/jail.d/custom.local.j2
+++ b/roles/fail2ban/templates/jail.d/custom.local.j2
@@ -1,4 +1,4 @@
-{{ ansible_managed | comment }}
+{{ ansible_managed | default('Ansible managed') | comment }}
 # Custom jails
 
 {% for jail in fail2ban_custom_jails %}

--- a/roles/fail2ban/templates/jail.d/database.local.j2
+++ b/roles/fail2ban/templates/jail.d/database.local.j2
@@ -1,4 +1,4 @@
-{{ ansible_managed | comment }}
+{{ ansible_managed | default('Ansible managed') | comment }}
 {% if fail2ban_mysqld_enabled %}
 
 # Database server jails

--- a/roles/fail2ban/templates/jail.d/grafana.local.j2
+++ b/roles/fail2ban/templates/jail.d/grafana.local.j2
@@ -1,4 +1,4 @@
-{{ ansible_managed | comment }}
+{{ ansible_managed | default('Ansible managed') | comment }}
 # Grafana monitoring jail
 
 [grafana]

--- a/roles/fail2ban/templates/jail.d/mail.local.j2
+++ b/roles/fail2ban/templates/jail.d/mail.local.j2
@@ -1,4 +1,4 @@
-{{ ansible_managed | comment }}
+{{ ansible_managed | default('Ansible managed') | comment }}
 {% if fail2ban_postfix_enabled %}
 
 # Mail server jails

--- a/roles/fail2ban/templates/jail.d/nginx.local.j2
+++ b/roles/fail2ban/templates/jail.d/nginx.local.j2
@@ -1,4 +1,4 @@
-{{ ansible_managed | comment }}
+{{ ansible_managed | default('Ansible managed') | comment }}
 {% if fail2ban_nginx_http_auth_enabled %}
 
 # Nginx web server jails

--- a/roles/fail2ban/templates/jail.d/recidive.local.j2
+++ b/roles/fail2ban/templates/jail.d/recidive.local.j2
@@ -1,4 +1,4 @@
-{{ ansible_managed | comment }}
+{{ ansible_managed | default('Ansible managed') | comment }}
 # Recidive jail for repeat offenders
 
 [recidive]

--- a/roles/fail2ban/templates/jail.d/sshd.local.j2
+++ b/roles/fail2ban/templates/jail.d/sshd.local.j2
@@ -1,4 +1,4 @@
-{{ ansible_managed | comment }}
+{{ ansible_managed | default('Ansible managed') | comment }}
 # SSH jails
 
 [sshd]

--- a/roles/fail2ban/templates/jail.local.j2
+++ b/roles/fail2ban/templates/jail.local.j2
@@ -1,4 +1,4 @@
-{{ ansible_managed | comment }}
+{{ ansible_managed | default('Ansible managed') | comment }}
 # Fail2ban main configuration
 
 [DEFAULT]

--- a/roles/firejail/templates/firejail-profile.local.j2
+++ b/roles/firejail/templates/firejail-profile.local.j2
@@ -1,4 +1,4 @@
-{{ ansible_managed | comment }}
+{{ ansible_managed | default('Ansible managed') | comment }}
 
 {% for line in item.value %}
 {{ line }}

--- a/roles/firejail/templates/firejail.config.j2
+++ b/roles/firejail/templates/firejail.config.j2
@@ -1,4 +1,4 @@
-{{ ansible_managed | comment }}
+{{ ansible_managed | default('Ansible managed') | comment }}
 
 {% for key, value in firejail_config.items() %}
 {{ key }} {{ value }}

--- a/roles/firejail/templates/globals.local.j2
+++ b/roles/firejail/templates/globals.local.j2
@@ -1,4 +1,4 @@
-{{ ansible_managed | comment }}
+{{ ansible_managed | default('Ansible managed') | comment }}
 {% if firejail_apparmor_enabled | default(false) | bool %}
 
 # AppArmor confinement for all sandboxed applications

--- a/roles/firewalld/templates/firewalld.conf.j2
+++ b/roles/firewalld/templates/firewalld.conf.j2
@@ -1,4 +1,4 @@
-{{ ansible_managed | comment }}
+{{ ansible_managed | default('Ansible managed') | comment }}
 #
 # firewalld.conf — Global daemon configuration
 #

--- a/roles/firewalld/templates/service.xml.j2
+++ b/roles/firewalld/templates/service.xml.j2
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-{{ ansible_managed | comment('xml') }}
+{{ ansible_managed | default('Ansible managed') | comment('xml') }}
 <service>
   <short>{{ item.short | default(item.name) }}</short>
 {% if item.description is defined %}

--- a/roles/fonts/templates/local.conf.j2
+++ b/roles/fonts/templates/local.conf.j2
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-{{ ansible_managed | comment('xml') }}
+{{ ansible_managed | default('Ansible managed') | comment('xml') }}
 <!DOCTYPE fontconfig SYSTEM "fonts.dtd">
 <fontconfig>
 {% if fonts_fontconfig_antialias_enabled %}

--- a/roles/gnupg/templates/dirmngr.conf.j2
+++ b/roles/gnupg/templates/dirmngr.conf.j2
@@ -1,4 +1,4 @@
-{{ ansible_managed | comment }}
+{{ ansible_managed | default('Ansible managed') | comment }}
 
 # Keyservers
 {% for ks in gnupg_keyservers %}

--- a/roles/gnupg/templates/gpg-agent.conf.j2
+++ b/roles/gnupg/templates/gpg-agent.conf.j2
@@ -1,4 +1,4 @@
-{{ ansible_managed | comment }}
+{{ ansible_managed | default('Ansible managed') | comment }}
 
 # Cache TTL
 default-cache-ttl {{ gnupg_agent_default_cache_ttl }}

--- a/roles/gnupg/templates/gpg.conf.j2
+++ b/roles/gnupg/templates/gpg.conf.j2
@@ -1,4 +1,4 @@
-{{ ansible_managed | comment }}
+{{ ansible_managed | default('Ansible managed') | comment }}
 
 {% if gnupg_user.default_key is defined and gnupg_user.default_key | length > 0 %}
 

--- a/roles/gnupg/templates/scdaemon.conf.j2
+++ b/roles/gnupg/templates/scdaemon.conf.j2
@@ -1,4 +1,4 @@
-{{ ansible_managed | comment }}
+{{ ansible_managed | default('Ansible managed') | comment }}
 {% if gnupg_scdaemon_disable_ccid %}
 
 # Disable integrated CCID driver (use PC/SC only)

--- a/roles/graphics/templates/80-nvidia-pm.rules.j2
+++ b/roles/graphics/templates/80-nvidia-pm.rules.j2
@@ -1,4 +1,4 @@
-{{ ansible_managed | comment }}
+{{ ansible_managed | default('Ansible managed') | comment }}
 
 # Enable runtime PM for NVIDIA VGA/3D controller devices on driver bind
 ACTION=="bind", SUBSYSTEM=="pci", ATTR{vendor}=="0x10de", ATTR{class}=="0x030000", TEST=="power/control", ATTR{power/control}="auto"

--- a/roles/graphics/templates/modprobe-i915.conf.j2
+++ b/roles/graphics/templates/modprobe-i915.conf.j2
@@ -1,4 +1,4 @@
-{{ ansible_managed | comment }}
+{{ ansible_managed | default('Ansible managed') | comment }}
 
 {% for param in graphics_intel_kernel_params %}
 options {{ param }}

--- a/roles/graphics/templates/modprobe-nvidia.conf.j2
+++ b/roles/graphics/templates/modprobe-nvidia.conf.j2
@@ -1,4 +1,4 @@
-{{ ansible_managed | comment }}
+{{ ansible_managed | default('Ansible managed') | comment }}
 
 {% for param in graphics_nvidia_kernel_params %}
 options {{ param }}

--- a/roles/graphics/templates/nvidia-pm.conf.j2
+++ b/roles/graphics/templates/nvidia-pm.conf.j2
@@ -1,4 +1,4 @@
-{{ ansible_managed | comment }}
+{{ ansible_managed | default('Ansible managed') | comment }}
 
 # NVIDIA Dynamic Power Management for RTD3
 # 0x02 = fine-grained (Turing/pre-Ampere)

--- a/roles/hardening/templates/modprobe-blacklist.conf.j2
+++ b/roles/hardening/templates/modprobe-blacklist.conf.j2
@@ -1,4 +1,4 @@
-{{ ansible_managed | comment }}
+{{ ansible_managed | default('Ansible managed') | comment }}
 {% if hardening_modules_blacklist_fs | difference(hardening_modules_blacklist_exclude) %}
 
 # Kernel module blacklist for security hardening

--- a/roles/hardening/templates/sysctl-hardening.conf.j2
+++ b/roles/hardening/templates/sysctl-hardening.conf.j2
@@ -1,4 +1,4 @@
-{{ ansible_managed | comment }}
+{{ ansible_managed | default('Ansible managed') | comment }}
 # Kernel hardening parameters
 
 {% for key, value in hardening_kernel_settings.items() %}

--- a/roles/hardware_tokens/templates/85-hardware-token-lock.rules.j2
+++ b/roles/hardware_tokens/templates/85-hardware-token-lock.rules.j2
@@ -1,4 +1,4 @@
-{{ ansible_managed | comment }}
+{{ ansible_managed | default('Ansible managed') | comment }}
 # Lock screen when hardware token is removed
 
 {% for device in hardware_tokens_lock_on_removal_devices %}

--- a/roles/hardware_tokens/templates/hardware-token-lock.sh.j2
+++ b/roles/hardware_tokens/templates/hardware-token-lock.sh.j2
@@ -1,4 +1,4 @@
 #!/bin/bash
-{{ ansible_managed | comment }}
+{{ ansible_managed | default('Ansible managed') | comment }}
 # Lock all active user sessions when hardware token is removed
 /usr/bin/loginctl lock-sessions

--- a/roles/logrotate/templates/logrotate.conf.j2
+++ b/roles/logrotate/templates/logrotate.conf.j2
@@ -1,4 +1,4 @@
-{{ ansible_managed | comment }}
+{{ ansible_managed | default('Ansible managed') | comment }}
 #
 # see "man logrotate" for details
 

--- a/roles/logrotate/templates/logrotate.d.j2
+++ b/roles/logrotate/templates/logrotate.d.j2
@@ -1,4 +1,4 @@
-{{ ansible_managed | comment }}
+{{ ansible_managed | default('Ansible managed') | comment }}
 #
 # {{ item.name }} log rotation
 

--- a/roles/lynis/templates/custom.prf.j2
+++ b/roles/lynis/templates/custom.prf.j2
@@ -1,4 +1,4 @@
-{{ ansible_managed | comment }}
+{{ ansible_managed | default('Ansible managed') | comment }}
 #
 # Lynis Custom Profile
 # Place customizations here — never edit default.prf (overwritten on upgrade)

--- a/roles/lynis/templates/lynis-audit.service.j2
+++ b/roles/lynis/templates/lynis-audit.service.j2
@@ -1,4 +1,4 @@
-{{ ansible_managed | comment }}
+{{ ansible_managed | default('Ansible managed') | comment }}
 
 [Unit]
 Description=Lynis Security Audit

--- a/roles/lynis/templates/lynis-audit.sh.j2
+++ b/roles/lynis/templates/lynis-audit.sh.j2
@@ -1,5 +1,5 @@
 #!/bin/bash
-{{ ansible_managed | comment }}
+{{ ansible_managed | default('Ansible managed') | comment }}
 #
 # Lynis Audit Script — executed by lynis-audit.timer
 #

--- a/roles/lynis/templates/lynis-audit.timer.j2
+++ b/roles/lynis/templates/lynis-audit.timer.j2
@@ -1,4 +1,4 @@
-{{ ansible_managed | comment }}
+{{ ansible_managed | default('Ansible managed') | comment }}
 #
 # Lynis Security Audit Systemd Timer
 #

--- a/roles/multiplexer/templates/config.kdl.j2
+++ b/roles/multiplexer/templates/config.kdl.j2
@@ -1,4 +1,4 @@
-{{ ansible_managed | comment('c') }}
+{{ ansible_managed | default('Ansible managed') | comment('c') }}
 // zellij Configuration
 
 {% if multiplexer_zellij_config.theme | default('') | length > 0 %}

--- a/roles/multiplexer/templates/tmux.conf.j2
+++ b/roles/multiplexer/templates/tmux.conf.j2
@@ -1,4 +1,4 @@
-{{ ansible_managed | comment }}
+{{ ansible_managed | default('Ansible managed') | comment }}
 # tmux Configuration
 
 {% if multiplexer_tmux_config.prefix | default('') | length > 0 %}

--- a/roles/networkmanager/templates/49-networkmanager.rules.j2
+++ b/roles/networkmanager/templates/49-networkmanager.rules.j2
@@ -1,4 +1,4 @@
-{{ ansible_managed | comment('c') }}
+{{ ansible_managed | default('Ansible managed') | comment('c') }}
 
 // Allow members of the "{{ networkmanager_polkit_group }}" group to manage
 // NetworkManager without authentication.

--- a/roles/networkmanager/templates/dispatcher.d/09-timezone.sh.j2
+++ b/roles/networkmanager/templates/dispatcher.d/09-timezone.sh.j2
@@ -1,5 +1,5 @@
 #!/bin/sh
-{{ ansible_managed | comment }}
+{{ ansible_managed | default('Ansible managed') | comment }}
 
 # This script automatically sets the system timezone based on the current IP address
 # using the ipapi.co API when a network connection comes up.

--- a/roles/networkmanager/templates/dispatcher.d/20-vpn-autoconnect.sh.j2
+++ b/roles/networkmanager/templates/dispatcher.d/20-vpn-autoconnect.sh.j2
@@ -1,6 +1,6 @@
 #jinja2:lstrip_blocks: True
 #!/bin/sh
-{{ ansible_managed | comment }}
+{{ ansible_managed | default('Ansible managed') | comment }}
 
 # This script automatically activates a WireGuard VPN tunnel when connecting
 # to a non-home network, and deactivates it when the base connection drops.

--- a/roles/networkmanager/templates/dispatcher.d/30-mount-smb.sh.j2
+++ b/roles/networkmanager/templates/dispatcher.d/30-mount-smb.sh.j2
@@ -1,6 +1,6 @@
 #jinja2:lstrip_blocks: True
 #!/bin/sh
-{{ ansible_managed | comment }}
+{{ ansible_managed | default('Ansible managed') | comment }}
 
 # This script automatically mounts SMB shares based on the active NetworkManager connection.
 # It checks if the current active network connection (Ethernet or Wi-Fi) is a dependency

--- a/roles/networkmanager/templates/dispatcher.d/30-mount-sshfs.sh.j2
+++ b/roles/networkmanager/templates/dispatcher.d/30-mount-sshfs.sh.j2
@@ -1,6 +1,6 @@
 #jinja2:lstrip_blocks: True
 #!/bin/sh
-{{ ansible_managed | comment }}
+{{ ansible_managed | default('Ansible managed') | comment }}
 
 # This script automatically mounts SSHFS shares when a network connection comes up.
 

--- a/roles/networkmanager/templates/dispatcher.d/40-umount-smb.sh.j2
+++ b/roles/networkmanager/templates/dispatcher.d/40-umount-smb.sh.j2
@@ -1,6 +1,6 @@
 #jinja2:lstrip_blocks: True
 #!/bin/sh
-{{ ansible_managed | comment }}
+{{ ansible_managed | default('Ansible managed') | comment }}
 
 # This script attempts to unmount SMB shares when a network connection goes down (e.g., unexpected disconnect).
 # It ensures a share is only unmounted if none of its dependencies are active anymore.

--- a/roles/networkmanager/templates/dispatcher.d/40-umount-sshfs.sh.j2
+++ b/roles/networkmanager/templates/dispatcher.d/40-umount-sshfs.sh.j2
@@ -1,6 +1,6 @@
 #jinja2:lstrip_blocks: True
 #!/bin/sh
-{{ ansible_managed | comment }}
+{{ ansible_managed | default('Ansible managed') | comment }}
 
 # This script automatically unmounts SSHFS shares when the last network connection goes down.
 # It serves as a fallback for shutdown/restart scenarios where pre-down might not run.

--- a/roles/networkmanager/templates/dispatcher.d/50-vpn-mount-smb.sh.j2
+++ b/roles/networkmanager/templates/dispatcher.d/50-vpn-mount-smb.sh.j2
@@ -1,6 +1,6 @@
 #jinja2:lstrip_blocks: True
 #!/bin/sh
-{{ ansible_managed | comment }}
+{{ ansible_managed | default('Ansible managed') | comment }}
 
 # This script mounts SMB shares associated with a specific VPN connection
 # when the VPN connection comes up.

--- a/roles/networkmanager/templates/dispatcher.d/60-vpn-umount-smb.sh.j2
+++ b/roles/networkmanager/templates/dispatcher.d/60-vpn-umount-smb.sh.j2
@@ -1,6 +1,6 @@
 #jinja2:lstrip_blocks: True
 #!/bin/sh
-{{ ansible_managed | comment }}
+{{ ansible_managed | default('Ansible managed') | comment }}
 
 # This script unmounts SMB shares associated with a specific VPN connection
 # when the VPN connection goes down.

--- a/roles/networkmanager/templates/dispatcher.d/pre-down.d/30-umount-smb.sh.j2
+++ b/roles/networkmanager/templates/dispatcher.d/pre-down.d/30-umount-smb.sh.j2
@@ -1,6 +1,6 @@
 #jinja2:lstrip_blocks: True
 #!/bin/sh
-{{ ansible_managed | comment }}
+{{ ansible_managed | default('Ansible managed') | comment }}
 
 # This script attempts to unmount SMB shares before a network connection is brought down.
 # It ensures a share is only unmounted if none of its dependencies are active anymore.

--- a/roles/networkmanager/templates/dispatcher.d/pre-down.d/30-umount-sshfs.sh.j2
+++ b/roles/networkmanager/templates/dispatcher.d/pre-down.d/30-umount-sshfs.sh.j2
@@ -1,6 +1,6 @@
 #jinja2:lstrip_blocks: True
 #!/bin/sh
-{{ ansible_managed | comment }}
+{{ ansible_managed | default('Ansible managed') | comment }}
 
 # This script automatically unmounts SSHFS shares when the last network connection is about to go down.
 

--- a/roles/networkmanager/templates/networkmanager.conf.j2
+++ b/roles/networkmanager/templates/networkmanager.conf.j2
@@ -1,4 +1,4 @@
-{{ ansible_managed | comment }}
+{{ ansible_managed | default('Ansible managed') | comment }}
 #
 # NetworkManager daemon configuration
 # Deployed to /etc/NetworkManager/conf.d/00-ansible.conf

--- a/roles/networkmanager/templates/wg-quick-smb.conf.j2
+++ b/roles/networkmanager/templates/wg-quick-smb.conf.j2
@@ -1,4 +1,4 @@
-{{ ansible_managed | comment(decoration='# ') }}
+{{ ansible_managed | default('Ansible managed') | comment(decoration='# ') }}
 #
 # systemd drop-in for wg-quick@.service
 # Mounts/unmounts SMB shares when WireGuard tunnels start/stop.

--- a/roles/networkmanager/templates/wireguard-smb-mount.sh.j2
+++ b/roles/networkmanager/templates/wireguard-smb-mount.sh.j2
@@ -1,6 +1,6 @@
 #jinja2:lstrip_blocks: True
 #!/bin/sh
-{{ ansible_managed | comment }}
+{{ ansible_managed | default('Ansible managed') | comment }}
 
 # This script is called by wg-quick@.service via systemd drop-in.
 # It mounts/unmounts SMB shares that depend on WireGuard interfaces.

--- a/roles/openssh/templates/10-network.conf.j2
+++ b/roles/openssh/templates/10-network.conf.j2
@@ -1,4 +1,4 @@
-{{ ansible_managed | comment }}
+{{ ansible_managed | default('Ansible managed') | comment }}
 # Network settings
 
 Port {{ openssh_server_port }}

--- a/roles/openssh/templates/20-hostkeys.conf.j2
+++ b/roles/openssh/templates/20-hostkeys.conf.j2
@@ -1,4 +1,4 @@
-{{ ansible_managed | comment }}
+{{ ansible_managed | default('Ansible managed') | comment }}
 # Host keys
 
 {% for keytype in openssh_server_host_key_types %}

--- a/roles/openssh/templates/30-crypto.conf.j2
+++ b/roles/openssh/templates/30-crypto.conf.j2
@@ -1,4 +1,4 @@
-{{ ansible_managed | comment }}
+{{ ansible_managed | default('Ansible managed') | comment }}
 # Cryptographic settings
 
 {#- Derive algorithm lists from host key types when set to 'auto' -#}

--- a/roles/openssh/templates/40-authentication.conf.j2
+++ b/roles/openssh/templates/40-authentication.conf.j2
@@ -1,4 +1,4 @@
-{{ ansible_managed | comment }}
+{{ ansible_managed | default('Ansible managed') | comment }}
 # Authentication settings
 
 LoginGraceTime {{ openssh_server_login_grace_time }}

--- a/roles/openssh/templates/50-access.conf.j2
+++ b/roles/openssh/templates/50-access.conf.j2
@@ -1,4 +1,4 @@
-{{ ansible_managed | comment }}
+{{ ansible_managed | default('Ansible managed') | comment }}
 {% if openssh_server_allow_users | length > 0 %}
 
 # Access control

--- a/roles/openssh/templates/60-session.conf.j2
+++ b/roles/openssh/templates/60-session.conf.j2
@@ -1,4 +1,4 @@
-{{ ansible_managed | comment }}
+{{ ansible_managed | default('Ansible managed') | comment }}
 # Session settings
 
 ClientAliveInterval {{ openssh_server_client_alive_interval }}

--- a/roles/openssh/templates/70-forwarding.conf.j2
+++ b/roles/openssh/templates/70-forwarding.conf.j2
@@ -1,4 +1,4 @@
-{{ ansible_managed | comment }}
+{{ ansible_managed | default('Ansible managed') | comment }}
 # Forwarding settings
 
 AllowTcpForwarding {{ openssh_server_allow_tcp_forwarding | ternary('yes', 'no') }}

--- a/roles/openssh/templates/80-subsystems.conf.j2
+++ b/roles/openssh/templates/80-subsystems.conf.j2
@@ -1,4 +1,4 @@
-{{ ansible_managed | comment }}
+{{ ansible_managed | default('Ansible managed') | comment }}
 {% if openssh_server_sftp_enabled | bool %}
 
 # Subsystems

--- a/roles/openssh/templates/85-logging.conf.j2
+++ b/roles/openssh/templates/85-logging.conf.j2
@@ -1,4 +1,4 @@
-{{ ansible_managed | comment }}
+{{ ansible_managed | default('Ansible managed') | comment }}
 # Logging
 
 SyslogFacility {{ openssh_server_syslog_facility }}

--- a/roles/openssh/templates/90-match.conf.j2
+++ b/roles/openssh/templates/90-match.conf.j2
@@ -1,4 +1,4 @@
-{{ ansible_managed | comment }}
+{{ ansible_managed | default('Ansible managed') | comment }}
 {% if openssh_server_sftp_chroot_enabled | default(false) | bool %}
 
 # Match blocks

--- a/roles/openssh/templates/ssh_config.j2
+++ b/roles/openssh/templates/ssh_config.j2
@@ -1,4 +1,4 @@
-{{ ansible_managed | comment }}
+{{ ansible_managed | default('Ansible managed') | comment }}
 # SSH client defaults
 
 {#- Derive host key algorithms from host key types when set to 'auto' -#}

--- a/roles/package_management/templates/archlinux/makepkg.conf.j2
+++ b/roles/package_management/templates/archlinux/makepkg.conf.j2
@@ -1,4 +1,4 @@
-{{ ansible_managed | comment }}
+{{ ansible_managed | default('Ansible managed') | comment }}
 #!/hint/bash
 # shellcheck disable=2034
 #

--- a/roles/package_management/templates/archlinux/makepkg.user.conf.j2
+++ b/roles/package_management/templates/archlinux/makepkg.user.conf.j2
@@ -1,4 +1,4 @@
-{{ ansible_managed | comment }}
+{{ ansible_managed | default('Ansible managed') | comment }}
 #!/hint/bash
 # shellcheck disable=2034
 #

--- a/roles/package_management/templates/archlinux/pacman.conf.j2
+++ b/roles/package_management/templates/archlinux/pacman.conf.j2
@@ -1,4 +1,4 @@
-{{ ansible_managed | comment }}
+{{ ansible_managed | default('Ansible managed') | comment }}
 #
 # /etc/pacman.conf
 #

--- a/roles/package_management/templates/archlinux/paru.conf.j2
+++ b/roles/package_management/templates/archlinux/paru.conf.j2
@@ -1,4 +1,4 @@
-{{ ansible_managed | comment }}
+{{ ansible_managed | default('Ansible managed') | comment }}
 #
 # /etc/paru.conf - System-wide paru configuration
 #

--- a/roles/package_management/templates/archlinux/reflector.conf.j2
+++ b/roles/package_management/templates/archlinux/reflector.conf.j2
@@ -1,4 +1,4 @@
-{{ ansible_managed | comment }}
+{{ ansible_managed | default('Ansible managed') | comment }}
 # Reflector configuration file for the systemd service.
 #
 # Empty lines and lines beginning with "#" are ignored.  All other lines should

--- a/roles/package_management/templates/debian/apt-periodic.conf.j2
+++ b/roles/package_management/templates/debian/apt-periodic.conf.j2
@@ -1,4 +1,4 @@
-{{ ansible_managed | comment('c') }}
+{{ ansible_managed | default('Ansible managed') | comment('c') }}
 // APT Periodic Configuration
 
 APT::Periodic::Update-Package-Lists "{{ apt_periodic_update }}";

--- a/roles/package_management/templates/debian/apt-preferences.j2
+++ b/roles/package_management/templates/debian/apt-preferences.j2
@@ -1,4 +1,4 @@
-{{ ansible_managed | comment }}
+{{ ansible_managed | default('Ansible managed') | comment }}
 # APT Preferences (Package Pinning)
 
 {% for pref in apt_preferences %}

--- a/roles/package_management/templates/debian/apt.conf.j2
+++ b/roles/package_management/templates/debian/apt.conf.j2
@@ -1,4 +1,4 @@
-{{ ansible_managed | comment('c') }}
+{{ ansible_managed | default('Ansible managed') | comment('c') }}
 // APT Configuration
 
 // Install recommendations

--- a/roles/package_management/templates/debian/auto-upgrades.conf.j2
+++ b/roles/package_management/templates/debian/auto-upgrades.conf.j2
@@ -1,4 +1,4 @@
-{{ ansible_managed | comment('c') }}
+{{ ansible_managed | default('Ansible managed') | comment('c') }}
 // Auto-Upgrades Configuration
 
 APT::Periodic::Update-Package-Lists "1";

--- a/roles/package_management/templates/debian/unattended-upgrades.conf.j2
+++ b/roles/package_management/templates/debian/unattended-upgrades.conf.j2
@@ -1,4 +1,4 @@
-{{ ansible_managed | comment('c') }}
+{{ ansible_managed | default('Ansible managed') | comment('c') }}
 // Unattended Upgrades Configuration
 
 Unattended-Upgrade::Allowed-Origins {

--- a/roles/package_management/templates/redhat/dnf-automatic.conf.j2
+++ b/roles/package_management/templates/redhat/dnf-automatic.conf.j2
@@ -1,4 +1,4 @@
-{{ ansible_managed | comment }}
+{{ ansible_managed | default('Ansible managed') | comment }}
 [commands]
 upgrade_type = {{ dnf_automatic_upgrade_type }}
 random_sleep = 0

--- a/roles/package_management/templates/redhat/dnf.conf.j2
+++ b/roles/package_management/templates/redhat/dnf.conf.j2
@@ -1,4 +1,4 @@
-{{ ansible_managed | comment }}
+{{ ansible_managed | default('Ansible managed') | comment }}
 [main]
 gpgcheck=1
 installonly_limit=3

--- a/roles/pam_hardening/templates/2fa-setup.sh.j2
+++ b/roles/pam_hardening/templates/2fa-setup.sh.j2
@@ -1,5 +1,5 @@
 #!/bin/bash
-{{ ansible_managed | comment }}
+{{ ansible_managed | default('Ansible managed') | comment }}
 #
 # Two-Factor Authentication Setup Script
 # Run this script as the user who needs TOTP 2FA configured.

--- a/roles/pam_hardening/templates/access.conf.j2
+++ b/roles/pam_hardening/templates/access.conf.j2
@@ -1,4 +1,4 @@
-{{ ansible_managed | comment }}
+{{ ansible_managed | default('Ansible managed') | comment }}
 #
 # Login access control table.
 # See access.conf(5) for full documentation.

--- a/roles/pam_hardening/templates/faillock.conf.j2
+++ b/roles/pam_hardening/templates/faillock.conf.j2
@@ -1,4 +1,4 @@
-{{ ansible_managed | comment }}
+{{ ansible_managed | default('Ansible managed') | comment }}
 #
 # Configuration for pam_faillock — account lockout after repeated
 # authentication failures.

--- a/roles/pam_hardening/templates/limits.conf.j2
+++ b/roles/pam_hardening/templates/limits.conf.j2
@@ -1,4 +1,4 @@
-{{ ansible_managed | comment }}
+{{ ansible_managed | default('Ansible managed') | comment }}
 #
 # /etc/security/limits.d/99-hardening.conf
 #

--- a/roles/pam_hardening/templates/pwquality.conf.j2
+++ b/roles/pam_hardening/templates/pwquality.conf.j2
@@ -1,4 +1,4 @@
-{{ ansible_managed | comment }}
+{{ ansible_managed | default('Ansible managed') | comment }}
 #
 # Configuration for pam_pwquality — password quality checking.
 #

--- a/roles/pam_hardening/templates/securetty.j2
+++ b/roles/pam_hardening/templates/securetty.j2
@@ -1,4 +1,4 @@
-{{ ansible_managed | comment }}
+{{ ansible_managed | default('Ansible managed') | comment }}
 #
 # List of terminals from which root can log in.
 # See securetty(5) for details.

--- a/roles/php/templates/99-ansible.ini.j2
+++ b/roles/php/templates/99-ansible.ini.j2
@@ -1,4 +1,4 @@
-{{ ansible_managed | comment(decoration='; ') }}
+{{ ansible_managed | default('Ansible managed') | comment(decoration='; ') }}
 
 [PHP]
 ; Resource Limits

--- a/roles/php/templates/www.conf.j2
+++ b/roles/php/templates/www.conf.j2
@@ -1,4 +1,4 @@
-{{ ansible_managed | comment(decoration='; ') }}
+{{ ansible_managed | default('Ansible managed') | comment(decoration='; ') }}
 
 ; Pool name
 [www]

--- a/roles/pki/templates/apparmor-pki-ocsp.j2
+++ b/roles/pki/templates/apparmor-pki-ocsp.j2
@@ -1,4 +1,4 @@
-{{ ansible_managed | comment }}
+{{ ansible_managed | default('Ansible managed') | comment }}
 #
 # AppArmor profile for PKI OCSP Responder
 

--- a/roles/pki/templates/ca-openssl.cnf.j2
+++ b/roles/pki/templates/ca-openssl.cnf.j2
@@ -1,4 +1,4 @@
-{{ ansible_managed | comment }}
+{{ ansible_managed | default('Ansible managed') | comment }}
 #
 # OpenSSL CA Configuration
 

--- a/roles/pki/templates/openssl-system-default.conf.j2
+++ b/roles/pki/templates/openssl-system-default.conf.j2
@@ -1,4 +1,4 @@
-{{ ansible_managed | comment }}
+{{ ansible_managed | default('Ansible managed') | comment }}
 #
 # System-wide OpenSSL defaults (drop-in override)
 

--- a/roles/pki/templates/pki-cert-check.service.j2
+++ b/roles/pki/templates/pki-cert-check.service.j2
@@ -1,4 +1,4 @@
-{{ ansible_managed | comment }}
+{{ ansible_managed | default('Ansible managed') | comment }}
 #
 # Certificate expiry check service
 

--- a/roles/pki/templates/pki-cert-check.sh.j2
+++ b/roles/pki/templates/pki-cert-check.sh.j2
@@ -1,5 +1,5 @@
 #!/bin/bash
-{{ ansible_managed | comment }}
+{{ ansible_managed | default('Ansible managed') | comment }}
 #
 # Certificate expiry check script
 # Scans certificate directories and reports certificates expiring

--- a/roles/pki/templates/pki-cert-check.timer.j2
+++ b/roles/pki/templates/pki-cert-check.timer.j2
@@ -1,4 +1,4 @@
-{{ ansible_managed | comment }}
+{{ ansible_managed | default('Ansible managed') | comment }}
 #
 # Certificate expiry check timer
 

--- a/roles/pki/templates/pki-ocsp.service.j2
+++ b/roles/pki/templates/pki-ocsp.service.j2
@@ -1,4 +1,4 @@
-{{ ansible_managed | comment }}
+{{ ansible_managed | default('Ansible managed') | comment }}
 #
 # OCSP Responder systemd service
 

--- a/roles/podman/templates/containers.conf.j2
+++ b/roles/podman/templates/containers.conf.j2
@@ -1,4 +1,4 @@
-{{ ansible_managed | comment }}
+{{ ansible_managed | default('Ansible managed') | comment }}
 #
 # Podman Containers Configuration
 # See containers.conf(5) for details.

--- a/roles/podman/templates/podman-docker.sh.j2
+++ b/roles/podman/templates/podman-docker.sh.j2
@@ -1,4 +1,4 @@
-{{ ansible_managed | comment }}
+{{ ansible_managed | default('Ansible managed') | comment }}
 # Podman Docker compatibility aliases
 alias docker=podman
 alias docker-compose=podman-compose

--- a/roles/podman/templates/podman-prune.service.j2
+++ b/roles/podman/templates/podman-prune.service.j2
@@ -1,4 +1,4 @@
-{{ ansible_managed | comment }}
+{{ ansible_managed | default('Ansible managed') | comment }}
 #
 # Podman System Prune Service
 

--- a/roles/podman/templates/podman-prune.timer.j2
+++ b/roles/podman/templates/podman-prune.timer.j2
@@ -1,4 +1,4 @@
-{{ ansible_managed | comment }}
+{{ ansible_managed | default('Ansible managed') | comment }}
 #
 # Podman System Prune Timer
 

--- a/roles/podman/templates/registries.conf.j2
+++ b/roles/podman/templates/registries.conf.j2
@@ -1,4 +1,4 @@
-{{ ansible_managed | comment }}
+{{ ansible_managed | default('Ansible managed') | comment }}
 #
 # Podman Registries Configuration
 # See containers-registries.conf(5) for details.

--- a/roles/podman/templates/storage.conf.j2
+++ b/roles/podman/templates/storage.conf.j2
@@ -1,4 +1,4 @@
-{{ ansible_managed | comment }}
+{{ ansible_managed | default('Ansible managed') | comment }}
 #
 # Podman Storage Configuration
 # See containers-storage.conf(5) for details.

--- a/roles/resolved/templates/resolved.conf.j2
+++ b/roles/resolved/templates/resolved.conf.j2
@@ -1,4 +1,4 @@
-{{ ansible_managed | comment }}
+{{ ansible_managed | default('Ansible managed') | comment }}
 
 [Resolve]
 {% if resolved_dns | length > 0 %}

--- a/roles/restic/templates/backup.service.j2
+++ b/roles/restic/templates/backup.service.j2
@@ -1,4 +1,4 @@
-{{ ansible_managed | comment }}
+{{ ansible_managed | default('Ansible managed') | comment }}
 #
 # Restic Backup Service: {{ item.name }}
 #

--- a/roles/restic/templates/backup.sh.j2
+++ b/roles/restic/templates/backup.sh.j2
@@ -1,5 +1,5 @@
 #!/bin/bash
-{{ ansible_managed | comment }}
+{{ ansible_managed | default('Ansible managed') | comment }}
 #
 # Restic Backup Script: {{ item.name }}
 #

--- a/roles/restic/templates/backup.timer.j2
+++ b/roles/restic/templates/backup.timer.j2
@@ -1,4 +1,4 @@
-{{ ansible_managed | comment }}
+{{ ansible_managed | default('Ansible managed') | comment }}
 #
 # Restic Backup Timer: {{ item.name }}
 #

--- a/roles/restic/templates/environment.j2
+++ b/roles/restic/templates/environment.j2
@@ -1,4 +1,4 @@
-{{ ansible_managed | comment }}
+{{ ansible_managed | default('Ansible managed') | comment }}
 #
 # Restic environment variables: {{ item.name }}
 #

--- a/roles/restic/templates/excludes.j2
+++ b/roles/restic/templates/excludes.j2
@@ -1,4 +1,4 @@
-{{ ansible_managed | comment }}
+{{ ansible_managed | default('Ansible managed') | comment }}
 #
 # Restic exclude patterns: {{ item.name }}
 #

--- a/roles/rkhunter/templates/rkhunter-check.service.j2
+++ b/roles/rkhunter/templates/rkhunter-check.service.j2
@@ -1,4 +1,4 @@
-{{ ansible_managed | comment }}
+{{ ansible_managed | default('Ansible managed') | comment }}
 #
 # rkhunter rootkit check systemd service
 #

--- a/roles/rkhunter/templates/rkhunter-check.sh.j2
+++ b/roles/rkhunter/templates/rkhunter-check.sh.j2
@@ -1,5 +1,5 @@
 #!/bin/bash
-{{ ansible_managed | comment }}
+{{ ansible_managed | default('Ansible managed') | comment }}
 #
 # rkhunter scheduled check script
 

--- a/roles/rkhunter/templates/rkhunter-check.timer.j2
+++ b/roles/rkhunter/templates/rkhunter-check.timer.j2
@@ -1,4 +1,4 @@
-{{ ansible_managed | comment }}
+{{ ansible_managed | default('Ansible managed') | comment }}
 #
 # rkhunter Rootkit Check Systemd Timer
 #

--- a/roles/rkhunter/templates/rkhunter.conf.j2
+++ b/roles/rkhunter/templates/rkhunter.conf.j2
@@ -1,4 +1,4 @@
-{{ ansible_managed | comment }}
+{{ ansible_managed | default('Ansible managed') | comment }}
 #
 # rkhunter configuration file
 #

--- a/roles/shell/templates/ohmyzsh.zshrc.j2
+++ b/roles/shell/templates/ohmyzsh.zshrc.j2
@@ -1,4 +1,4 @@
-{{ ansible_managed | comment }}
+{{ ansible_managed | default('Ansible managed') | comment }}
 #
 # Oh My Zsh Configuration
 #

--- a/roles/shell/templates/starship.toml.j2
+++ b/roles/shell/templates/starship.toml.j2
@@ -1,3 +1,3 @@
-# {{ ansible_managed }}
+# {{ ansible_managed | default('Ansible managed') }}
 # Starship config — minimal default (no preset selected).
 # See https://starship.rs/config/ for available options.

--- a/roles/snmp/templates/snmpd-override.conf.j2
+++ b/roles/snmp/templates/snmpd-override.conf.j2
@@ -1,4 +1,4 @@
-{{ ansible_managed | comment }}
+{{ ansible_managed | default('Ansible managed') | comment }}
 #
 # Override snmpd ExecStart to use agentaddress from snmpd.conf
 # instead of hardcoded "udp: udp6:" in upstream unit file.

--- a/roles/snmp/templates/snmpd.conf.j2
+++ b/roles/snmp/templates/snmpd.conf.j2
@@ -1,4 +1,4 @@
-{{ ansible_managed | comment }}
+{{ ansible_managed | default('Ansible managed') | comment }}
 #
 # Net-SNMP agent configuration
 #

--- a/roles/sudo/templates/sudoers.d/custom.j2
+++ b/roles/sudo/templates/sudoers.d/custom.j2
@@ -1,4 +1,4 @@
-{{ ansible_managed | comment }}
+{{ ansible_managed | default('Ansible managed') | comment }}
 # Custom sudoers configuration: {{ item.name }}
 {% if item.content is defined %}
 {{ item.content }}

--- a/roles/sudo/templates/sudoers.d/custom_group.j2
+++ b/roles/sudo/templates/sudoers.d/custom_group.j2
@@ -1,4 +1,4 @@
-{{ ansible_managed | comment }}
+{{ ansible_managed | default('Ansible managed') | comment }}
 # Sudo access for group: {{ item.name }}
 {% if item.commands is defined and item.commands | length > 0 %}
 {% if item.nopasswd | default(false) %}

--- a/roles/sudo/templates/sudoers.d/user.j2
+++ b/roles/sudo/templates/sudoers.d/user.j2
@@ -1,4 +1,4 @@
-{{ ansible_managed | comment }}
+{{ ansible_managed | default('Ansible managed') | comment }}
 # Sudo access for user: {{ item.name }}
 {% if item.commands is defined and item.commands | length > 0 %}
 {% if item.nopasswd | default(false) %}

--- a/roles/sudo/templates/sudoers.j2
+++ b/roles/sudo/templates/sudoers.j2
@@ -1,4 +1,4 @@
-{{ ansible_managed | comment }}
+{{ ansible_managed | default('Ansible managed') | comment }}
 #
 # /etc/sudoers
 #

--- a/roles/sysctl/templates/sysctl.conf.j2
+++ b/roles/sysctl/templates/sysctl.conf.j2
@@ -1,4 +1,4 @@
-{{ ansible_managed | comment }}
+{{ ansible_managed | default('Ansible managed') | comment }}
 #
 # Sysctl Configuration
 #

--- a/roles/unbound/templates/forward-zones.conf.j2
+++ b/roles/unbound/templates/forward-zones.conf.j2
@@ -1,4 +1,4 @@
-{{ ansible_managed | comment }}
+{{ ansible_managed | default('Ansible managed') | comment }}
 
 {% for zone in unbound_forward_zones %}
 forward-zone:

--- a/roles/unbound/templates/local-zones.conf.j2
+++ b/roles/unbound/templates/local-zones.conf.j2
@@ -1,4 +1,4 @@
-{{ ansible_managed | comment }}
+{{ ansible_managed | default('Ansible managed') | comment }}
 
 {% for zone in unbound_local_zones %}
 # Zone: {{ zone.name }}

--- a/roles/unbound/templates/unbound-blocklist.service.j2
+++ b/roles/unbound/templates/unbound-blocklist.service.j2
@@ -1,4 +1,4 @@
-{{ ansible_managed | comment }}
+{{ ansible_managed | default('Ansible managed') | comment }}
 
 [Unit]
 Description=Update Unbound DNS Blocklist

--- a/roles/unbound/templates/unbound-blocklist.timer.j2
+++ b/roles/unbound/templates/unbound-blocklist.timer.j2
@@ -1,4 +1,4 @@
-{{ ansible_managed | comment }}
+{{ ansible_managed | default('Ansible managed') | comment }}
 
 [Unit]
 Description=Update Unbound DNS Blocklist Timer

--- a/roles/unbound/templates/unbound-root-hints.service.j2
+++ b/roles/unbound/templates/unbound-root-hints.service.j2
@@ -1,4 +1,4 @@
-{{ ansible_managed | comment }}
+{{ ansible_managed | default('Ansible managed') | comment }}
 
 [Unit]
 Description=Update Unbound Root Hints

--- a/roles/unbound/templates/unbound-root-hints.timer.j2
+++ b/roles/unbound/templates/unbound-root-hints.timer.j2
@@ -1,4 +1,4 @@
-{{ ansible_managed | comment }}
+{{ ansible_managed | default('Ansible managed') | comment }}
 
 [Unit]
 Description=Update Unbound Root Hints Timer

--- a/roles/unbound/templates/unbound.conf.j2
+++ b/roles/unbound/templates/unbound.conf.j2
@@ -1,4 +1,4 @@
-{{ ansible_managed | comment }}
+{{ ansible_managed | default('Ansible managed') | comment }}
 
 server:
     # Network

--- a/roles/unbound/templates/update-blocklist.sh.j2
+++ b/roles/unbound/templates/update-blocklist.sh.j2
@@ -1,5 +1,5 @@
 #!/bin/bash
-{{ ansible_managed | comment }}
+{{ ansible_managed | default('Ansible managed') | comment }}
 
 set -euo pipefail
 

--- a/roles/wireguard/templates/wg.conf.j2
+++ b/roles/wireguard/templates/wg.conf.j2
@@ -1,4 +1,4 @@
-{{ ansible_managed | comment }}
+{{ ansible_managed | default('Ansible managed') | comment }}
 #
 # WireGuard Configuration: {{ __wireguard_iface.name }}
 #


### PR DESCRIPTION
## Summary

- Add `| default('Ansible managed')` fallback to every `ansible_managed` reference across 154 templates so they render correctly on ansible-core 2.23+, where `DEFAULT_MANAGED_STR` is removed and `ansible_managed` is no longer auto-populated by the ssh connection plugin.
- Covers all seven `ansible_managed` patterns in use: `comment`, `comment('c')`, `comment('xml')`, `comment(decoration='# ')`, `comment(decoration='" ')`, `comment(decoration='; ')`, plus the one bare reference in `roles/shell/templates/starship.toml.j2`.
- The `| default(...)` filter is inserted between `ansible_managed` and the existing comment filter, leaving the rest of each line untouched. Hosts that already set `ansible_managed` via inventory continue to see their inventory value — `default` only fires when undefined.

## Test plan

- [x] grep verifies all 154 templates now carry `default('Ansible managed')` (no remaining bare reference)
- [x] Render-test of all 7 variants in both scenarios (`ansible_managed` undefined / set via inventory) — 14/14 pass; default wins when undefined, inventory value wins when set
- [x] `pre-commit run --files <changed>` passes (trailing-whitespace, end-of-file-fixer, mixed-line-ending, check-added-large-files, check-merge-conflict, detect-secrets)
- [x] `ansible-lint --profile=production --offline` over the full collection: 0 failures, 0 warnings across 1011 files
- [x] `molecule test -p base-archlinux` on `roles/base`: 36 ok / 0 failed, both `Check ansible_managed header` assertions pass, idempotence clean

References #131