### PR TITLE
feat(roles): add minor-version level to with_first_found vars lookup

### DIFF
--- a/roles/aide/tasks/main.yml
+++ b/roles/aide/tasks/main.yml
@@ -20,6 +20,7 @@
   ansible.builtin.include_vars: '{{ item }}'
   with_first_found:
     - files:
+        - '{{ ansible_facts["distribution"] }}-{{ ansible_facts["distribution_version"] }}.yml'
         - '{{ ansible_facts["distribution"] }}-{{ ansible_facts["distribution_major_version"] }}.yml'
         - '{{ ansible_facts["os_family"] }}-{{ ansible_facts["distribution_major_version"] }}.yml'
         - '{{ ansible_facts["distribution"] }}.yml'

--- a/roles/ansible/tasks/main.yml
+++ b/roles/ansible/tasks/main.yml
@@ -3,6 +3,7 @@
   ansible.builtin.include_vars: '{{ item }}'
   with_first_found:
     - files:
+        - '{{ ansible_facts["distribution"] }}-{{ ansible_facts["distribution_version"] }}.yml'
         - '{{ ansible_facts["distribution"] }}-{{ ansible_facts["distribution_major_version"] }}.yml'
         - '{{ ansible_facts["os_family"] }}-{{ ansible_facts["distribution_major_version"] }}.yml'
         - '{{ ansible_facts["distribution"] }}.yml'

--- a/roles/apparmor/tasks/main.yml
+++ b/roles/apparmor/tasks/main.yml
@@ -3,6 +3,7 @@
   ansible.builtin.include_vars: '{{ item }}'
   with_first_found:
     - files:
+        - '{{ ansible_facts["distribution"] }}-{{ ansible_facts["distribution_version"] }}.yml'
         - '{{ ansible_facts["distribution"] }}-{{ ansible_facts["distribution_major_version"] }}.yml'
         - '{{ ansible_facts["os_family"] }}-{{ ansible_facts["distribution_major_version"] }}.yml'
         - '{{ ansible_facts["distribution"] }}.yml'

--- a/roles/auditd/tasks/main.yml
+++ b/roles/auditd/tasks/main.yml
@@ -3,6 +3,7 @@
   ansible.builtin.include_vars: '{{ item }}'
   with_first_found:
     - files:
+        - '{{ ansible_facts["distribution"] }}-{{ ansible_facts["distribution_version"] }}.yml'
         - '{{ ansible_facts["distribution"] }}-{{ ansible_facts["distribution_major_version"] }}.yml'
         - '{{ ansible_facts["os_family"] }}-{{ ansible_facts["distribution_major_version"] }}.yml'
         - '{{ ansible_facts["distribution"] }}.yml'

--- a/roles/avahi/tasks/main.yml
+++ b/roles/avahi/tasks/main.yml
@@ -3,6 +3,7 @@
   ansible.builtin.include_vars: '{{ item }}'
   with_first_found:
     - files:
+        - '{{ ansible_facts["distribution"] }}-{{ ansible_facts["distribution_version"] }}.yml'
         - '{{ ansible_facts["distribution"] }}-{{ ansible_facts["distribution_major_version"] }}.yml'
         - '{{ ansible_facts["os_family"] }}-{{ ansible_facts["distribution_major_version"] }}.yml'
         - '{{ ansible_facts["distribution"] }}.yml'

--- a/roles/base/tasks/main.yml
+++ b/roles/base/tasks/main.yml
@@ -3,6 +3,7 @@
   ansible.builtin.include_vars: '{{ item }}'
   with_first_found:
     - files:
+        - '{{ ansible_facts["distribution"] }}-{{ ansible_facts["distribution_version"] }}.yml'
         - '{{ ansible_facts["distribution"] }}-{{ ansible_facts["distribution_major_version"] }}.yml'
         - '{{ ansible_facts["os_family"] }}-{{ ansible_facts["distribution_major_version"] }}.yml'
         - '{{ ansible_facts["distribution"] }}.yml'

--- a/roles/chrony/tasks/main.yml
+++ b/roles/chrony/tasks/main.yml
@@ -3,6 +3,7 @@
   ansible.builtin.include_vars: '{{ item }}'
   with_first_found:
     - files:
+        - '{{ ansible_facts["distribution"] }}-{{ ansible_facts["distribution_version"] }}.yml'
         - '{{ ansible_facts["distribution"] }}-{{ ansible_facts["distribution_major_version"] }}.yml'
         - '{{ ansible_facts["os_family"] }}-{{ ansible_facts["distribution_major_version"] }}.yml'
         - '{{ ansible_facts["distribution"] }}.yml'

--- a/roles/clamav/tasks/main.yml
+++ b/roles/clamav/tasks/main.yml
@@ -3,6 +3,7 @@
   ansible.builtin.include_vars: '{{ item }}'
   with_first_found:
     - files:
+        - '{{ ansible_facts["distribution"] }}-{{ ansible_facts["distribution_version"] }}.yml'
         - '{{ ansible_facts["distribution"] }}-{{ ansible_facts["distribution_major_version"] }}.yml'
         - '{{ ansible_facts["os_family"] }}-{{ ansible_facts["distribution_major_version"] }}.yml'
         - '{{ ansible_facts["distribution"] }}.yml'

--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -3,6 +3,7 @@
   ansible.builtin.include_vars: '{{ item }}'
   with_first_found:
     - files:
+        - '{{ ansible_facts["distribution"] }}-{{ ansible_facts["distribution_version"] }}.yml'
         - '{{ ansible_facts["distribution"] }}-{{ ansible_facts["distribution_major_version"] }}.yml'
         - '{{ ansible_facts["os_family"] }}-{{ ansible_facts["distribution_major_version"] }}.yml'
         - '{{ ansible_facts["distribution"] }}.yml'

--- a/roles/editors/tasks/main.yml
+++ b/roles/editors/tasks/main.yml
@@ -3,6 +3,7 @@
   ansible.builtin.include_vars: '{{ item }}'
   with_first_found:
     - files:
+        - '{{ ansible_facts["distribution"] }}-{{ ansible_facts["distribution_version"] }}.yml'
         - '{{ ansible_facts["distribution"] }}-{{ ansible_facts["distribution_major_version"] }}.yml'
         - '{{ ansible_facts["os_family"] }}-{{ ansible_facts["distribution_major_version"] }}.yml'
         - '{{ ansible_facts["distribution"] }}.yml'

--- a/roles/energy_management/tasks/main.yml
+++ b/roles/energy_management/tasks/main.yml
@@ -3,6 +3,7 @@
   ansible.builtin.include_vars: '{{ item }}'
   with_first_found:
     - files:
+        - '{{ ansible_facts["distribution"] }}-{{ ansible_facts["distribution_version"] }}.yml'
         - '{{ ansible_facts["distribution"] }}-{{ ansible_facts["distribution_major_version"] }}.yml'
         - '{{ ansible_facts["os_family"] }}-{{ ansible_facts["distribution_major_version"] }}.yml'
         - '{{ ansible_facts["distribution"] }}.yml'

--- a/roles/fail2ban/tasks/main.yml
+++ b/roles/fail2ban/tasks/main.yml
@@ -3,6 +3,7 @@
   ansible.builtin.include_vars: '{{ item }}'
   with_first_found:
     - files:
+        - '{{ ansible_facts["distribution"] }}-{{ ansible_facts["distribution_version"] }}.yml'
         - '{{ ansible_facts["distribution"] }}-{{ ansible_facts["distribution_major_version"] }}.yml'
         - '{{ ansible_facts["os_family"] }}-{{ ansible_facts["distribution_major_version"] }}.yml'
         - '{{ ansible_facts["distribution"] }}.yml'

--- a/roles/firejail/tasks/main.yml
+++ b/roles/firejail/tasks/main.yml
@@ -3,6 +3,7 @@
   ansible.builtin.include_vars: '{{ item }}'
   with_first_found:
     - files:
+        - '{{ ansible_facts["distribution"] }}-{{ ansible_facts["distribution_version"] }}.yml'
         - '{{ ansible_facts["distribution"] }}-{{ ansible_facts["distribution_major_version"] }}.yml'
         - '{{ ansible_facts["os_family"] }}-{{ ansible_facts["distribution_major_version"] }}.yml'
         - '{{ ansible_facts["distribution"] }}.yml'

--- a/roles/fonts/tasks/main.yml
+++ b/roles/fonts/tasks/main.yml
@@ -3,6 +3,7 @@
   ansible.builtin.include_vars: '{{ item }}'
   with_first_found:
     - files:
+        - '{{ ansible_facts["distribution"] }}-{{ ansible_facts["distribution_version"] }}.yml'
         - '{{ ansible_facts["distribution"] }}-{{ ansible_facts["distribution_major_version"] }}.yml'
         - '{{ ansible_facts["os_family"] }}-{{ ansible_facts["distribution_major_version"] }}.yml'
         - '{{ ansible_facts["distribution"] }}.yml'

--- a/roles/gnupg/tasks/main.yml
+++ b/roles/gnupg/tasks/main.yml
@@ -3,6 +3,7 @@
   ansible.builtin.include_vars: '{{ item }}'
   with_first_found:
     - files:
+        - '{{ ansible_facts["distribution"] }}-{{ ansible_facts["distribution_version"] }}.yml'
         - '{{ ansible_facts["distribution"] }}-{{ ansible_facts["distribution_major_version"] }}.yml'
         - '{{ ansible_facts["os_family"] }}-{{ ansible_facts["distribution_major_version"] }}.yml'
         - '{{ ansible_facts["distribution"] }}.yml'

--- a/roles/graphics/tasks/main.yml
+++ b/roles/graphics/tasks/main.yml
@@ -3,6 +3,7 @@
   ansible.builtin.include_vars: '{{ item }}'
   with_first_found:
     - files:
+        - '{{ ansible_facts["distribution"] }}-{{ ansible_facts["distribution_version"] }}.yml'
         - '{{ ansible_facts["distribution"] }}-{{ ansible_facts["distribution_major_version"] }}.yml'
         - '{{ ansible_facts["os_family"] }}-{{ ansible_facts["distribution_major_version"] }}.yml'
         - '{{ ansible_facts["distribution"] }}.yml'

--- a/roles/hardening/tasks/main.yml
+++ b/roles/hardening/tasks/main.yml
@@ -3,6 +3,7 @@
   ansible.builtin.include_vars: '{{ item }}'
   with_first_found:
     - files:
+        - '{{ ansible_facts["distribution"] }}-{{ ansible_facts["distribution_version"] }}.yml'
         - '{{ ansible_facts["distribution"] }}-{{ ansible_facts["distribution_major_version"] }}.yml'
         - '{{ ansible_facts["os_family"] }}-{{ ansible_facts["distribution_major_version"] }}.yml'
         - '{{ ansible_facts["distribution"] }}.yml'

--- a/roles/hardware_tokens/tasks/main.yml
+++ b/roles/hardware_tokens/tasks/main.yml
@@ -3,6 +3,7 @@
   ansible.builtin.include_vars: '{{ item }}'
   with_first_found:
     - files:
+        - '{{ ansible_facts["distribution"] }}-{{ ansible_facts["distribution_version"] }}.yml'
         - '{{ ansible_facts["distribution"] }}-{{ ansible_facts["distribution_major_version"] }}.yml'
         - '{{ ansible_facts["os_family"] }}-{{ ansible_facts["distribution_major_version"] }}.yml'
         - '{{ ansible_facts["distribution"] }}.yml'

--- a/roles/logrotate/tasks/main.yml
+++ b/roles/logrotate/tasks/main.yml
@@ -3,6 +3,7 @@
   ansible.builtin.include_vars: '{{ item }}'
   with_first_found:
     - files:
+        - '{{ ansible_facts["distribution"] }}-{{ ansible_facts["distribution_version"] }}.yml'
         - '{{ ansible_facts["distribution"] }}-{{ ansible_facts["distribution_major_version"] }}.yml'
         - '{{ ansible_facts["os_family"] }}-{{ ansible_facts["distribution_major_version"] }}.yml'
         - '{{ ansible_facts["distribution"] }}.yml'

--- a/roles/lynis/tasks/main.yml
+++ b/roles/lynis/tasks/main.yml
@@ -3,6 +3,7 @@
   ansible.builtin.include_vars: '{{ item }}'
   with_first_found:
     - files:
+        - '{{ ansible_facts["distribution"] }}-{{ ansible_facts["distribution_version"] }}.yml'
         - '{{ ansible_facts["distribution"] }}-{{ ansible_facts["distribution_major_version"] }}.yml'
         - '{{ ansible_facts["os_family"] }}-{{ ansible_facts["distribution_major_version"] }}.yml'
         - '{{ ansible_facts["distribution"] }}.yml'

--- a/roles/multiplexer/tasks/main.yml
+++ b/roles/multiplexer/tasks/main.yml
@@ -3,6 +3,7 @@
   ansible.builtin.include_vars: '{{ item }}'
   with_first_found:
     - files:
+        - '{{ ansible_facts["distribution"] }}-{{ ansible_facts["distribution_version"] }}.yml'
         - '{{ ansible_facts["distribution"] }}-{{ ansible_facts["distribution_major_version"] }}.yml'
         - '{{ ansible_facts["os_family"] }}-{{ ansible_facts["distribution_major_version"] }}.yml'
         - '{{ ansible_facts["distribution"] }}.yml'

--- a/roles/networkmanager/tasks/main.yml
+++ b/roles/networkmanager/tasks/main.yml
@@ -3,6 +3,7 @@
   ansible.builtin.include_vars: '{{ item }}'
   with_first_found:
     - files:
+        - '{{ ansible_facts["distribution"] }}-{{ ansible_facts["distribution_version"] }}.yml'
         - '{{ ansible_facts["distribution"] }}-{{ ansible_facts["distribution_major_version"] }}.yml'
         - '{{ ansible_facts["os_family"] }}-{{ ansible_facts["distribution_major_version"] }}.yml'
         - '{{ ansible_facts["distribution"] }}.yml'

--- a/roles/nodejs/tasks/main.yml
+++ b/roles/nodejs/tasks/main.yml
@@ -3,6 +3,7 @@
   ansible.builtin.include_vars: '{{ item }}'
   with_first_found:
     - files:
+        - '{{ ansible_facts["distribution"] }}-{{ ansible_facts["distribution_version"] }}.yml'
         - '{{ ansible_facts["distribution"] }}-{{ ansible_facts["distribution_major_version"] }}.yml'
         - '{{ ansible_facts["os_family"] }}-{{ ansible_facts["distribution_major_version"] }}.yml'
         - '{{ ansible_facts["distribution"] }}.yml'

--- a/roles/openssh/tasks/main.yml
+++ b/roles/openssh/tasks/main.yml
@@ -3,6 +3,7 @@
   ansible.builtin.include_vars: '{{ item }}'
   with_first_found:
     - files:
+        - '{{ ansible_facts["distribution"] }}-{{ ansible_facts["distribution_version"] }}.yml'
         - '{{ ansible_facts["distribution"] }}-{{ ansible_facts["distribution_major_version"] }}.yml'
         - '{{ ansible_facts["os_family"] }}-{{ ansible_facts["distribution_major_version"] }}.yml'
         - '{{ ansible_facts["distribution"] }}.yml'

--- a/roles/pam_hardening/tasks/main.yml
+++ b/roles/pam_hardening/tasks/main.yml
@@ -3,6 +3,7 @@
   ansible.builtin.include_vars: '{{ item }}'
   with_first_found:
     - files:
+        - '{{ ansible_facts["distribution"] }}-{{ ansible_facts["distribution_version"] }}.yml'
         - '{{ ansible_facts["distribution"] }}-{{ ansible_facts["distribution_major_version"] }}.yml'
         - '{{ ansible_facts["os_family"] }}-{{ ansible_facts["distribution_major_version"] }}.yml'
         - '{{ ansible_facts["distribution"] }}.yml'

--- a/roles/php/tasks/main.yml
+++ b/roles/php/tasks/main.yml
@@ -3,6 +3,7 @@
   ansible.builtin.include_vars: '{{ item }}'
   with_first_found:
     - files:
+        - '{{ ansible_facts["distribution"] }}-{{ ansible_facts["distribution_version"] }}.yml'
         - '{{ ansible_facts["distribution"] }}-{{ ansible_facts["distribution_major_version"] }}.yml'
         - '{{ ansible_facts["os_family"] }}-{{ ansible_facts["distribution_major_version"] }}.yml'
         - '{{ ansible_facts["distribution"] }}.yml'

--- a/roles/pki/tasks/main.yml
+++ b/roles/pki/tasks/main.yml
@@ -3,6 +3,7 @@
   ansible.builtin.include_vars: '{{ item }}'
   with_first_found:
     - files:
+        - '{{ ansible_facts["distribution"] }}-{{ ansible_facts["distribution_version"] }}.yml'
         - '{{ ansible_facts["distribution"] }}-{{ ansible_facts["distribution_major_version"] }}.yml'
         - '{{ ansible_facts["os_family"] }}-{{ ansible_facts["distribution_major_version"] }}.yml'
         - '{{ ansible_facts["distribution"] }}.yml'

--- a/roles/podman/tasks/main.yml
+++ b/roles/podman/tasks/main.yml
@@ -3,6 +3,7 @@
   ansible.builtin.include_vars: '{{ item }}'
   with_first_found:
     - files:
+        - '{{ ansible_facts["distribution"] }}-{{ ansible_facts["distribution_version"] }}.yml'
         - '{{ ansible_facts["distribution"] }}-{{ ansible_facts["distribution_major_version"] }}.yml'
         - '{{ ansible_facts["os_family"] }}-{{ ansible_facts["distribution_major_version"] }}.yml'
         - '{{ ansible_facts["distribution"] }}.yml'

--- a/roles/python/tasks/main.yml
+++ b/roles/python/tasks/main.yml
@@ -3,6 +3,7 @@
   ansible.builtin.include_vars: '{{ item }}'
   with_first_found:
     - files:
+        - '{{ ansible_facts["distribution"] }}-{{ ansible_facts["distribution_version"] }}.yml'
         - '{{ ansible_facts["distribution"] }}-{{ ansible_facts["distribution_major_version"] }}.yml'
         - '{{ ansible_facts["os_family"] }}-{{ ansible_facts["distribution_major_version"] }}.yml'
         - '{{ ansible_facts["distribution"] }}.yml'

--- a/roles/resolved/tasks/main.yml
+++ b/roles/resolved/tasks/main.yml
@@ -3,6 +3,7 @@
   ansible.builtin.include_vars: '{{ item }}'
   with_first_found:
     - files:
+        - '{{ ansible_facts["distribution"] }}-{{ ansible_facts["distribution_version"] }}.yml'
         - '{{ ansible_facts["distribution"] }}-{{ ansible_facts["distribution_major_version"] }}.yml'
         - '{{ ansible_facts["os_family"] }}-{{ ansible_facts["distribution_major_version"] }}.yml'
         - '{{ ansible_facts["distribution"] }}.yml'

--- a/roles/restic/tasks/main.yml
+++ b/roles/restic/tasks/main.yml
@@ -3,6 +3,7 @@
   ansible.builtin.include_vars: '{{ item }}'
   with_first_found:
     - files:
+        - '{{ ansible_facts["distribution"] }}-{{ ansible_facts["distribution_version"] }}.yml'
         - '{{ ansible_facts["distribution"] }}-{{ ansible_facts["distribution_major_version"] }}.yml'
         - '{{ ansible_facts["os_family"] }}-{{ ansible_facts["distribution_major_version"] }}.yml'
         - '{{ ansible_facts["distribution"] }}.yml'

--- a/roles/rkhunter/tasks/main.yml
+++ b/roles/rkhunter/tasks/main.yml
@@ -3,6 +3,7 @@
   ansible.builtin.include_vars: '{{ item }}'
   with_first_found:
     - files:
+        - '{{ ansible_facts["distribution"] }}-{{ ansible_facts["distribution_version"] }}.yml'
         - '{{ ansible_facts["distribution"] }}-{{ ansible_facts["distribution_major_version"] }}.yml'
         - '{{ ansible_facts["os_family"] }}-{{ ansible_facts["distribution_major_version"] }}.yml'
         - '{{ ansible_facts["distribution"] }}.yml'

--- a/roles/shell/tasks/main.yml
+++ b/roles/shell/tasks/main.yml
@@ -7,6 +7,7 @@
   ansible.builtin.include_vars: '{{ item }}'
   with_first_found:
     - files:
+        - '{{ ansible_facts["distribution"] }}-{{ ansible_facts["distribution_version"] }}.yml'
         - '{{ ansible_facts["distribution"] }}-{{ ansible_facts["distribution_major_version"] }}.yml'
         - '{{ ansible_facts["os_family"] }}-{{ ansible_facts["distribution_major_version"] }}.yml'
         - '{{ ansible_facts["distribution"] }}.yml'

--- a/roles/snmp/tasks/main.yml
+++ b/roles/snmp/tasks/main.yml
@@ -3,6 +3,7 @@
   ansible.builtin.include_vars: '{{ item }}'
   with_first_found:
     - files:
+        - '{{ ansible_facts["distribution"] }}-{{ ansible_facts["distribution_version"] }}.yml'
         - '{{ ansible_facts["distribution"] }}-{{ ansible_facts["distribution_major_version"] }}.yml'
         - '{{ ansible_facts["os_family"] }}-{{ ansible_facts["distribution_major_version"] }}.yml'
         - '{{ ansible_facts["distribution"] }}.yml'

--- a/roles/sudo/tasks/main.yml
+++ b/roles/sudo/tasks/main.yml
@@ -3,6 +3,7 @@
   ansible.builtin.include_vars: '{{ item }}'
   with_first_found:
     - files:
+        - '{{ ansible_facts["distribution"] }}-{{ ansible_facts["distribution_version"] }}.yml'
         - '{{ ansible_facts["distribution"] }}-{{ ansible_facts["distribution_major_version"] }}.yml'
         - '{{ ansible_facts["os_family"] }}-{{ ansible_facts["distribution_major_version"] }}.yml'
         - '{{ ansible_facts["distribution"] }}.yml'

--- a/roles/sysctl/tasks/main.yml
+++ b/roles/sysctl/tasks/main.yml
@@ -3,6 +3,7 @@
   ansible.builtin.include_vars: '{{ item }}'
   with_first_found:
     - files:
+        - '{{ ansible_facts["distribution"] }}-{{ ansible_facts["distribution_version"] }}.yml'
         - '{{ ansible_facts["distribution"] }}-{{ ansible_facts["distribution_major_version"] }}.yml'
         - '{{ ansible_facts["os_family"] }}-{{ ansible_facts["distribution_major_version"] }}.yml'
         - '{{ ansible_facts["distribution"] }}.yml'

--- a/roles/unbound/tasks/main.yml
+++ b/roles/unbound/tasks/main.yml
@@ -3,6 +3,7 @@
   ansible.builtin.include_vars: '{{ item }}'
   with_first_found:
     - files:
+        - '{{ ansible_facts["distribution"] }}-{{ ansible_facts["distribution_version"] }}.yml'
         - '{{ ansible_facts["distribution"] }}-{{ ansible_facts["distribution_major_version"] }}.yml'
         - '{{ ansible_facts["os_family"] }}-{{ ansible_facts["distribution_major_version"] }}.yml'
         - '{{ ansible_facts["distribution"] }}.yml'

--- a/roles/utils/tasks/main.yml
+++ b/roles/utils/tasks/main.yml
@@ -3,6 +3,7 @@
   ansible.builtin.include_vars: '{{ item }}'
   with_first_found:
     - files:
+        - '{{ ansible_facts["distribution"] }}-{{ ansible_facts["distribution_version"] }}.yml'
         - '{{ ansible_facts["distribution"] }}-{{ ansible_facts["distribution_major_version"] }}.yml'
         - '{{ ansible_facts["os_family"] }}-{{ ansible_facts["distribution_major_version"] }}.yml'
         - '{{ ansible_facts["distribution"] }}.yml'

--- a/roles/wireguard/tasks/main.yml
+++ b/roles/wireguard/tasks/main.yml
@@ -3,6 +3,7 @@
   ansible.builtin.include_vars: '{{ item }}'
   with_first_found:
     - files:
+        - '{{ ansible_facts["distribution"] }}-{{ ansible_facts["distribution_version"] }}.yml'
         - '{{ ansible_facts["distribution"] }}-{{ ansible_facts["distribution_major_version"] }}.yml'
         - '{{ ansible_facts["os_family"] }}-{{ ansible_facts["distribution_major_version"] }}.yml'
         - '{{ ansible_facts["distribution"] }}.yml'


### PR DESCRIPTION
## Summary

- Extend the `with_first_found` OS-vars lookup in every role's `tasks/main.yml` with a new minor-version layer (`{distribution}-{distribution_version}.yml`, e.g. `Rocky-10.3.yml`), inserted at the top of the `files:` list so a role can ship per-minor-version overrides when EPEL/AppStream package availability changes within a major version.
- Purely additive: no role in this collection ships a minor-version vars file, so the new lookup falls through to the existing major-version / distribution / os_family files. Behaviour for existing consumers is unchanged.
- Covers every role that uses `with_first_found` for OS-vars loading in `tasks/main.yml` (39 roles).

## Test plan

- [x] grep verifies all 39 affected roles now carry the new lookup line at the top of the `files:` list
- [x] `ansible-lint --profile=production --offline` over the full collection: 0 failures, 0 warnings across 1011 files
- [x] `molecule test -p shell-archlinux` on `roles/shell`: 24 ok / 0 failed; vars lookup falls through to existing `Archlinux.yml` (no `Archlinux-rolling.yml` exists), behaviour unchanged

References #135