### PR TITLE
test(editors): cover initial and disabled modes in molecule

### DIFF
--- a/roles/editors/molecule/default/converge.yml
+++ b/roles/editors/molecule/default/converge.yml
@@ -1,5 +1,5 @@
 ---
-- name: Converge
+- name: Converge | Managed mode
   hosts: all
   gather_facts: true
 
@@ -40,6 +40,94 @@
         __users_newly_created:
           - 'testuser'
           - 'disableduser'
+
+  tasks:
+    - name: Converge | Include editors role  # noqa: role-name[path]
+      ansible.builtin.include_role:
+        name: '{{ playbook_dir }}/../..'
+
+
+- name: Converge | Initial mode (per-user gating)
+  hosts: all
+  gather_facts: false
+
+  vars:
+    editors_enabled: true
+    editors_nano_enabled: true
+    editors_vim_enabled: true
+    editors_neovim_enabled: true
+    editors_default: 'vim'
+    editors_user_config_mode: 'initial'
+    editors_users:
+      - username: 'initialnewuser'
+        vim_config:
+          set_relativenumber: true
+      - username: 'initialexistuser'
+        vim_config:
+          set_relativenumber: true
+
+  pre_tasks:
+    - name: Converge | Create initial-mode users
+      ansible.builtin.user:
+        name: '{{ item }}'
+        state: present
+        create_home: true
+      loop:
+        - initialnewuser
+        - initialexistuser
+
+    - name: Converge | Pre-seed existing user vimrc to prove it is left untouched
+      ansible.builtin.copy:
+        content: |
+          " molecule-fixture: pre-existing user content
+          set background=dark
+        dest: /home/initialexistuser/.vimrc
+        owner: initialexistuser
+        group: initialexistuser
+        mode: '0644'
+
+    - name: Converge | Mark only initialnewuser as newly created
+      ansible.builtin.set_fact:
+        __users_newly_created:
+          - 'initialnewuser'
+
+  tasks:
+    - name: Converge | Include editors role  # noqa: role-name[path]
+      ansible.builtin.include_role:
+        name: '{{ playbook_dir }}/../..'
+
+
+- name: Converge | Disabled mode (global)
+  hosts: all
+  gather_facts: false
+
+  vars:
+    editors_enabled: true
+    editors_nano_enabled: true
+    editors_vim_enabled: true
+    editors_neovim_enabled: true
+    editors_default: 'vim'
+    editors_user_config_mode: 'disabled'
+    editors_users:
+      - username: 'globaldisableduser'
+        vim_config:
+          set_relativenumber: true
+        neovim_config:
+          colorscheme: 'catppuccin'
+        nano_config:
+          set_mouse: false
+
+  pre_tasks:
+    - name: Converge | Create global-disabled-mode user
+      ansible.builtin.user:
+        name: globaldisableduser
+        state: present
+        create_home: true
+
+    - name: Converge | Mark global-disabled user as newly created
+      ansible.builtin.set_fact:
+        __users_newly_created:
+          - 'globaldisableduser'
 
   tasks:
     - name: Converge | Include editors role  # noqa: role-name[path]

--- a/roles/editors/molecule/default/verify.yml
+++ b/roles/editors/molecule/default/verify.yml
@@ -353,3 +353,101 @@
       ansible.builtin.assert:
         that:
           - not __verify_disabled_nano.stat.exists
+
+    #
+    # Initial Mode — Newly Created User (initialnewuser)
+    #
+    # editors_user_config_mode=initial + user IN __users_newly_created
+    # → role MUST deploy the user's config.
+    #
+
+    - name: Verify | Check initialnewuser vim config exists
+      ansible.builtin.stat:
+        path: /home/initialnewuser/.vimrc
+      register: __verify_initialnew_vimrc
+
+    - name: Verify | Assert initialnewuser vim config is deployed
+      ansible.builtin.assert:
+        that:
+          - __verify_initialnew_vimrc.stat.exists
+          - __verify_initialnew_vimrc.stat.mode == '0644'
+          - __verify_initialnew_vimrc.stat.pw_name == 'initialnewuser'
+
+    - name: Verify | Read initialnewuser vim config
+      ansible.builtin.slurp:
+        src: /home/initialnewuser/.vimrc
+      register: __verify_initialnew_vimrc_content
+
+    - name: Verify | Assert initialnewuser vim config has rendered template content
+      ansible.builtin.assert:
+        that:
+          - "'Ansible managed' in (__verify_initialnew_vimrc_content.content | b64decode)"
+          - "'set relativenumber' in (__verify_initialnew_vimrc_content.content | b64decode)"
+
+    #
+    # Initial Mode — Existing User (initialexistuser)
+    #
+    # editors_user_config_mode=initial + user NOT IN __users_newly_created
+    # → role MUST leave the user's pre-existing vimrc untouched.
+    #
+
+    - name: Verify | Check initialexistuser vim config exists
+      ansible.builtin.stat:
+        path: /home/initialexistuser/.vimrc
+      register: __verify_initialexist_vimrc
+
+    - name: Verify | Assert initialexistuser vim config file still present
+      ansible.builtin.assert:
+        that:
+          - __verify_initialexist_vimrc.stat.exists
+
+    - name: Verify | Read initialexistuser vim config
+      ansible.builtin.slurp:
+        src: /home/initialexistuser/.vimrc
+      register: __verify_initialexist_vimrc_content
+
+    - name: Verify | Assert initialexistuser vim config is unchanged
+      ansible.builtin.assert:
+        that:
+          - >-
+            'molecule-fixture: pre-existing user content'
+            in (__verify_initialexist_vimrc_content.content | b64decode)
+          - "'Ansible managed' not in (__verify_initialexist_vimrc_content.content | b64decode)"
+          - "'set relativenumber' not in (__verify_initialexist_vimrc_content.content | b64decode)"
+
+    #
+    # Disabled Mode — Global (globaldisableduser)
+    #
+    # editors_user_config_mode=disabled
+    # → role MUST NOT deploy any per-user config files.
+    #
+
+    - name: Verify | Check globaldisableduser has no vim config
+      ansible.builtin.stat:
+        path: /home/globaldisableduser/.vimrc
+      register: __verify_globaldisabled_vimrc
+
+    - name: Verify | Assert globaldisableduser has no vim config
+      ansible.builtin.assert:
+        that:
+          - not __verify_globaldisabled_vimrc.stat.exists
+
+    - name: Verify | Check globaldisableduser has no neovim config
+      ansible.builtin.stat:
+        path: /home/globaldisableduser/.config/nvim/init.vim
+      register: __verify_globaldisabled_nvim
+
+    - name: Verify | Assert globaldisableduser has no neovim config
+      ansible.builtin.assert:
+        that:
+          - not __verify_globaldisabled_nvim.stat.exists
+
+    - name: Verify | Check globaldisableduser has no nano config
+      ansible.builtin.stat:
+        path: /home/globaldisableduser/.config/nano/nanorc
+      register: __verify_globaldisabled_nano
+
+    - name: Verify | Assert globaldisableduser has no nano config
+      ansible.builtin.assert:
+        that:
+          - not __verify_globaldisabled_nano.stat.exists


### PR DESCRIPTION
## Summary
- Adds two converge plays to the `editors` molecule scenario covering the `initial` and `disabled` paths of `editors_user_config_mode`.
- `initial` play creates two users, stubs `__users_newly_created` to contain only one of them, and pre-seeds the other user's `.vimrc` with a marker so the untouched-on-existing-user case is asserted.
- `disabled` play sets the mode globally and asserts no per-user config files are written.

## Test plan
- [x] `ansible-lint roles/editors/molecule/default/{converge,verify}.yml` — passed
- [x] `molecule test -p editors-archlinux` — passed (65 verify tasks, idempotence ok)
- [ ] CI runs `default` on all 4 platforms (archlinux, debian-trixie, rocky-9, rocky-10)

Refs #140 — first role of the uniform multi-mode coverage tracker; remaining roles (`multiplexer`, `gnupg`, `package_management`, `shell`) follow in separate PRs.