### PR TITLE
test(multiplexer): cover initial and disabled modes in molecule

### DIFF
--- a/roles/multiplexer/molecule/default/converge.yml
+++ b/roles/multiplexer/molecule/default/converge.yml
@@ -1,5 +1,5 @@
 ---
-- name: Converge
+- name: Converge | Managed mode
   hosts: all
   gather_facts: true
 
@@ -38,6 +38,99 @@
         __users_newly_created:
           - 'testuser'
           - 'disableduser'
+
+  tasks:
+    - name: Converge | Include multiplexer role  # noqa: role-name[path]
+      ansible.builtin.include_role:
+        name: '{{ playbook_dir }}/../..'
+
+
+- name: Converge | Initial mode (per-user gating)
+  hosts: all
+  gather_facts: false
+
+  vars:
+    multiplexer_enabled: true
+    multiplexer_tmux_enabled: true
+    multiplexer_zellij_enabled: false
+    multiplexer_user_config_mode: 'initial'
+    multiplexer_users:
+      - username: 'initialnewuser'
+        tpm_enabled: false
+        tmux_config:
+          prefix: 'C-b'
+      - username: 'initialexistuser'
+        tpm_enabled: false
+        tmux_config:
+          prefix: 'C-b'
+
+  pre_tasks:
+    - name: Converge | Create initial-mode users
+      ansible.builtin.user:
+        name: '{{ item }}'
+        state: present
+        create_home: true
+      loop:
+        - initialnewuser
+        - initialexistuser
+
+    - name: Converge | Ensure existing user tmux config directory
+      ansible.builtin.file:
+        path: /home/initialexistuser/.config/tmux
+        state: directory
+        owner: initialexistuser
+        group: initialexistuser
+        mode: '0755'
+
+    - name: Converge | Pre-seed existing user tmux config to prove it is left untouched
+      ansible.builtin.copy:
+        content: |
+          # molecule-fixture: pre-existing user content
+          set -g prefix C-z
+        dest: /home/initialexistuser/.config/tmux/tmux.conf
+        owner: initialexistuser
+        group: initialexistuser
+        mode: '0644'
+
+    - name: Converge | Mark only initialnewuser as newly created
+      ansible.builtin.set_fact:
+        __users_newly_created:
+          - 'initialnewuser'
+
+  tasks:
+    - name: Converge | Include multiplexer role  # noqa: role-name[path]
+      ansible.builtin.include_role:
+        name: '{{ playbook_dir }}/../..'
+
+
+- name: Converge | Disabled mode (global)
+  hosts: all
+  gather_facts: false
+
+  vars:
+    multiplexer_enabled: true
+    multiplexer_tmux_enabled: true
+    multiplexer_zellij_enabled: "{{ ansible_facts['os_family'] == 'Archlinux' }}"
+    multiplexer_user_config_mode: 'disabled'
+    multiplexer_users:
+      - username: 'globaldisableduser'
+        tpm_enabled: false
+        tmux_config:
+          prefix: 'C-b'
+        zellij_config:
+          theme: 'catppuccin'
+
+  pre_tasks:
+    - name: Converge | Create global-disabled-mode user
+      ansible.builtin.user:
+        name: globaldisableduser
+        state: present
+        create_home: true
+
+    - name: Converge | Mark global-disabled user as newly created
+      ansible.builtin.set_fact:
+        __users_newly_created:
+          - 'globaldisableduser'
 
   tasks:
     - name: Converge | Include multiplexer role  # noqa: role-name[path]

--- a/roles/multiplexer/molecule/default/verify.yml
+++ b/roles/multiplexer/molecule/default/verify.yml
@@ -231,3 +231,93 @@
       ansible.builtin.assert:
         that:
           - not __verify_disabled_zellij.stat.exists
+
+    #
+    # Initial Mode — Newly Created User (initialnewuser)
+    #
+    # multiplexer_user_config_mode=initial + user IN __users_newly_created
+    # → role MUST deploy the user's config.
+    #
+
+    - name: Verify | Check initialnewuser tmux config exists
+      ansible.builtin.stat:
+        path: /home/initialnewuser/.config/tmux/tmux.conf
+      register: __verify_initialnew_tmux_conf
+
+    - name: Verify | Assert initialnewuser tmux config is deployed
+      ansible.builtin.assert:
+        that:
+          - __verify_initialnew_tmux_conf.stat.exists
+          - __verify_initialnew_tmux_conf.stat.mode == '0644'
+          - __verify_initialnew_tmux_conf.stat.pw_name == 'initialnewuser'
+
+    - name: Verify | Read initialnewuser tmux config
+      ansible.builtin.slurp:
+        src: /home/initialnewuser/.config/tmux/tmux.conf
+      register: __verify_initialnew_tmux_content
+
+    - name: Verify | Assert initialnewuser tmux config has rendered template content
+      ansible.builtin.assert:
+        that:
+          - "'Ansible managed' in (__verify_initialnew_tmux_content.content | b64decode)"
+          - "'prefix C-b' in (__verify_initialnew_tmux_content.content | b64decode)"
+
+    #
+    # Initial Mode — Existing User (initialexistuser)
+    #
+    # multiplexer_user_config_mode=initial + user NOT IN __users_newly_created
+    # → role MUST leave the user's pre-existing tmux.conf untouched.
+    #
+
+    - name: Verify | Check initialexistuser tmux config exists
+      ansible.builtin.stat:
+        path: /home/initialexistuser/.config/tmux/tmux.conf
+      register: __verify_initialexist_tmux_conf
+
+    - name: Verify | Assert initialexistuser tmux config file still present
+      ansible.builtin.assert:
+        that:
+          - __verify_initialexist_tmux_conf.stat.exists
+
+    - name: Verify | Read initialexistuser tmux config
+      ansible.builtin.slurp:
+        src: /home/initialexistuser/.config/tmux/tmux.conf
+      register: __verify_initialexist_tmux_content
+
+    - name: Verify | Assert initialexistuser tmux config is unchanged
+      ansible.builtin.assert:
+        that:
+          - >-
+            'molecule-fixture: pre-existing user content'
+            in (__verify_initialexist_tmux_content.content | b64decode)
+          - "'Ansible managed' not in (__verify_initialexist_tmux_content.content | b64decode)"
+          - "'prefix C-b' not in (__verify_initialexist_tmux_content.content | b64decode)"
+
+    #
+    # Disabled Mode — Global (globaldisableduser)
+    #
+    # multiplexer_user_config_mode=disabled
+    # → role MUST NOT deploy any per-user config files.
+    #
+
+    - name: Verify | Check globaldisableduser has no tmux config
+      ansible.builtin.stat:
+        path: /home/globaldisableduser/.config/tmux/tmux.conf
+      register: __verify_globaldisabled_tmux
+
+    - name: Verify | Assert globaldisableduser has no tmux config
+      ansible.builtin.assert:
+        that:
+          - not __verify_globaldisabled_tmux.stat.exists
+
+    - name: Verify | Check globaldisableduser has no zellij config (Arch only)
+      ansible.builtin.stat:
+        path: /home/globaldisableduser/.config/zellij/config.kdl
+      register: __verify_globaldisabled_zellij
+      when: ansible_facts['os_family'] == 'Archlinux'
+
+    - name: Verify | Assert globaldisableduser has no zellij config (Arch only)
+      ansible.builtin.assert:
+        that:
+          - not __verify_globaldisabled_zellij.stat.exists
+      when: ansible_facts['os_family'] == 'Archlinux'


### PR DESCRIPTION
## Summary
- Adds two converge plays to the `multiplexer` molecule scenario covering the `initial` and `disabled` paths of `multiplexer_user_config_mode`.
- `initial` play creates two users, stubs `__users_newly_created` to contain only one of them, and pre-seeds the other user's `tmux.conf` with a marker so the untouched-on-existing-user case is asserted.
- `disabled` play sets the mode globally and asserts no per-user config files (tmux + zellij on Arch) are written.

## Test plan
- [x] `ansible-lint roles/multiplexer/molecule/default/{converge,verify}.yml` — passed
- [x] `molecule test -p multiplexer-archlinux` — passed (45 verify tasks, idempotence ok)
- [ ] CI runs `default` on all 4 platforms (archlinux, debian-trixie, rocky-9, rocky-10)

Refs #140 — second role of the uniform multi-mode coverage tracker; remaining roles (`gnupg`, `package_management`, `shell`) follow in separate PRs.