### PR TITLE
test(gnupg): cover initial and disabled modes in molecule

### DIFF
--- a/roles/gnupg/molecule/default/converge.yml
+++ b/roles/gnupg/molecule/default/converge.yml
@@ -1,5 +1,5 @@
 ---
-- name: Converge
+- name: Converge | Managed mode
   hosts: all
   gather_facts: true
 
@@ -35,6 +35,93 @@
         name: disableduser
         state: present
         create_home: true
+
+  tasks:
+    - name: Converge | Include gnupg role  # noqa: role-name[path]
+      ansible.builtin.include_role:
+        name: '{{ playbook_dir }}/../..'
+
+
+- name: Converge | Initial mode (per-user gating)
+  hosts: all
+  gather_facts: false
+
+  vars:
+    gnupg_enabled: true
+    gnupg_gui_enabled: false
+    gnupg_tools_enabled: false
+    gnupg_agent_ssh_enabled: false
+    gnupg_user_config_mode: 'initial'
+    gnupg_users:
+      - username: 'initialnewuser'
+        agent_ssh: false
+      - username: 'initialexistuser'
+        agent_ssh: false
+
+  pre_tasks:
+    - name: Converge | Create initial-mode users
+      ansible.builtin.user:
+        name: '{{ item }}'
+        state: present
+        create_home: true
+      loop:
+        - initialnewuser
+        - initialexistuser
+
+    - name: Converge | Ensure existing user .gnupg directory
+      ansible.builtin.file:
+        path: /home/initialexistuser/.gnupg
+        state: directory
+        owner: initialexistuser
+        group: initialexistuser
+        mode: '0700'
+
+    - name: Converge | Pre-seed existing user gpg.conf to prove it is left untouched
+      ansible.builtin.copy:
+        content: |
+          # molecule-fixture: pre-existing user content
+          trust-model classic
+        dest: /home/initialexistuser/.gnupg/gpg.conf
+        owner: initialexistuser
+        group: initialexistuser
+        mode: '0600'
+
+    - name: Converge | Mark only initialnewuser as newly created
+      ansible.builtin.set_fact:
+        __users_newly_created:
+          - 'initialnewuser'
+
+  tasks:
+    - name: Converge | Include gnupg role  # noqa: role-name[path]
+      ansible.builtin.include_role:
+        name: '{{ playbook_dir }}/../..'
+
+
+- name: Converge | Disabled mode (global)
+  hosts: all
+  gather_facts: false
+
+  vars:
+    gnupg_enabled: true
+    gnupg_gui_enabled: false
+    gnupg_tools_enabled: false
+    gnupg_agent_ssh_enabled: true
+    gnupg_user_config_mode: 'disabled'
+    gnupg_users:
+      - username: 'globaldisableduser'
+        agent_ssh: true
+
+  pre_tasks:
+    - name: Converge | Create global-disabled-mode user
+      ansible.builtin.user:
+        name: globaldisableduser
+        state: present
+        create_home: true
+
+    - name: Converge | Mark global-disabled user as newly created
+      ansible.builtin.set_fact:
+        __users_newly_created:
+          - 'globaldisableduser'
 
   tasks:
     - name: Converge | Include gnupg role  # noqa: role-name[path]

--- a/roles/gnupg/molecule/default/verify.yml
+++ b/roles/gnupg/molecule/default/verify.yml
@@ -285,3 +285,102 @@
         that:
           - not disabled_gnupg.stat.exists
         fail_msg: 'disableduser should not have .gnupg directory (mode: disabled)'
+
+    #
+    # Initial Mode — Newly Created User (initialnewuser)
+    #
+    # gnupg_user_config_mode=initial + user IN __users_newly_created
+    # → role MUST deploy the user's config.
+    #
+
+    - name: Verify | Check initialnewuser .gnupg directory
+      ansible.builtin.stat:
+        path: /home/initialnewuser/.gnupg
+      register: __verify_initialnew_gnupg_dir
+
+    - name: Verify | Assert initialnewuser .gnupg directory deployed
+      ansible.builtin.assert:
+        that:
+          - __verify_initialnew_gnupg_dir.stat.exists
+          - __verify_initialnew_gnupg_dir.stat.isdir
+          - __verify_initialnew_gnupg_dir.stat.mode == '0700'
+          - __verify_initialnew_gnupg_dir.stat.pw_name == 'initialnewuser'
+
+    - name: Verify | Read initialnewuser gpg.conf
+      ansible.builtin.slurp:
+        src: /home/initialnewuser/.gnupg/gpg.conf
+      register: __verify_initialnew_gpg_conf
+
+    - name: Verify | Assert initialnewuser gpg.conf has rendered template content
+      ansible.builtin.assert:
+        that:
+          - "'Ansible managed' in (__verify_initialnew_gpg_conf.content | b64decode)"
+          - "'trust-model tofu+pgp' in (__verify_initialnew_gpg_conf.content | b64decode)"
+
+    #
+    # Initial Mode — Existing User (initialexistuser)
+    #
+    # gnupg_user_config_mode=initial + user NOT IN __users_newly_created
+    # → role MUST leave the user's pre-existing gpg.conf untouched.
+    #
+
+    - name: Verify | Check initialexistuser gpg.conf exists
+      ansible.builtin.stat:
+        path: /home/initialexistuser/.gnupg/gpg.conf
+      register: __verify_initialexist_gpg_conf
+
+    - name: Verify | Assert initialexistuser gpg.conf still present
+      ansible.builtin.assert:
+        that:
+          - __verify_initialexist_gpg_conf.stat.exists
+
+    - name: Verify | Read initialexistuser gpg.conf
+      ansible.builtin.slurp:
+        src: /home/initialexistuser/.gnupg/gpg.conf
+      register: __verify_initialexist_gpg_content
+
+    - name: Verify | Assert initialexistuser gpg.conf is unchanged
+      ansible.builtin.assert:
+        that:
+          - >-
+            'molecule-fixture: pre-existing user content'
+            in (__verify_initialexist_gpg_content.content | b64decode)
+          - "'Ansible managed' not in (__verify_initialexist_gpg_content.content | b64decode)"
+          - "'trust-model tofu+pgp' not in (__verify_initialexist_gpg_content.content | b64decode)"
+
+    - name: Verify | Check initialexistuser has no gpg-agent.conf
+      ansible.builtin.stat:
+        path: /home/initialexistuser/.gnupg/gpg-agent.conf
+      register: __verify_initialexist_agent_conf
+
+    - name: Verify | Assert initialexistuser has no gpg-agent.conf
+      ansible.builtin.assert:
+        that:
+          - not __verify_initialexist_agent_conf.stat.exists
+
+    #
+    # Disabled Mode — Global (globaldisableduser)
+    #
+    # gnupg_user_config_mode=disabled
+    # → role MUST NOT deploy a .gnupg directory or any config files.
+    #
+
+    - name: Verify | Check globaldisableduser has no .gnupg directory
+      ansible.builtin.stat:
+        path: /home/globaldisableduser/.gnupg
+      register: __verify_globaldisabled_gnupg
+
+    - name: Verify | Assert globaldisableduser has no .gnupg directory
+      ansible.builtin.assert:
+        that:
+          - not __verify_globaldisabled_gnupg.stat.exists
+
+    - name: Verify | Check globaldisableduser has no SSH environment file
+      ansible.builtin.stat:
+        path: /home/globaldisableduser/.config/environment.d/50-gpg-ssh.conf
+      register: __verify_globaldisabled_ssh_env
+
+    - name: Verify | Assert globaldisableduser has no SSH environment file
+      ansible.builtin.assert:
+        that:
+          - not __verify_globaldisabled_ssh_env.stat.exists


### PR DESCRIPTION
## Summary
- Adds two converge plays to the `gnupg` molecule scenario covering the `initial` and `disabled` paths of `gnupg_user_config_mode`.
- `initial` play creates two users, stubs `__users_newly_created` to contain only one of them, and pre-seeds the other user's `~/.gnupg/gpg.conf` with a marker so the untouched-on-existing-user case is asserted.
- `disabled` play sets the mode globally and asserts no `.gnupg` directory or SSH environment file is created.

## Test plan
- [x] `ansible-lint roles/gnupg/molecule/default/{converge,verify}.yml` — passed
- [x] `molecule test -p gnupg-archlinux` — passed (54 verify tasks, idempotence ok)
- [ ] CI runs `default` on all 4 platforms (archlinux, debian-trixie, rocky-9, rocky-10)

Refs #140 — third role of the uniform multi-mode coverage tracker; remaining roles (`package_management`, `shell`) follow in separate PRs.