### PR TITLE
test(package_management): cover initial and disabled makepkg modes

### DIFF
--- a/roles/package_management/molecule/default/converge.yml
+++ b/roles/package_management/molecule/default/converge.yml
@@ -1,5 +1,5 @@
 ---
-- name: Converge
+- name: Converge | Managed mode
   hosts: all
   gather_facts: true
 
@@ -67,3 +67,147 @@
     - name: Converge | Include package_management role  # noqa: role-name[path]
       ansible.builtin.include_role:
         name: '{{ playbook_dir }}/../..'
+
+
+- name: Converge | Initial mode (per-user gating, Arch only)
+  hosts: all
+  gather_facts: false
+
+  vars:
+    package_management_enabled: true
+    # ArchLinux specific (kept identical to managed play for idempotency)
+    pacman_parallel_downloads: 5
+    pacman_color: true
+    pacman_ilovecandy: true
+    pacman_check_space: true
+    reflector_enabled: true
+    reflector:
+      countries: []
+      protocol: 'https'
+      latest: 5
+      sort: 'rate'
+      score: ''
+      age: 24
+    aur_helper: ''
+    paccache_enabled: true
+    pacman_pkgfile_enabled: true
+    makepkg_user_config_mode: 'initial'
+    makepkg_users:
+      - username: 'initialnewuser'
+        packager: 'Initial New <initial.new@example.com>'
+        gpg_key: '0011223344556677'
+      - username: 'initialexistuser'
+        packager: 'Initial Exist <initial.exist@example.com>'
+        gpg_key: '0011223344556677'
+    # Other-OS toggles kept for cross-platform converge no-op
+    apt_periodic_enabled: true
+    apt_periodic_update: 1
+    apt_install_recommends: true
+    apt_unattended_upgrades_enabled: false
+    apt_apt_file_enabled: true
+    apt_needrestart_enabled: true
+    apt_non_free_enabled: true
+    apt_non_free_firmware_enabled: true
+    dnf_fastestmirror: true
+    dnf_max_parallel_downloads: 10
+    dnf_best: true
+    dnf_epel_enabled: true
+    dnf_automatic_enabled: false
+    dnf_utils_enabled: true
+
+  pre_tasks:
+    - name: Converge | Initial mode pre-tasks (Arch only)
+      when: ansible_facts['os_family'] == 'Archlinux'
+      block:
+        - name: Converge | Create initial-mode users
+          ansible.builtin.user:
+            name: '{{ item }}'
+            state: present
+            create_home: true
+          loop:
+            - initialnewuser
+            - initialexistuser
+
+        - name: Converge | Pre-seed existing user makepkg.conf to prove it is left untouched
+          ansible.builtin.copy:
+            content: |
+              # molecule-fixture: pre-existing user content
+              PACKAGER="Should Not Be Overwritten <noop@example.com>"
+            dest: /home/initialexistuser/.makepkg.conf
+            owner: initialexistuser
+            group: initialexistuser
+            mode: '0644'
+
+        - name: Converge | Mark only initialnewuser as newly created
+          ansible.builtin.set_fact:
+            __users_newly_created:
+              - 'initialnewuser'
+
+  tasks:
+    - name: Converge | Include package_management role  # noqa: role-name[path]
+      ansible.builtin.include_role:
+        name: '{{ playbook_dir }}/../..'
+      when: ansible_facts['os_family'] == 'Archlinux'
+
+
+- name: Converge | Disabled mode (global, Arch only)
+  hosts: all
+  gather_facts: false
+
+  vars:
+    package_management_enabled: true
+    pacman_parallel_downloads: 5
+    pacman_color: true
+    pacman_ilovecandy: true
+    pacman_check_space: true
+    reflector_enabled: true
+    reflector:
+      countries: []
+      protocol: 'https'
+      latest: 5
+      sort: 'rate'
+      score: ''
+      age: 24
+    aur_helper: ''
+    paccache_enabled: true
+    pacman_pkgfile_enabled: true
+    makepkg_user_config_mode: 'disabled'
+    makepkg_users:
+      - username: 'globaldisableduser'
+        packager: 'Global Disabled <global.disabled@example.com>'
+        gpg_key: '0011223344556677'
+    apt_periodic_enabled: true
+    apt_periodic_update: 1
+    apt_install_recommends: true
+    apt_unattended_upgrades_enabled: false
+    apt_apt_file_enabled: true
+    apt_needrestart_enabled: true
+    apt_non_free_enabled: true
+    apt_non_free_firmware_enabled: true
+    dnf_fastestmirror: true
+    dnf_max_parallel_downloads: 10
+    dnf_best: true
+    dnf_epel_enabled: true
+    dnf_automatic_enabled: false
+    dnf_utils_enabled: true
+
+  pre_tasks:
+    - name: Converge | Disabled mode pre-tasks (Arch only)
+      when: ansible_facts['os_family'] == 'Archlinux'
+      block:
+        - name: Converge | Create global-disabled-mode user
+          ansible.builtin.user:
+            name: globaldisableduser
+            state: present
+            create_home: true
+
+        - name: Converge | Mark global-disabled user as newly created
+          ansible.builtin.set_fact:
+            __users_newly_created:
+              - 'globaldisableduser'
+
+  tasks:
+    - name: Converge | Include package_management role  # noqa: role-name[path]
+      ansible.builtin.include_role:
+        name: '{{ playbook_dir }}/../..'
+      when: ansible_facts['os_family'] == 'Archlinux'

--- a/roles/package_management/molecule/default/verify.yml
+++ b/roles/package_management/molecule/default/verify.yml
@@ -280,6 +280,97 @@
             fail_msg: 'disableduser should not have .makepkg.conf (mode: disabled)'
 
     #
+    # Initial Mode — Newly Created User (initialnewuser, Arch only)
+    #
+    # makepkg_user_config_mode=initial + user IN __users_newly_created
+    # → role MUST deploy the user's makepkg.conf.
+    #
+
+    - name: Verify | Initial-mode newly-created user (Arch only)
+      when: ansible_facts['os_family'] == 'Archlinux'
+      block:
+        - name: Verify | Check initialnewuser makepkg.conf exists
+          ansible.builtin.stat:
+            path: /home/initialnewuser/.makepkg.conf
+          register: __verify_initialnew_makepkg
+
+        - name: Verify | Assert initialnewuser makepkg.conf is deployed
+          ansible.builtin.assert:
+            that:
+              - __verify_initialnew_makepkg.stat.exists
+              - __verify_initialnew_makepkg.stat.mode == '0644'
+              - __verify_initialnew_makepkg.stat.pw_name == 'initialnewuser'
+
+        - name: Verify | Read initialnewuser makepkg.conf
+          ansible.builtin.slurp:
+            src: /home/initialnewuser/.makepkg.conf
+          register: __verify_initialnew_makepkg_content
+
+        - name: Verify | Assert initialnewuser makepkg.conf has rendered template content
+          ansible.builtin.assert:
+            that:
+              - "'Ansible managed' in (__verify_initialnew_makepkg_content.content | b64decode)"
+              - >-
+                'PACKAGER="Initial New <initial.new@example.com>"'
+                in (__verify_initialnew_makepkg_content.content | b64decode)
+
+    #
+    # Initial Mode — Existing User (initialexistuser, Arch only)
+    #
+    # makepkg_user_config_mode=initial + user NOT IN __users_newly_created
+    # → role MUST leave the user's pre-existing makepkg.conf untouched.
+    #
+
+    - name: Verify | Initial-mode existing user (Arch only)
+      when: ansible_facts['os_family'] == 'Archlinux'
+      block:
+        - name: Verify | Check initialexistuser makepkg.conf exists
+          ansible.builtin.stat:
+            path: /home/initialexistuser/.makepkg.conf
+          register: __verify_initialexist_makepkg
+
+        - name: Verify | Assert initialexistuser makepkg.conf file still present
+          ansible.builtin.assert:
+            that:
+              - __verify_initialexist_makepkg.stat.exists
+
+        - name: Verify | Read initialexistuser makepkg.conf
+          ansible.builtin.slurp:
+            src: /home/initialexistuser/.makepkg.conf
+          register: __verify_initialexist_makepkg_content
+
+        - name: Verify | Assert initialexistuser makepkg.conf is unchanged
+          ansible.builtin.assert:
+            that:
+              - >-
+                'molecule-fixture: pre-existing user content'
+                in (__verify_initialexist_makepkg_content.content | b64decode)
+              - "'Ansible managed' not in (__verify_initialexist_makepkg_content.content | b64decode)"
+              - >-
+                'PACKAGER="Initial Exist <initial.exist@example.com>"'
+                not in (__verify_initialexist_makepkg_content.content | b64decode)
+
+    #
+    # Disabled Mode — Global (globaldisableduser, Arch only)
+    #
+    # makepkg_user_config_mode=disabled
+    # → role MUST NOT deploy a per-user makepkg.conf.
+    #
+
+    - name: Verify | Disabled-mode global user (Arch only)
+      when: ansible_facts['os_family'] == 'Archlinux'
+      block:
+        - name: Verify | Check globaldisableduser has no makepkg.conf
+          ansible.builtin.stat:
+            path: /home/globaldisableduser/.makepkg.conf
+          register: __verify_globaldisabled_makepkg
+
+        - name: Verify | Assert globaldisableduser has no makepkg.conf
+          ansible.builtin.assert:
+            that:
+              - not __verify_globaldisabled_makepkg.stat.exists
+
+    #
     # Cross-platform Verification
     #
 


### PR DESCRIPTION
## Summary
- Adds two converge plays to the `package_management` molecule scenario covering the `initial` and `disabled` paths of `makepkg_user_config_mode`.
- The `makepkg` per-user `.makepkg.conf` is the only role surface gated by this mode variable, so each new play wraps the Arch-only pre-tasks and the role include in an `os_family == 'Archlinux'` guard — non-Arch platforms remain a no-op.
- `initial` play creates two users, stubs `__users_newly_created` to contain only one of them, and pre-seeds the other user's `.makepkg.conf` with a marker so the untouched-on-existing-user case is asserted.
- `disabled` play sets the mode globally and asserts no per-user `.makepkg.conf` is written.

## Test plan
- [x] `ansible-lint roles/package_management/molecule/default/{converge,verify}.yml` — passed
- [x] `molecule test -p package-management-archlinux` — passed (29 verify tasks, idempotence ok)
- [ ] CI runs `default` on all 4 platforms (archlinux, debian-trixie, rocky-9, rocky-10)

Refs #140 — fourth role of the uniform multi-mode coverage tracker; remaining role (`shell`) follows in a separate PR.