### PR TITLE
ci(release-please): make MIGRATION.md date step idempotent

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -92,6 +92,15 @@ jobs:
             exit 0
           fi
 
+          # Idempotency guard: if the dated heading for this version
+          # already exists in the file, the rewrite has run before.
+          # Skip to avoid stacking duplicate headings on subsequent
+          # main-pushes within the same release cycle (MD024).
+          if grep -Fxq "$REPLACEMENT" <<< "$OLD_CONTENT"; then
+            echo "MIGRATION.md already contains '${REPLACEMENT}' heading — no-op."
+            exit 0
+          fi
+
           # Rewrite the first `## Unreleased` to two stacked headings:
           # a fresh empty `## Unreleased` block (for the next cycle) on
           # top, followed by the dated heading for this release. Any


### PR DESCRIPTION
## Summary
The `Date Unreleased section in MIGRATION.md` step in `.github/workflows/release-please.yml` rewrites `## Unreleased` into a stacked `## Unreleased` + `## v<X.Y.Z> - <DATE>` pair on every main-push. Without an idempotency guard, each push within the same release cycle stacks another `## v<X.Y.Z> - <DATE>` heading on top of the previous one.

After 5 merges today (#209, #210, #211, #212, #213), the release-please PR branch `release-please--branches--main` accumulated three identical `## v2.1.0 - 2026-06-11` headings, tripping markdownlint MD024 (`no-duplicate-heading`) on #182.

Adds an early-exit before the rewrite: if the file already contains the dated heading for the current version, no-op. Subsequent main-pushes within the same cycle leave MIGRATION.md untouched.

A follow-up direct commit on `release-please--branches--main` will deduplicate the existing stack — the workflow alone does not clean up past damage.

## Test plan
- [x] `yamllint .github/workflows/release-please.yml` — passed
- [ ] After merge: next push to main triggers release-please; verify the workflow does not re-add a dated heading on the bot branch.

Fixes the MD024 markdownlint failure on #182 once the bot branch is also deduplicated.