### PR TITLE
fix(base): use OS-specific binary and path for GRUB regeneration handler

### DIFF
--- a/roles/base/handlers/main.yml
+++ b/roles/base/handlers/main.yml
@@ -48,7 +48,7 @@
 
 - name: Regenerate GRUB config
   ansible.builtin.command:
-    cmd: 'grub-mkconfig -o /boot/grub/grub.cfg'
+    cmd: '{{ __base_grub_mkconfig }} -o {{ __base_grub_cfg }}'
   changed_when: true
   listen: 'regenerate grub config'
   when:

--- a/roles/base/vars/Archlinux.yml
+++ b/roles/base/vars/Archlinux.yml
@@ -19,3 +19,7 @@ __base_dialog_package: 'dialog'
 
 # Default bootloader (Arch installer ships systemd-boot as the modern choice)
 __base_default_bootloader: 'systemd-boot'
+
+# GRUB binary + config path (when base_bootloader is overridden to 'grub')
+__base_grub_mkconfig: 'grub-mkconfig'
+__base_grub_cfg: '/boot/grub/grub.cfg'

--- a/roles/base/vars/Debian.yml
+++ b/roles/base/vars/Debian.yml
@@ -19,3 +19,6 @@ __base_dialog_package: 'dialog'
 
 # Default bootloader (Debian ships GRUB by default)
 __base_default_bootloader: 'grub'
+
+__base_grub_mkconfig: 'grub-mkconfig'
+__base_grub_cfg: '/boot/grub/grub.cfg'

--- a/roles/base/vars/RedHat.yml
+++ b/roles/base/vars/RedHat.yml
@@ -23,3 +23,7 @@ __base_dialog_package: 'dialog'
 
 # Default bootloader (RHEL-family ships GRUB by default)
 __base_default_bootloader: 'grub'
+
+# GRUB binary + config path (EL ships grub2-* variants under /boot/grub2/)
+__base_grub_mkconfig: 'grub2-mkconfig'
+__base_grub_cfg: '/boot/grub2/grub.cfg'


### PR DESCRIPTION
## Summary

Fix the `Regenerate GRUB config` handler in `marcstraube.common.base`. The handler hardcoded `grub-mkconfig` + `/boot/grub/grub.cfg`, which only matches the Arch/Debian convention. On EL the binary is `grub2-mkconfig` and the config lives under `/boot/grub2/grub.cfg`, so the handler failed with `Errno 2`.

Introduce `__base_grub_mkconfig` and `__base_grub_cfg` in the OS-specific `vars/` files (following the existing `__base_*` pattern) and reference them from the handler.

## Test plan

- [x] `ansible-lint` passes on changed files
- [x] Live-applied on Rocky 9 host — handler completes successfully (re-run after restoring pre-fix VM snapshot)
- [x] No drift in `vars/Archlinux.yml` / `vars/Debian.yml` behavior (binary + path values unchanged from previous hardcode)

Closes #218