### PR TITLE
fix(python): honor optional HTTP(S) proxy for pipx bootstrap pip install

### DIFF
--- a/roles/python/README.md
+++ b/roles/python/README.md
@@ -43,6 +43,7 @@ overrides if needed.
 | Variable                | Default | Description                                       |
 |-------------------------|---------|---------------------------------------------------|
 | `python_pipx_enabled`   | `true`  | Enable pipx for user-level Python tool management |
+| `python_pip_proxy`      | `''`    | HTTP(S) proxy for pip (used by pipx bootstrap)    |
 | `python_extra_packages` | `[]`    | Additional OS packages to install                 |
 
 ## Tags
@@ -77,6 +78,12 @@ On Rocky 9, the system pipx from EPEL (1.2.1) is too old for
 `community.general.pipx`. This role installs pipx via pip into a dedicated
 venv at `/opt/pipx-bootstrap/`. Downstream roles should use the bootstrap
 path on EL 9.
+
+In networks without direct PyPI/DNS access (e.g. an internal corporate
+network with an outbound HTTP(S) proxy), set `python_pip_proxy` to the
+proxy URL. It is applied as `HTTPS_PROXY`/`HTTP_PROXY` on the bootstrap
+pip task only; the OS-package tasks rely on the system package manager's
+own proxy configuration.
 
 ## References
 

--- a/roles/python/defaults/main.yml
+++ b/roles/python/defaults/main.yml
@@ -13,5 +13,10 @@ python_enabled: true
 # Enable pipx for user-level Python tool management
 python_pipx_enabled: true
 
+# Optional HTTP(S) proxy for pip — applied as HTTPS_PROXY/HTTP_PROXY env
+# vars on the pipx bootstrap pip task. Required in networks that have no
+# direct DNS/internet access to PyPI. Empty (default) = no proxy.
+python_pip_proxy: ''
+
 # Additional OS packages to install (e.g., python3-dev, python3-lxml)
 python_extra_packages: []

--- a/roles/python/tasks/install.yml
+++ b/roles/python/tasks/install.yml
@@ -33,6 +33,9 @@
     name: pipx
     state: present
     virtualenv: /opt/pipx-bootstrap
+  environment:
+    HTTPS_PROXY: '{{ python_pip_proxy }}'
+    HTTP_PROXY: '{{ python_pip_proxy }}'
   retries: 3
   delay: 5
   when:


### PR DESCRIPTION
## Summary

Fix `Install | pipx in bootstrap venv` in `marcstraube.common.python`. The task ran `pip install pipx` without any proxy plumbing. In networks where outbound DNS for `pypi.org` is blocked and only an internal HTTP(S) proxy can reach PyPI, the task fails with `[Errno -2] Name or service not known`. Affects Rocky 9 only — on the other distros `__python_bootstrap_pipx` is `false` and the bootstrap is skipped.

Add a new `python_pip_proxy` variable (default `''`, no behavior change for hosts with direct PyPI access) and apply it as `HTTPS_PROXY`/`HTTP_PROXY` on the bootstrap pip task. OS-package tasks remain on the system package manager's proxy configuration.

README updated with the new variable in the Settings table and a paragraph in Notes.

## Test plan

- [x] `ansible-lint` passes on changed files
- [x] Pre-commit hooks (markdownlint, yamllint, …) pass
- [x] Live-applied on Rocky 9 host behind HTTP(S) proxy — pipx bootstrap completes successfully (run continued past this task on the same host)

Closes #221