### PR TITLE
fix(hardening): restart PrivateTmp services after /var/tmp bind change

### DIFF
--- a/roles/hardening/handlers/main.yml
+++ b/roles/hardening/handlers/main.yml
@@ -6,3 +6,27 @@
   changed_when: false
   failed_when: false
   when: hardening_enabled | bool
+
+# When /tmp or /var/tmp mount layout changes after services with
+# PrivateTmp=yes have already started, their existing mount namespaces
+# are stale. A subsequent `systemctl reload` then fails with
+# status=226/NAMESPACE because systemd cannot rebuild the per-service
+# /var/tmp bind in the running namespace. Restart every running service
+# that declares PrivateTmp=yes so it re-enters a fresh namespace built
+# against the new host mounts. Idempotent on hosts where /tmp/var-tmp
+# never changed (no services to restart).
+- name: Restart PrivateTmp services
+  ansible.builtin.shell:
+    cmd: |
+      set -euo pipefail
+      systemctl list-units --type=service --state=running --no-legend --no-pager \
+        | awk '{print $1}' \
+        | while read -r unit; do
+            if [ "$(systemctl show -p PrivateTmp --value "$unit" 2>/dev/null)" = "yes" ]; then
+              systemctl restart "$unit"
+            fi
+          done
+    executable: /bin/bash
+  changed_when: true
+  listen: 'restart privatetmp services'
+  when: hardening_enabled | bool

--- a/roles/hardening/tasks/filesystem.yml
+++ b/roles/hardening/tasks/filesystem.yml
@@ -57,22 +57,18 @@
   when: not ansible_check_mode
   changed_when: false
 
-- name: Filesystem | Configure /var/tmp bind mount in fstab
+# /var/tmp does not face the chicken-and-egg problem that gates the
+# /tmp tasks above (Ansible's payload lives in /tmp, not /var/tmp), so
+# we can use state: mounted directly. This combines fstab write +
+# actual mount in one task and reports `changed` precisely when one
+# of the two side-effects happens, which lets us notify the handler
+# only on real mount-layout changes.
+- name: Filesystem | Configure /var/tmp bind mount
   ansible.posix.mount:
     path: '/var/tmp'
     src: '/tmp'
     fstype: 'none'
     opts: 'bind'
-    state: present
+    state: mounted
   when: hardening_fs_vartmp_bind_enabled | bool
-  register: __hardening_vartmp_fstab
-
-- name: Filesystem | Mount /var/tmp bind
-  ansible.builtin.raw: >-
-    if ! findmnt -n /var/tmp > /dev/null 2>&1; then
-      mount /var/tmp;
-    fi
-  when:
-    - hardening_fs_vartmp_bind_enabled | bool
-    - not ansible_check_mode
-  changed_when: false
+  notify: 'restart privatetmp services'


### PR DESCRIPTION
## Summary

Fix `marcstraube.common.hardening`. When the role enables the `/var/tmp` → `/tmp` bind mount on a host where services with `PrivateTmp=yes` (e.g. nginx, postgresql) are already running, the running services keep a stale mount namespace. Any subsequent `systemctl reload` then fails with `status=226/NAMESPACE` because systemd cannot rebuild the per-service `/var/tmp` mountpoint in the running namespace.

Three changes:

1. Switch the `/var/tmp` task from `state: present` + raw mount to `state: mounted` (one change-aware task that handles both fstab and actual mount).
2. Add a new handler `Restart PrivateTmp services` that enumerates running services with `PrivateTmp=yes` and restarts each one, rebuilding the namespace.
3. Notify the new handler from the `/var/tmp` task when the mount actually changes — idempotent on hosts already in the right state.

## Test plan

- [x] `ansible-lint` passes on changed files
- [x] Live-applied on Rocky 9 host where nginx reload was failing with status=226/NAMESPACE after `/var/tmp` was bind-mounted — restart handler triggers, nginx comes up cleanly, subsequent runs are idempotent (no change → no restart)

Closes #223