### PR TITLE
fix(nodejs): pre-create global node_modules directory with mode 0755

### DIFF
--- a/roles/nodejs/tasks/configure.yml
+++ b/roles/nodejs/tasks/configure.yml
@@ -87,3 +87,33 @@
   when:
     - nodejs_npm_config | length > 0
     - item.stdout | default('') | trim != item.item.value | string
+
+#
+# Global npm prefix directory
+#
+# `npm install -g <pkg>` writes into `<npm prefix>/lib/node_modules/`. On
+# hosts hardened with pam_umask 0077 (the marcstraube.common.pam_hardening
+# default), npm creates this directory with mode 0700 on first use because
+# it inherits the calling process umask. That makes the install tree
+# inaccessible to non-root service users and causes downstream
+# `status=203/EXEC, Permission denied` failures on services that try to
+# exec the global binaries (n8n, gitlab-runner, etc.).
+#
+# Pre-create the directory with mode 0755 so npm uses it as-is. This is a
+# no-op on hosts where the directory already exists with the right
+# permissions, and only sets the top-level mode — per-package subtrees
+# stay as npm wrote them (individual install roles can fix those further
+# down).
+
+- name: Configure | Detect npm global prefix
+  ansible.builtin.command: npm prefix -g
+  register: __nodejs_npm_prefix
+  changed_when: false
+
+- name: Configure | Ensure global node_modules directory is traversable
+  ansible.builtin.file:
+    path: '{{ __nodejs_npm_prefix.stdout | trim }}/lib/node_modules'
+    state: directory
+    owner: root
+    group: root
+    mode: '0755'


### PR DESCRIPTION
## Summary

Fix `marcstraube.common.nodejs`. `npm install -g` honors the calling process umask. On hardened hosts (`marcstraube.common.pam_hardening` default `pam_umask: '0077'`), the **first** global npm install creates `/usr/local/lib/node_modules` with mode 0700, owned by root. Every subsequent npm package lands underneath that directory and inherits the traversal restriction — non-root service users cannot reach their installed binaries even when the per-package subtree is permissive.

In `tasks/configure.yml`, detect the npm global prefix and pre-create the global `node_modules` directory with mode 0755 owned by root. This pins the directory at a known-good mode before any `npm install -g` runs and is a no-op when it is already present with the right mode. Only the top-level directory is touched — per-package subtrees stay as npm wrote them and remain the responsibility of the individual install role for each package.

The mode 0755 default is consistent with the standard Unix layout (`/usr/local/lib` and its conventional system-binary subdirectories are 0755 across all major distributions). The restrictive `pam_umask: '0077'` is intended for files created in interactive user sessions, not for system-wide software installs — both defaults stand without conflict.

## Test plan

- [x] `ansible-lint` passes on changed files
- [x] Live-applied on a Rocky 9 host with `pam_umask: '0077'`; downstream npm-installed services (n8n in this case) start cleanly afterwards instead of failing with `status=203/EXEC`

Closes #225