### PR TITLE
feat(networkmanager): add zone option for firewalld zone assignment

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -136,7 +136,7 @@
         "filename": "roles/networkmanager/molecule/default/molecule.yml",
         "hashed_secret": "206c80413b9a96c1312cc346b7d2517b84463edd",
         "is_verified": false,
-        "line_number": 113
+        "line_number": 114
       }
     ],
     "roles/package_management/molecule/default/converge.yml": [
@@ -317,5 +317,5 @@
       }
     ]
   },
-  "generated_at": "2026-05-22T06:41:20Z"
+  "generated_at": "2026-07-01T13:51:47Z"
 }

--- a/roles/firewalld/README.md
+++ b/roles/firewalld/README.md
@@ -98,6 +98,17 @@ Deployed as `/etc/firewalld/firewalld.conf`.
 |------------------------|---------|----------------------------------------------------|
 | `firewalld_interfaces` | `[]`    | Interfaces assigned to zones (`{zone, interface}`) |
 
+> **NetworkManager-managed interfaces:** `firewalld_interfaces` binds the
+> interface on the firewalld side, which does not persist when
+> NetworkManager manages the interface — NetworkManager's `connection.zone`
+> takes precedence and drifts the interface back to the default zone on
+> reapply/reboot (`The interface is under control of NetworkManager`). For
+> those interfaces, set the zone via the `networkmanager` role's `zone:`
+> option instead. Use `firewalld_interfaces` only for interfaces
+> NetworkManager does not manage. This is the default configuration on
+> RHEL-family distributions, where firewalld and NetworkManager both ship
+> active.
+
 ### Port Forwarding
 
 | Variable             | Default | Description                                        |

--- a/roles/networkmanager/README.md
+++ b/roles/networkmanager/README.md
@@ -139,6 +139,7 @@ networkmanager_connections:
       autoconnect: true
       ip4: "192.168.1.10/24"
       gw4: "192.168.1.1"
+      zone: "internal"                  # firewalld zone (NM connection.zone)
       dns4: ["1.1.1.1", "8.8.8.8"]
       dns4_search: ["office.local"]
       routes4: ["10.0.0.0/8 192.168.1.254"]
@@ -147,6 +148,25 @@ networkmanager_connections:
       settings:                         # generic nmcli-native settings (see below)
         ipv4.dhcp-send-hostname: "no"
 ```
+
+#### firewalld zones on NetworkManager-managed interfaces
+
+Use `zone:` to assign an interface to a firewalld zone. It maps to
+NetworkManager's `connection.zone`, so NetworkManager applies the zone and
+keeps it across `nmcli device reapply` and reboot. This is the correct
+mechanism for any interface NetworkManager manages.
+
+Do **not** also assign the same interface through the `firewalld` role's
+`firewalld_interfaces`: firewalld's own interface-to-zone binding does not
+persist on NM-managed interfaces (`The interface is under control of
+NetworkManager`) and drifts back to the default zone. Reserve
+`firewalld_interfaces` for interfaces NetworkManager does not manage.
+
+On RHEL-family distributions (Rocky, AlmaLinux, RHEL, Fedora, CentOS
+Stream) firewalld and NetworkManager are both active by default, so this
+coupling is the standard case there and `zone:` is the expected way to
+assign an interface's zone. Elsewhere it applies wherever NetworkManager
+manages the interface and firewalld is in use.
 
 #### WiFi Connections
 

--- a/roles/networkmanager/defaults/main.yml
+++ b/roles/networkmanager/defaults/main.yml
@@ -139,7 +139,15 @@ networkmanager_vpn_plugins: []
 # Connection profiles managed via community.general.nmcli.
 #
 # First-class fields map to community.general.nmcli module parameters
-# (ifname, ip4, gw4, dns4, routes4, autoconnect, ...).
+# (ifname, ip4, gw4, dns4, routes4, autoconnect, zone, ...).
+#
+# firewalld zone note: on hosts running firewalld, set the interface's
+# firewalld zone here via `zone:` (mapped to NetworkManager's
+# connection.zone). NetworkManager owns the zone of the interfaces it
+# manages, so assigning the same interface through the firewalld role's
+# `firewalld_interfaces` does not persist and drifts back to the default
+# zone on reapply/reboot. Use `firewalld_interfaces` only for interfaces
+# NetworkManager does not manage.
 #
 # The generic `settings:` dict takes nmcli-native keys and is applied via
 # a single `nmcli connection modify` per connection. Any setting nmcli
@@ -158,6 +166,7 @@ networkmanager_vpn_plugins: []
 #       autoconnect: true
 #       ip4: "192.168.1.10/24"
 #       gw4: "192.168.1.1"
+#       zone: "internal"          # firewalld zone (NM connection.zone)
 #       dns4:
 #         - "8.8.8.8"
 #         - "8.8.4.4"

--- a/roles/networkmanager/molecule/default/molecule.yml
+++ b/roles/networkmanager/molecule/default/molecule.yml
@@ -46,6 +46,7 @@ provisioner:
               ifname: eth1
               ip4: 192.168.1.10/24
               gw4: 192.168.1.1
+              zone: internal
               state: present
               autoconnect: false
               vpn:
@@ -173,6 +174,7 @@ provisioner:
               ifname: eth1
               ip4: 192.168.1.10/24
               gw4: 192.168.1.1
+              zone: internal
               state: present
               autoconnect: false
               settings:
@@ -197,6 +199,7 @@ provisioner:
               ifname: eth1
               ip4: 192.168.1.10/24
               gw4: 192.168.1.1
+              zone: internal
               state: present
               autoconnect: false
               settings:
@@ -221,6 +224,7 @@ provisioner:
               ifname: eth1
               ip4: 192.168.1.10/24
               gw4: 192.168.1.1
+              zone: internal
               state: present
               autoconnect: false
               settings:

--- a/roles/networkmanager/molecule/default/verify.yml
+++ b/roles/networkmanager/molecule/default/verify.yml
@@ -263,6 +263,51 @@
         label: "{{ item.item.conn_name }}/{{ item.item.key }}"
 
     #
+    # Connection Zone Verification
+    #
+    # Walks every present connection that defines a `zone` and asserts
+    # nmcli stored it as connection.zone (the firewalld zone owned by NM).
+
+    - name: Verify | Flatten zone entries from test inventory
+      ansible.builtin.set_fact:
+        verify_zone_entries: >-
+          {{ verify_zone_entries | default([])
+             + [{'conn_name': item.key, 'zone': item.value.zone}] }}
+      loop: >-
+        {{ (test_networkmanager_connections.ethernet | default({}) | dict2items)
+           + (test_networkmanager_connections.wifi | default({}) | dict2items) }}
+      loop_control:
+        label: "{{ item.key }}"
+      when:
+        - item.value.state | default('present') == 'present'
+        - item.value.zone is defined
+
+    - name: Verify | Query nmcli for each connection zone
+      ansible.builtin.command:
+        cmd: 'nmcli -t -f connection.zone connection show {{ item.conn_name | quote }}'
+      register: verify_zone_query
+      changed_when: false
+      loop: "{{ verify_zone_entries | default([]) }}"
+      loop_control:
+        label: "{{ item.conn_name }}"
+
+    - name: Verify | Assert each connection zone matches inventory
+      vars:
+        current_zone: "{{ item.stdout | regex_replace('^[^:]+:', '') }}"
+      ansible.builtin.assert:
+        that:
+          - current_zone == item.item.zone
+        fail_msg: >-
+          Connection '{{ item.item.conn_name }}' expected zone
+          '{{ item.item.zone }}' but nmcli stored '{{ current_zone }}'
+        success_msg: >-
+          Connection '{{ item.item.conn_name }}' correctly assigned to
+          zone '{{ item.item.zone }}'
+      loop: "{{ verify_zone_query.results | default([]) }}"
+      loop_control:
+        label: "{{ item.item.conn_name }}"
+
+    #
     # Polkit Verification
     #
 

--- a/roles/networkmanager/tasks/connections.yml
+++ b/roles/networkmanager/tasks/connections.yml
@@ -74,6 +74,7 @@
     may_fail4: "{{ item.value.may_fail4 | default(omit) }}"
     method4: "{{ item.value.method4 | default(omit) }}"
     method6: "{{ item.value.method6 | default(omit) }}"
+    zone: "{{ item.value.zone | default(omit) }}"
     state: "{{ item.value.state | default('present') }}"
   loop: "{{ networkmanager_connections.ethernet | dict2items }}"
   loop_control:
@@ -156,6 +157,7 @@
     may_fail4: "{{ item.value.may_fail4 | default(omit) }}"
     method4: "{{ item.value.method4 | default(omit) }}"
     method6: "{{ item.value.method6 | default(omit) }}"
+    zone: "{{ item.value.zone | default(omit) }}"
     state: "{{ item.value.state | default('present') }}"
   loop: "{{ networkmanager_connections.wifi | dict2items }}"
   loop_control:


### PR DESCRIPTION
## Summary

Adds a first-class `zone:` option to the `networkmanager` role's ethernet and wifi connections, mapping to the native `zone` parameter of `community.general.nmcli` (NetworkManager's `connection.zone`). This makes NetworkManager the durable owner of an interface's firewalld zone on the interfaces it manages, preventing the interface from drifting back to the default zone on `nmcli device reapply` or reboot.

The `firewalld` role's `firewalld_interfaces` mechanism is unchanged and remains the correct way to assign zones on interfaces NetworkManager does not manage. Both role READMEs now document which mechanism owns the zone in which scenario, including that firewalld and NetworkManager are the default coupling on RHEL-family distributions.

## Changes

- `networkmanager`: `zone` option on ethernet/wifi connections (`connections.yml`), documented in `defaults/main.yml` and the role README.
- `firewalld`: README note on the NetworkManager interaction (documentation only, no functional change).
- `networkmanager` molecule: `zone: internal` on the test ethernet connection across all platforms, plus a verify assertion on `connection.zone`.

## Test plan

- [x] yamllint — clean
- [x] ansible-lint (production profile) — clean
- [x] markdownlint — clean
- [x] molecule Rocky 9 (full test) — converge, idempotence (changed=0), verify, destroy all green
- [x] verify asserts nmcli `connection.zone` equals `internal` for the test connection

Closes #233

🤖 Generated with [Claude Code](https://claude.com/claude-code)
