### PR TITLE
fix(nodejs): don't fail verify in check mode when Node.js is absent

### DIFF
--- a/roles/nodejs/tasks/verify.yml
+++ b/roles/nodejs/tasks/verify.yml
@@ -1,25 +1,34 @@
 ---
-# Read-only version probes — must also run in check mode so the
-# nodejs_installed_version fact is populated for downstream roles
-# (e.g. marcstraube.server.n8n asserts Node.js >= 22).
+# Read-only version probes. check_mode: false forces them to run even in
+# check mode so nodejs_installed_version is populated for downstream roles
+# (e.g. marcstraube.server.n8n asserts Node.js >= 22). In a check-mode run
+# the install step may only be simulated, so a missing node/npm binary is
+# expected there and must not fail the play — only enforce presence on a
+# real (non-check) run.
 - name: Verify | Check Node.js version
   ansible.builtin.command: node --version
   register: __nodejs_version_check
   changed_when: false
   check_mode: false
-  failed_when: __nodejs_version_check.rc != 0
+  failed_when:
+    - __nodejs_version_check.rc != 0
+    - not ansible_check_mode
 
 - name: Verify | Check npm version
   ansible.builtin.command: npm --version
   register: __nodejs_npm_version_check
   changed_when: false
   check_mode: false
-  failed_when: __nodejs_npm_version_check.rc != 0
+  failed_when:
+    - __nodejs_npm_version_check.rc != 0
+    - not ansible_check_mode
 
 - name: Verify | Set nodejs_installed_version fact
   ansible.builtin.set_fact:
     nodejs_installed_version: "{{ __nodejs_version_check.stdout | regex_replace('^v', '') }}"
+  when: __nodejs_version_check.rc == 0
 
 - name: Verify | Display installed versions
   ansible.builtin.debug:
     msg: "Node.js {{ __nodejs_version_check.stdout }} / npm {{ __nodejs_npm_version_check.stdout }}"
+  when: __nodejs_version_check.rc == 0


### PR DESCRIPTION
## Summary

The `nodejs` role's verify probes run with `check_mode: false` so `nodejs_installed_version` is populated for downstream roles (e.g. `marcstraube.server.n8n`) even in check mode. Combined with `failed_when: rc != 0`, an `ansible-playbook --check` run against a host that has not received Node.js yet aborted the whole play — the install step is only simulated while the probes execute for real and fail with rc=2. Since Node.js is included in the base-system flow by default, this broke `--check` on any not-yet-provisioned host.

## Changes

- `failed_when` on both probes now also requires `not ansible_check_mode`, so a missing binary is only an error on a real run.
- `set_fact` / `debug` are guarded on `rc == 0`, so no empty `nodejs_installed_version` is set when the binary is absent in check mode.
- The happy path is unchanged: when Node.js is present (real or check run), the fact is populated as before.

## Test plan

- [x] yamllint — clean
- [x] ansible-lint (production profile) — clean
- [x] Real run still fails verify on a missing/broken Node.js (`failed_when` active when `not ansible_check_mode`)
- [x] Check run with Node.js absent no longer aborts (probes tolerated, fact skipped)
- [x] Node.js present → `nodejs_installed_version` populated as before (existing molecule verify coverage, unchanged)

Note: the check-mode-without-Node.js path is not directly exercised by molecule (containers have Node.js after converge and molecule does not run `--check`); it is covered here by the `failed_when`/`when` logic and the unchanged happy-path tests.

Closes #236

🤖 Generated with [Claude Code](https://claude.com/claude-code)
