### PR TITLE
fix(networkmanager): reload daemon config instead of restarting to preserve SSH

### DIFF
--- a/roles/networkmanager/README.md
+++ b/roles/networkmanager/README.md
@@ -40,7 +40,17 @@ overrides if needed.
 ```yaml
 networkmanager_enabled: true            # enable the networkmanager role
 networkmanager_service_enabled: true    # enable and start the networkmanager service
+
+networkmanager_service_wait_for_connection_delay: 5     # delay (s) before recovery check after a restart
+networkmanager_service_wait_for_connection_timeout: 180 # timeout (s) for recovery check after a restart
 ```
+
+> **Restart recovery:** Only the restart path (see
+> [reload vs. restart](#how-daemon-config-changes-are-applied-reload-vs-restart))
+> waits for connectivity to return. Restarting NetworkManager can tear down the
+> interface used to reach the host over SSH, so recovery may exceed the 60 s
+> Ansible default. Raise `networkmanager_service_wait_for_connection_timeout`
+> (or extend the delay) on slow links.
 
 ### Daemon Configuration
 
@@ -103,6 +113,34 @@ networkmanager_wifi_backend: ''            # wpa_supplicant, iwd
 ```yaml
 networkmanager_ifupdown_managed: false     # manage /etc/network/interfaces devices
 ```
+
+#### How daemon-config changes are applied (reload vs. restart)
+
+NetworkManager re-reads `NetworkManager.conf` / `conf.d/*.conf` on reload
+(`nmcli general reload`, SIGHUP semantics) **without** tearing down active
+connections. A full daemon restart, by contrast, can drop the very interface
+used to reach the host over SSH.
+
+The role therefore reloads by default and only restarts when a setting is
+configured that NetworkManager does not apply at runtime.
+
+**Applied via reload (no restart):** `dns`, `rc-manager`, `no-auto-default`,
+`ignore-carrier`, all `[logging]` settings, all `[connectivity]` settings, all
+`[connection]` defaults (mdns, llmnr, powersave, wake-on-lan, dhcp-send-hostname),
+and `unmanaged_devices` (`[keyfile]`).
+
+**Requires a restart:** `plugins`, `systemd_resolved: false`, `hostname_mode`,
+`auth_polkit`, `firewall_backend`, `migrate_ifcfg_rh`, `wifi_backend`,
+`wifi_scan_rand_mac: false` (`[device]`), and `ifupdown_managed` (Debian).
+
+When any restart-requiring setting deviates from its distro default, a
+daemon-config change restarts NetworkManager (followed by a
+`wait_for_connection` recovery check) instead of reloading. The trigger is
+whether such a setting is *set*, not whether that exact key changed — so a host
+that configures, e.g., `wifi_backend` will restart on every daemon-config
+change. Hosts reachable over an NM-managed interface typically set none of the
+restart-requiring keys, so their daemon-config changes reload and the SSH
+session survives.
 
 ### Installation
 

--- a/roles/networkmanager/defaults/main.yml
+++ b/roles/networkmanager/defaults/main.yml
@@ -9,6 +9,14 @@ networkmanager_enabled: true
 # Enable and start the networkmanager service
 networkmanager_service_enabled: true
 
+# wait_for_connection settings applied after a NetworkManager restart. Only the
+# restart path uses them — a reload does not drop active connections. Restarting
+# the daemon can tear down the very interface used to reach the host over SSH,
+# so recovery may outlast the 60 s Ansible default (observed ~69 s on a live
+# run). Raise the timeout or extend the delay to fit your environment.
+networkmanager_service_wait_for_connection_delay: 5
+networkmanager_service_wait_for_connection_timeout: 180
+
 #
 # Daemon Configuration
 #

--- a/roles/networkmanager/handlers/main.yml
+++ b/roles/networkmanager/handlers/main.yml
@@ -5,17 +5,32 @@
   changed_when: false
   when: networkmanager_enabled | bool
 
+# Re-reads NetworkManager.conf / conf.d/*.conf without tearing down active
+# connections (SIGHUP semantics). Used for daemon-config changes that do not
+# require a full daemon restart, so an SSH session on an NM-managed interface
+# survives. Restart-requiring settings notify "Restart NetworkManager" instead
+# (gated by __networkmanager_restart_required, computed in configure.yml).
+- name: Reload NetworkManager
+  ansible.builtin.command:
+    cmd: nmcli general reload
+  changed_when: false
+  when:
+    - networkmanager_service_enabled | bool
+    - not (__networkmanager_restart_required | default(false) | bool)
+
 - name: Restart NetworkManager
   ansible.builtin.systemd_service:
     name: '{{ __networkmanager_service_name }}'
     state: restarted
-  when: networkmanager_service_enabled | bool
+  when:
+    - networkmanager_service_enabled | bool
+    - __networkmanager_restart_required | default(false) | bool
   notify: Wait for network recovery
 
 - name: Wait for network recovery
   ansible.builtin.wait_for_connection:
-    delay: 5
-    timeout: 60
+    delay: '{{ networkmanager_service_wait_for_connection_delay }}'
+    timeout: '{{ networkmanager_service_wait_for_connection_timeout }}'
   when: networkmanager_service_enabled | bool
 
 - name: Reload systemd daemon

--- a/roles/networkmanager/molecule/default/verify.yml
+++ b/roles/networkmanager/molecule/default/verify.yml
@@ -143,6 +143,41 @@
         success_msg: Daemon config contains all expected sections and directives
 
     #
+    # Reload Behavior Verification
+    #
+    # The role reloads daemon config (nmcli general reload) instead of restarting
+    # for settings that do not require a restart, so an SSH session on an
+    # NM-managed interface survives. Assert that a reload keeps the same daemon
+    # process (MainPID unchanged) — i.e. it does not restart NetworkManager.
+
+    - name: Verify | Capture NetworkManager MainPID before reload
+      ansible.builtin.systemd_service:
+        name: NetworkManager.service
+      register: nm_state_before
+
+    - name: Verify | Reload NetworkManager daemon config
+      ansible.builtin.command: nmcli general reload
+      changed_when: false
+
+    - name: Verify | Capture NetworkManager MainPID after reload
+      ansible.builtin.systemd_service:
+        name: NetworkManager.service
+      register: nm_state_after
+
+    - name: Verify | Assert reload did not restart NetworkManager
+      ansible.builtin.assert:
+        that:
+          - nm_state_before.status.MainPID != '0'
+          - nm_state_before.status.MainPID == nm_state_after.status.MainPID
+        fail_msg: >-
+          nmcli general reload restarted NetworkManager
+          (MainPID {{ nm_state_before.status.MainPID }} ->
+          {{ nm_state_after.status.MainPID }})
+        success_msg: >-
+          nmcli general reload kept the same NetworkManager process
+          (MainPID {{ nm_state_after.status.MainPID }})
+
+    #
     # Legacy Config Migration Verification
     #
 

--- a/roles/networkmanager/tasks/configure.yml
+++ b/roles/networkmanager/tasks/configure.yml
@@ -1,4 +1,25 @@
 ---
+# Most daemon-config changes are re-read on reload (SIGHUP) without dropping
+# active connections. A full restart is only required for settings NetworkManager
+# does not apply at runtime. This fact decides which handler fires: it is true
+# when any restart-requiring setting deviates from its distro default. Config
+# tasks notify both handlers; each handler gates itself on this fact so exactly
+# one runs. Granularity is "a restart-requiring setting is set", not "that exact
+# key changed" — servers reachable over an NM-managed interface set none of these,
+# so daemon-config changes reload and the SSH session survives.
+- name: Configure | Determine whether a daemon restart is required
+  ansible.builtin.set_fact:
+    __networkmanager_restart_required: >-
+      {{ (networkmanager_plugins | length > 0)
+         or (not networkmanager_systemd_resolved)
+         or (networkmanager_hostname_mode | length > 0)
+         or (networkmanager_auth_polkit | length > 0)
+         or (networkmanager_firewall_backend | length > 0)
+         or (networkmanager_migrate_ifcfg_rh | bool)
+         or (networkmanager_wifi_backend | length > 0)
+         or (not networkmanager_wifi_scan_rand_mac)
+         or (ansible_facts['os_family'] == 'Debian' and networkmanager_ifupdown_managed | bool) }}
+
 - name: Configure | Deploy NetworkManager daemon configuration
   ansible.builtin.template:
     src: networkmanager.conf.j2
@@ -6,19 +27,25 @@
     owner: root
     group: root
     mode: '0644'
-  notify: Restart NetworkManager
+  notify:
+    - Reload NetworkManager
+    - Restart NetworkManager
 
 - name: Configure | Remove legacy dhcp-send-hostname config (migrated to 00-ansible.conf)
   ansible.builtin.file:
     path: /etc/NetworkManager/conf.d/dhcp-send-hostname.conf
     state: absent
-  notify: Restart NetworkManager
+  notify:
+    - Reload NetworkManager
+    - Restart NetworkManager
 
 - name: Configure | Remove legacy unmanaged devices config (migrated to 00-ansible.conf)
   ansible.builtin.file:
     path: /etc/NetworkManager/conf.d/unmanaged.conf
     state: absent
-  notify: Restart NetworkManager
+  notify:
+    - Reload NetworkManager
+    - Restart NetworkManager
 
 - name: Configure | Flush handlers to apply configuration
   ansible.builtin.meta: flush_handlers


### PR DESCRIPTION
## Problem

Deploying NetworkManager daemon configuration notified a full `Restart NetworkManager` handler. On a host managed over SSH via a NetworkManager-managed interface, restarting the daemon can drop the active connection — observed on a live Rocky 9 run where `wait_for_connection` timed out at ~69 s and the play failed on the first run, self-healing only on a re-run.

## Fix

NetworkManager re-reads `NetworkManager.conf` / `conf.d/*.conf` on reload (`nmcli general reload`, SIGHUP) without tearing down active connections, so a restart is only required for the few settings it does not apply at runtime. The role now reloads by default and restarts only when needed.

- `configure.yml` computes `__networkmanager_restart_required` — true when a restart-only setting (`plugins`, `systemd_resolved: false`, `hostname_mode`, `auth_polkit`, `firewall_backend`, `migrate_ifcfg_rh`, `wifi_backend`, `wifi_scan_rand_mac: false`, `ifupdown_managed`) deviates from its distro default.
- Config tasks notify both the new `Reload NetworkManager` handler and the existing `Restart NetworkManager` handler; each gates itself on the fact so exactly one runs.
- Reload-applicable settings (`dns`, `rc-manager`, `[logging]`, `[connectivity]`, `[connection]` defaults, `unmanaged_devices`, …) reload and the SSH session survives; restart-only settings still restart with the `wait_for_connection` recovery check.
- The recovery timeout is now configurable via `networkmanager_service_wait_for_connection_delay` / `_timeout` (default 180, raised from the hardcoded 60 s), matching the docker role convention.

## Testing

- ansible-lint (production profile), yamllint, markdownlint, detect-secrets: green.
- `molecule/default/verify.yml` asserts `nmcli general reload` keeps the daemon MainPID, i.e. it does not restart NetworkManager.
- Full `molecule test` green on Arch Linux, Debian Trixie and Rocky 9: reload keeps MainPID stable, the restart path fires for restart-only settings with the recovery wait, and the run is idempotent.

Closes #238
