### PR TITLE
docs(package_management): fix Debian repo table markdownlint line-length

### DIFF
--- a/roles/package_management/README.md
+++ b/roles/package_management/README.md
@@ -129,12 +129,12 @@ overrides if needed.
 
 ### Debian/Ubuntu - Repositories
 
-| Variable                              | Default | Description                                                              |
-|---------------------------------------|---------|--------------------------------------------------------------------------|
-| `apt_backports_enabled`               | `false` | Enable Debian Backports                                                  |
-| `apt_non_free_enabled`                | `false` | Append `non-free` to Components in default Debian deb822 sources         |
-| `apt_non_free_firmware_enabled`       | `false` | Append `non-free-firmware` to Components in default Debian deb822 sources |
-| `apt_custom_repos`                    | `[]`    | Custom repository definitions                                            |
+| Variable                        | Default | Description                                         |
+|---------------------------------|---------|-----------------------------------------------------|
+| `apt_backports_enabled`         | `false` | Enable Debian Backports                             |
+| `apt_non_free_enabled`          | `false` | Add `non-free` to Debian deb822 Components          |
+| `apt_non_free_firmware_enabled` | `false` | Add `non-free-firmware` to Debian deb822 Components |
+| `apt_custom_repos`              | `[]`    | Custom repository definitions                       |
 
 ### RHEL/Rocky - DNF
 


### PR DESCRIPTION
## Summary

The "Debian/Ubuntu - Repositories" table in `roles/package_management/README.md` had rows of 126–127 characters, exceeding the configured `MD013` line-length limit of 120 (`.markdownlint.yml`, `tables: true`). This made the local `pre-commit` markdownlint hook fail on any commit touching this file.

This shortens the `apt_non_free_enabled` / `apt_non_free_firmware_enabled` descriptions and re-aligns the whole table, reducing the widest row from 127 to 99 characters. The oversized column-1 padding is tightened at the same time, which also resolves the `MD060` (table-column-style) misalignment on the longest row.

## Test plan

- [x] `pre-commit run markdownlint --files roles/package_management/README.md` passes.
- [x] Every table row measures identically (col1=33, col2=9, col3=53), well under the 120-character limit.

Closes #241

🤖 Generated with [Claude Code](https://claude.com/claude-code)
