### PR TITLE
feat(package_management): add makepkg_devtools_enabled toggle

### DIFF
--- a/roles/package_management/README.md
+++ b/roles/package_management/README.md
@@ -63,17 +63,19 @@ overrides if needed.
 
 ### Arch Linux - Makepkg
 
-| Variable                 | Default      | Description                                     |
-|--------------------------|--------------|-------------------------------------------------|
-| `makepkg_packager`       | `''`         | Packager name/email for built packages          |
-| `makepkg_cflags`         | `''`         | Custom C compiler flags (empty = Arch defaults) |
-| `makepkg_ltoflags`       | `-flto=auto` | LTO flags                                       |
-| `makepkg_ccache_enabled` | `false`      | Enable ccache                                   |
-| `makepkg_distcc_enabled` | `false`      | Enable distcc                                   |
-| `makepkg_check`          | `true`       | Run check() in PKGBUILDs                        |
-| `makepkg_sign`           | `false`      | Sign built packages                             |
-| `makepkg_debug`          | `true`       | Build with debug symbols                        |
-| `makepkg_lto`            | `true`       | Build with LTO                                  |
+| Variable                   | Default      | Description                                     |
+|----------------------------|--------------|-------------------------------------------------|
+| `makepkg_packager`         | `''`         | Packager name/email for built packages          |
+| `makepkg_cflags`           | `''`         | Custom C compiler flags (empty = Arch defaults) |
+| `makepkg_ltoflags`         | `-flto=auto` | LTO flags                                       |
+| `makepkg_ccache_enabled`   | `false`      | Enable ccache                                   |
+| `makepkg_sccache_enabled`  | `false`      | Enable sccache (Rust)                           |
+| `makepkg_distcc_enabled`   | `false`      | Enable distcc                                   |
+| `makepkg_devtools_enabled` | `false`      | Install devtools (chrooted builds)              |
+| `makepkg_check`            | `true`       | Run check() in PKGBUILDs                        |
+| `makepkg_sign`             | `false`      | Sign built packages                             |
+| `makepkg_debug`            | `true`       | Build with debug symbols                        |
+| `makepkg_lto`              | `true`       | Build with LTO                                  |
 
 ### Arch Linux - Paru (AUR Helper)
 

--- a/roles/package_management/defaults/main.yml
+++ b/roles/package_management/defaults/main.yml
@@ -238,6 +238,9 @@ makepkg_ccache_enabled: false
 # Use sccache for Rust compilation caching
 makepkg_sccache_enabled: false
 
+# Install devtools for chrooted builds (makechrootpkg, mkarchroot)
+makepkg_devtools_enabled: false
+
 # Run check() function in PKGBUILDs
 makepkg_check: true
 

--- a/roles/package_management/tasks/archlinux/makepkg.yml
+++ b/roles/package_management/tasks/archlinux/makepkg.yml
@@ -39,6 +39,14 @@
   delay: 5
   when: makepkg_distcc_enabled | bool
 
+- name: Makepkg | Install devtools
+  ansible.builtin.package:
+    name: 'devtools'
+    state: present
+  retries: 3
+  delay: 5
+  when: makepkg_devtools_enabled | bool
+
 #
 # Per-User makepkg.conf
 #


### PR DESCRIPTION
## Summary

Adds an opt-in `makepkg_devtools_enabled` toggle (default `false`) that installs the `devtools` package on Arch hosts, exposing `makechrootpkg` / `mkarchroot` for clean-room chrooted builds. Maintainer-focused hosts opt in via inventory; the typical workstation leaves it off.

The install task mirrors the existing `ccache` / `sccache` / `distcc` pattern in `tasks/archlinux/makepkg.yml` (package install guarded by the toggle, with the same retry/delay). The README variable table gains the new toggle and, in the same pass, the previously-undocumented `makepkg_sccache_enabled` entry.

## Test plan

- [x] `yamllint` and `ansible-lint` (production profile) pass on the changed files.
- [x] All `pre-commit` hooks pass, including markdownlint on the README.
- [x] README makepkg table re-aligned; every row measured to equal column widths.

Closes #230

🤖 Generated with [Claude Code](https://claude.com/claude-code)
