### PR TITLE
ci: unify markdownlint on cli2 with recursive globs

### DIFF
--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -1,5 +1,10 @@
 ---
 config:
   extends: .markdownlint.yml
+globs:
+  - "**/*.{md,markdown}"
 ignores:
   - "CHANGELOG.md"
+  - ".ansible/**"
+  - "**/.venv/**"
+  - "**/node_modules/**"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,14 +31,12 @@ repos:
   # =============================================================================
   # MARKDOWN
   # =============================================================================
-  - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.48.0
+  - repo: https://github.com/DavidAnson/markdownlint-cli2
+    rev: v0.22.1
     hooks:
-      - id: markdownlint
+      - id: markdownlint-cli2
         name: Markdown Lint
         language_version: '22.22.0'
-        args: [--config=.markdownlint.yml]
-        exclude: '^CHANGELOG\.md$'
 
   # =============================================================================
   # GENERAL

--- a/roles/gnupg/README.md
+++ b/roles/gnupg/README.md
@@ -16,10 +16,10 @@ daemon configuration, and keyserver management.
 
 ## Supported Platforms
 
-| Platform                  | Notes                                                          |
-|---------------------------|----------------------------------------------------------------|
-| Arch Linux                | GnuPG 2.4+, includes GUI tools (Seahorse)                      |
-| Debian Trixie             | GnuPG 2.2+, includes GUI tools (Seahorse)                      |
+| Platform                  | Notes                                                           |
+|---------------------------|-----------------------------------------------------------------|
+| Arch Linux                | GnuPG 2.4+, includes GUI tools (Seahorse)                       |
+| Debian Trixie             | GnuPG 2.2+, includes GUI tools (Seahorse)                       |
 | EL 9 (Rocky, Alma, RHEL)  | GnuPG 2.3+; `paperkey` is not in EPEL — see CLI tools note (\*) |
 | EL 10 (Rocky, Alma, RHEL) | GnuPG 2.4+; `paperkey` is not in EPEL — see CLI tools note (\*) |
 

--- a/roles/utils/README.md
+++ b/roles/utils/README.md
@@ -105,16 +105,18 @@ All other tools use the same package name on every supported distro.
 
 ### Archive / Compression
 
-| Variable                       | Default | Description                                                  |
-|--------------------------------|---------|--------------------------------------------------------------|
-| `utils_archive_tar_enabled`    | `true`  | POSIX tar (required on RHEL minimal; no-op on Arch/Debian)   |
-| `utils_archive_zstd_enabled`   | `true`  | Modern fast compressor (.zst, default Arch package format)   |
-| `utils_archive_zip_enabled`    | `true`  | zip — deprecated in `base`, will move here exclusively in v3 |
+| Variable                       | Default | Description                                                    |
+|--------------------------------|---------|----------------------------------------------------------------|
+| `utils_archive_tar_enabled`    | `true`  | POSIX tar (required on RHEL minimal; no-op on Arch/Debian)     |
+| `utils_archive_zstd_enabled`   | `true`  | Modern fast compressor (.zst, default Arch package format)     |
+| `utils_archive_zip_enabled`    | `true`  | zip — deprecated in `base`, will move here exclusively in v3   |
 | `utils_archive_unzip_enabled`  | `true`  | unzip — deprecated in `base`, will move here exclusively in v3 |
-| `utils_archive_p7zip_enabled`  | `false` | 7-Zip clone (RHEL: pulls p7zip + p7zip-plugins via EPEL)     |
-| `utils_archive_unrar_enabled`  | `false` | RAR extractor (Arch: AUR; Debian: needs `apt_non_free_enabled`; RHEL: needs `dnf_rpmfusion_nonfree_enabled`) |
-| `utils_archive_atool_enabled`  | `false` | Universal archive frontend (Arch/Debian/EL9; not in EPEL 10) |
-| `utils_archive_pigz_enabled`   | `false` | Parallel gzip                                                |
+| `utils_archive_p7zip_enabled`  | `false` | 7-Zip clone (RHEL: pulls p7zip + p7zip-plugins via EPEL)       |
+| `utils_archive_unrar_enabled`  | `false` | RAR extractor (Arch: AUR; non-free, see note \*)               |
+| `utils_archive_atool_enabled`  | `false` | Universal archive frontend (Arch/Debian/EL9; not in EPEL 10)   |
+| `utils_archive_pigz_enabled`   | `false` | Parallel gzip                                                  |
+
+(\*) `unrar` needs `apt_non_free_enabled` on Debian, `dnf_rpmfusion_nonfree_enabled` on RHEL; Arch builds from the AUR.
 
 ### File Managers
 


### PR DESCRIPTION
## Summary

Unifies markdownlint tooling so local `pre-commit` and CI use the same engine, config, and file coverage.

- **pre-commit**: swap `igorshubovych/markdownlint-cli` for the `DavidAnson/markdownlint-cli2` hook, pinned `v0.22.1` — the cli2 version bundled in `markdownlint-cli2-action@v23`.
- **`.markdownlint-cli2.yaml`**: add `globs: ["**/*.{md,markdown}"]` (recursive) and ignore `.ansible/**`, `**/.venv/**`, `**/node_modules/**`.
- **CI**: the action already runs with no `with:` overrides, so it now lints every role README via the shared config — previously it only checked the 3 root-level markdown files.

Enabling recursive linting surfaced 5 pre-existing violations, fixed here:

- `roles/gnupg/README.md` — 2× MD060 (table alignment; the em-dash rows were 1 column too wide)
- `roles/utils/README.md` — 1× MD013 + 2× MD060 (the `unrar` row is shortened with its `apt_non_free_enabled` / `dnf_rpmfusion_nonfree_enabled` references preserved in a footnote; table re-aligned)

## Test plan

- [x] `pre-commit run markdownlint-cli2 --all-files` passes with cli2 v0.22.1 (the CI engine).
- [x] Full pre-commit suite passes on the changed files.
- [x] Both fixed tables re-measured — every row has equal column widths.

Closes #244

🤖 Generated with [Claude Code](https://claude.com/claude-code)
