### PR TITLE
feat(package_management): add makepkg_nvchecker_enabled toggle

### DIFF
--- a/roles/package_management/README.md
+++ b/roles/package_management/README.md
@@ -63,19 +63,20 @@ overrides if needed.
 
 ### Arch Linux - Makepkg
 
-| Variable                   | Default      | Description                                     |
-|----------------------------|--------------|-------------------------------------------------|
-| `makepkg_packager`         | `''`         | Packager name/email for built packages          |
-| `makepkg_cflags`           | `''`         | Custom C compiler flags (empty = Arch defaults) |
-| `makepkg_ltoflags`         | `-flto=auto` | LTO flags                                       |
-| `makepkg_ccache_enabled`   | `false`      | Enable ccache                                   |
-| `makepkg_sccache_enabled`  | `false`      | Enable sccache (Rust)                           |
-| `makepkg_distcc_enabled`   | `false`      | Enable distcc                                   |
-| `makepkg_devtools_enabled` | `false`      | Install devtools (chrooted builds)              |
-| `makepkg_check`            | `true`       | Run check() in PKGBUILDs                        |
-| `makepkg_sign`             | `false`      | Sign built packages                             |
-| `makepkg_debug`            | `true`       | Build with debug symbols                        |
-| `makepkg_lto`              | `true`       | Build with LTO                                  |
+| Variable                    | Default      | Description                                     |
+|-----------------------------|--------------|-------------------------------------------------|
+| `makepkg_packager`          | `''`         | Packager name/email for built packages          |
+| `makepkg_cflags`            | `''`         | Custom C compiler flags (empty = Arch defaults) |
+| `makepkg_ltoflags`          | `-flto=auto` | LTO flags                                       |
+| `makepkg_ccache_enabled`    | `false`      | Enable ccache                                   |
+| `makepkg_sccache_enabled`   | `false`      | Enable sccache (Rust)                           |
+| `makepkg_distcc_enabled`    | `false`      | Enable distcc                                   |
+| `makepkg_devtools_enabled`  | `false`      | Install devtools (chrooted builds)              |
+| `makepkg_nvchecker_enabled` | `false`      | Install nvchecker (upstream version tracking)   |
+| `makepkg_check`             | `true`       | Run check() in PKGBUILDs                        |
+| `makepkg_sign`              | `false`      | Sign built packages                             |
+| `makepkg_debug`             | `true`       | Build with debug symbols                        |
+| `makepkg_lto`               | `true`       | Build with LTO                                  |
 
 ### Arch Linux - Paru (AUR Helper)
 

--- a/roles/package_management/defaults/main.yml
+++ b/roles/package_management/defaults/main.yml
@@ -241,6 +241,9 @@ makepkg_sccache_enabled: false
 # Install devtools for chrooted builds (makechrootpkg, mkarchroot)
 makepkg_devtools_enabled: false
 
+# Install nvchecker for tracking upstream package versions (PKGBUILD authoring)
+makepkg_nvchecker_enabled: false
+
 # Run check() function in PKGBUILDs
 makepkg_check: true
 

--- a/roles/package_management/tasks/archlinux/makepkg.yml
+++ b/roles/package_management/tasks/archlinux/makepkg.yml
@@ -47,6 +47,14 @@
   delay: 5
   when: makepkg_devtools_enabled | bool
 
+- name: Makepkg | Install nvchecker
+  ansible.builtin.package:
+    name: 'nvchecker'
+    state: present
+  retries: 3
+  delay: 5
+  when: makepkg_nvchecker_enabled | bool
+
 #
 # Per-User makepkg.conf
 #


### PR DESCRIPTION
## Summary

Add an opt-in `makepkg_nvchecker_enabled` toggle (default `false`) that installs `nvchecker` on Arch hosts via pacman. nvchecker tracks upstream package versions and supports the PKGBUILD-authoring workflow, so it sits alongside the existing `ccache` / `sccache` / `distcc` / `devtools` build-environment toggles.

## Changes

- `defaults/main.yml`: `makepkg_nvchecker_enabled: false`
- `tasks/archlinux/makepkg.yml`: pacman install task, gated on the toggle
- `README.md`: variable table row

## Test plan

- [x] `yamllint`, `ansible-lint`, `markdownlint` pass locally
- [x] Toggle defaults to `false` — no change to existing runs
- [ ] CI: `package_management` molecule green on Arch, Debian, Rocky 9/10

Closes #231
