### PR TITLE
feat(php): add pcov to the extension map

### DIFF
--- a/roles/php/README.md
+++ b/roles/php/README.md
@@ -242,12 +242,17 @@ Examples:
 
 - `pgsql` → `php-pgsql` (official) / `php84-pgsql` (AUR)
 - `xdebug` → `xdebug` (official) / `php84-xdebug` (AUR)
+- `pcov` → AUR only (`php84-pcov`); not in the official repos
 
 In both maps an empty string `''` marks an extension as built into the core
 package (no separate sub-package installed). Extensions missing from the map
 fall back to `<prefix><name>`. A handful of extensions (`redis`, `mongodb`,
 `grpc`) are not shipped by the AUR `phpXX` bundle and will hit the fallback —
 override `php_versions[].extensions` or supply your own AUR PKGBUILD.
+
+`pcov` is the inverse case: it exists only in the AUR, so it is available on
+the AUR path (`php84-pcov`) but not through the official `php` package, and is
+therefore absent from `__php_extension_map_official`.
 
 ### RHEL Extension Mapping
 
@@ -267,6 +272,11 @@ an extension as built into the base `php<XX>-php` package. Remi ships no
 unversioned ImageMagick binding — `imagick` maps to `pecl-imagick-im7`
 (ImageMagick 7). Version digits in PECL suffixes (`redis6`, `xdebug3`) track
 Remi's current packaging and are verified against `rpms.remirepo.net`.
+
+`pcov` is packaged only for Remi (`php<XX>-php-pecl-pcov`), not for AppStream
+or EPEL. On the default AppStream path it maps to `''` (a no-op), so requesting
+it installs nothing rather than failing; use `php_redhat_repo: 'remi'` to
+install it.
 
 ### Default Version Handling
 

--- a/roles/php/molecule/default/verify.yml
+++ b/roles/php/molecule/default/verify.yml
@@ -295,7 +295,7 @@
              _mapped_final +
              (_unmapped | map('regex_replace', '^(.*)$', 'php84-' + '\1') | list) }}
       vars:
-        _exts: [curl, mbstring, intl, pgsql, gd, imagick, xdebug, redis, json]
+        _exts: [curl, mbstring, intl, pgsql, gd, imagick, xdebug, pcov, redis, json]
         _map: '{{ __php_extension_map_aur }}'
         _mapped_raw: "{{ _exts | select('in', _map) | map('extract', _map) | reject('equalto', '') | list }}"
         _unmapped: "{{ _exts | reject('in', _map) | list }}"
@@ -316,6 +316,7 @@
           - "'php84-gd' in __verify_aur_packages"
           - "'php84-imagick' in __verify_aur_packages"
           - "'php84-xdebug' in __verify_aur_packages"
+          - "'php84-pcov' in __verify_aur_packages"
           # Official-only package names must not leak into the AUR path
           - "'php-curl' not in __verify_aur_packages"
           - "'php-pgsql' not in __verify_aur_packages"
@@ -353,7 +354,7 @@
              _mapped_final +
              (_unmapped | map('regex_replace', '^(.*)$', 'php84-php-' + '\1') | list) }}
       vars:
-        _exts: [curl, mbstring, intl, gd, xdebug, redis, mysqli, xsl, pdo_sqlite, json]
+        _exts: [curl, mbstring, intl, gd, xdebug, redis, pcov, mysqli, xsl, pdo_sqlite, json]
         _map: '{{ __php_extension_map_remi }}'
         _mapped_raw: "{{ _exts | select('in', _map) | map('extract', _map) | reject('equalto', '') | list }}"
         _unmapped: "{{ _exts | reject('in', _map) | list }}"
@@ -373,6 +374,8 @@
           # PECL suffixes carry the version digit
           - "'php84-php-pecl-xdebug3' in __verify_remi_packages"
           - "'php84-php-pecl-redis6' in __verify_remi_packages"
+          # pcov is Remi-only, resolved through the Remi map
+          - "'php84-php-pecl-pcov' in __verify_remi_packages"
           # Collapsed subpackages: mysqli -> mysqlnd, xsl -> xml
           - "'php84-php-mysqlnd' in __verify_remi_packages"
           - "'php84-php-xml' in __verify_remi_packages"

--- a/roles/php/molecule/remi/converge.yml
+++ b/roles/php/molecule/remi/converge.yml
@@ -18,6 +18,7 @@
           - mysqli      # collapses to php84-php-mysqlnd
           - xdebug      # versioned PECL: php84-php-pecl-xdebug3
           - redis       # versioned PECL: php84-php-pecl-redis6
+          - pcov        # PECL, Remi-only: php84-php-pecl-pcov
         fpm: true
 
   tasks:

--- a/roles/php/molecule/remi/verify.yml
+++ b/roles/php/molecule/remi/verify.yml
@@ -26,6 +26,7 @@
         - php84-php-mysqlnd    # mysqli collapses here
         - php84-php-pecl-xdebug3
         - php84-php-pecl-redis6
+        - php84-php-pecl-pcov
 
     - name: Verify | Assert AppStream package names were not installed
       ansible.builtin.assert:
@@ -55,6 +56,7 @@
           - "'mysqli' in __verify_php84_modules.stdout"
           - "'xdebug' in __verify_php84_modules.stdout"
           - "'redis' in __verify_php84_modules.stdout"
+          - "'pcov' in __verify_php84_modules.stdout"
         fail_msg: >-
           Expected extensions not loaded by php84:
           {{ __verify_php84_modules.stdout }}

--- a/roles/php/vars/Archlinux.yml
+++ b/roles/php/vars/Archlinux.yml
@@ -163,3 +163,4 @@ __php_extension_map_aur:
   memcached: 'memcached'
   igbinary: 'igbinary'
   xdebug: 'xdebug'
+  pcov: 'pcov'

--- a/roles/php/vars/RedHat.yml
+++ b/roles/php/vars/RedHat.yml
@@ -77,6 +77,11 @@ __php_extension_map:
   mongodb: 'php-pecl-mongodb'
   redis: 'php-pecl-redis'
   xdebug: 'php-pecl-xdebug3'
+  # pcov is not packaged for AppStream or EPEL — it is only available via
+  # the Remi repository (php_redhat_repo: 'remi', see
+  # __php_extension_map_remi below). Mapped to '' so that an AppStream
+  # request is an intentional no-op rather than a failing install.
+  pcov: ''
 
 # Extension name mapping for the Remi SCL layout (php_redhat_repo == 'remi').
 # Unlike __php_extension_map above (full AppStream package names used
@@ -138,3 +143,4 @@ __php_extension_map_remi:
   redis: 'pecl-redis6'
   xdebug: 'pecl-xdebug3'
   zip: 'pecl-zip'
+  pcov: 'pecl-pcov'


### PR DESCRIPTION
## Summary

Add the `pcov` code-coverage extension to the PHP extension maps so it can be enabled via `php_versions[].extensions`.

## Changes

- `vars/Archlinux.yml`: `pcov` in the AUR map (`php<XX>-pcov`).
- `vars/RedHat.yml`: `pcov` in the Remi SCL map (`php<XX>-php-pecl-pcov`); `pcov: ''` (no-op) in the AppStream map, since pcov is not packaged for AppStream or EPEL.
- Debian resolves through the existing prefix fallback (`php<X.Y>-pcov`) — no map entry needed.
- `molecule/remi/`: install and assert `php84-php-pecl-pcov`.
- `molecule/default/verify.yml`: AUR and Remi build-list assertions cover pcov.
- `README.md`: document pcov availability per platform.

## Notes

On the Arch official-repo path pcov is unavailable (AUR only); this matches the existing dual-map semantics and is documented.

## Test plan

- [x] `remi` scenario green locally on Rocky 9 — live-installs `php84-php-pecl-pcov`; `pcov` module loads
- [x] `default` scenario green locally on Arch (AUR build-list asserts `php84-pcov`) and Rocky 9 (Remi build-list asserts `php84-php-pecl-pcov`)
- [x] `yamllint`, `ansible-lint`, `markdownlint` pass locally
- [ ] CI green: `php/default` (Arch, Debian, Rocky 9/10) and `php/remi` (Rocky 9/10)

Closes #217
