### PR TITLE
fix(php): recompute per-version Remi facts in configure and service phases

### DIFF
--- a/roles/php/molecule/remi/converge.yml
+++ b/roles/php/molecule/remi/converge.yml
@@ -20,6 +20,12 @@
           - redis       # versioned PECL: php84-php-pecl-redis6
           - pcov        # PECL, Remi-only: php84-php-pecl-pcov
         fpm: true
+      # Second version proves Remi side-by-side multi-version installs (#192):
+      # both php<XX>-php-fpm services and per-version /etc/opt/remi paths.
+      - version: '8.3'
+        extensions:
+          - gd          # separate subpackage: php83-php-gd
+        fpm: true
 
   tasks:
     - name: Converge | Include php role  # noqa: role-name[path]

--- a/roles/php/molecule/remi/verify.yml
+++ b/roles/php/molecule/remi/verify.yml
@@ -27,6 +27,10 @@
         - php84-php-pecl-xdebug3
         - php84-php-pecl-redis6
         - php84-php-pecl-pcov
+        # Second side-by-side version (8.3)
+        - php83-php-cli
+        - php83-php-fpm
+        - php83-php-gd
 
     - name: Verify | Assert AppStream package names were not installed
       ansible.builtin.assert:
@@ -81,19 +85,46 @@
           {{ __verify_php_link.stat.lnk_target | default('missing') }}
 
     #
-    # FPM service for the Remi SCL version.
+    # Per-version FPM services and config — multi-version side-by-side (#192).
+    # Both requested versions (8.4 default + 8.3) must have their own active
+    # SCL FPM service and their own /etc/opt/remi/php<XX>/ config files.
     #
 
-    - name: Verify | Check Remi FPM service
+    - name: Verify | Check per-version Remi FPM services
       ansible.builtin.systemd_service:
-        name: php84-php-fpm
+        name: 'php{{ item }}-php-fpm'
       register: __verify_remi_fpm
+      loop:
+        - '84'
+        - '83'
 
-    - name: Verify | Assert Remi FPM is active and enabled
+    - name: Verify | Assert per-version Remi FPM services active and enabled
       ansible.builtin.assert:
         that:
-          - __verify_remi_fpm.status.ActiveState == 'active'
-          - __verify_remi_fpm.status.UnitFileState == 'enabled'
+          - item.status.ActiveState == 'active'
+          - item.status.UnitFileState == 'enabled'
         fail_msg: >-
-          php84-php-fpm not active/enabled:
-          {{ __verify_remi_fpm.status.ActiveState }}
+          php{{ item.item }}-php-fpm not active/enabled:
+          {{ item.status.ActiveState }}
+      loop: '{{ __verify_remi_fpm.results }}'
+      loop_control:
+        label: 'php{{ item.item }}-php-fpm'
+
+    - name: Verify | Check per-version Remi config files
+      ansible.builtin.stat:
+        path: '{{ item }}'
+      register: __verify_remi_conf
+      loop:
+        - /etc/opt/remi/php84/php.d/99-ansible.ini
+        - /etc/opt/remi/php84/php-fpm.d/www.conf
+        - /etc/opt/remi/php83/php.d/99-ansible.ini
+        - /etc/opt/remi/php83/php-fpm.d/www.conf
+
+    - name: Verify | Assert per-version Remi config files deployed
+      ansible.builtin.assert:
+        that:
+          - item.stat.exists
+        fail_msg: 'Remi config file missing: {{ item.item }}'
+      loop: '{{ __verify_remi_conf.results }}'
+      loop_control:
+        label: '{{ item.item }}'

--- a/roles/php/tasks/configure_version.yml
+++ b/roles/php/tasks/configure_version.yml
@@ -36,6 +36,22 @@
     - ansible_facts['os_family'] == 'Archlinux'
     - __php_ver != __php_system_version
 
+# Override for RedHat Remi (versioned SCL paths, one set per side-by-side
+# version). install_version.yml bakes these facts to the last installed
+# version, so recompute them per version here — otherwise every version's
+# php.ini/www.conf is written to the last version's /etc/opt/remi/php<XX> dir.
+- name: Configure Version | Set RedHat Remi config paths
+  ansible.builtin.set_fact:
+    __php_conf_dirs:
+      - '/etc/opt/remi/php{{ __php_ver_compact }}/php.d'
+    __php_fpm_pool_dir: '/etc/opt/remi/php{{ __php_ver_compact }}/php-fpm.d'
+    __php_fpm_listen_default: >-
+      /var/opt/remi/php{{ __php_ver_compact }}/run/php-fpm/www.sock
+    __php_fpm_service: 'php{{ __php_ver_compact }}-php-fpm'
+  when:
+    - ansible_facts['os_family'] == 'RedHat'
+    - php_redhat_repo == 'remi'
+
 - name: Configure Version | Set effective listen socket
   ansible.builtin.set_fact:
     __php_effective_listen: '{{ __php_fpm_listen_default }}'

--- a/roles/php/tasks/service_version.yml
+++ b/roles/php/tasks/service_version.yml
@@ -30,6 +30,17 @@
     - ansible_facts['os_family'] == 'Archlinux'
     - __php_ver != __php_system_version
 
+# Override for RedHat Remi (versioned SCL service, one per side-by-side version).
+# install_version.yml bakes __php_fpm_service to the last installed version, so
+# recompute it per version here or only that version's service gets managed.
+- name: Service Version | Set RedHat Remi service name
+  ansible.builtin.set_fact:
+    __php_fpm_service: 'php{{ __php_ver_compact }}-php-fpm'
+  when:
+    - __php_service_item.fpm | default(true) | bool
+    - ansible_facts['os_family'] == 'RedHat'
+    - php_redhat_repo == 'remi'
+
 - name: Service Version | Manage PHP-FPM
   ansible.builtin.systemd_service:
     name: '{{ __php_fpm_service }}'


### PR DESCRIPTION
## Summary

On the RedHat Remi path with more than one `php_versions` entry, only the **last** version's FPM service was managed and every version's config was written into the last version's paths. Exposed by the multi-version Remi molecule scenario added here (the #192 test).

## Root cause

`install_version.yml` sets the Remi per-version facts (`__php_fpm_service`, `__php_conf_dirs`, `__php_fpm_pool_dir`, `__php_fpm_listen_default`) via `set_fact`, baking them into concrete strings. After the install loop they hold the last version's values. `configure_version.yml` and `service_version.yml` recompute these per-version facts only for Archlinux — they had no RedHat/Remi branch — so the configure and service phases reused the last version's values.

Debian is unaffected (lazy `php{{ __php_ver }}-fpm` vars templates); Arch is handled by its explicit per-phase resets.

## Changes

- `service_version.yml`: RedHat + Remi per-version reset of `__php_fpm_service`.
- `configure_version.yml`: RedHat + Remi per-version reset of `__php_conf_dirs`, `__php_fpm_pool_dir`, `__php_fpm_listen_default`, `__php_fpm_service` (before the effective-listen step).
- `molecule/remi/`: converge installs 8.4 + 8.3 side by side; verify asserts both `php<XX>-php-fpm` services active and both `/etc/opt/remi/php<XX>/...` config files deployed (the #192 test).

## Test plan

- [x] `remi` scenario green locally on Rocky 9 — both `php84-php-fpm` and `php83-php-fpm` active/enabled; php.ini + www.conf deployed under both `/etc/opt/remi/php84/` and `/etc/opt/remi/php83/`; idempotent
- [x] `default` scenario green locally on Rocky 9 — RedHat non-Remi path unaffected by the shared configure/service changes; idempotent
- [x] `yamllint`, `ansible-lint` pass locally
- [ ] CI green: `php/default` (Arch, Debian, Rocky 9/10) and `php/remi` (Rocky 9/10)

Closes #254
Closes #192
