### PR TITLE
feat: add wait_for_connection recovery timeout to firewalld and wireguard

### DIFF
--- a/roles/firewalld/README.md
+++ b/roles/firewalld/README.md
@@ -31,10 +31,21 @@ overrides if needed.
 
 ### Role Control
 
-| Variable                    | Default | Description                            |
-|-----------------------------|---------|----------------------------------------|
-| `firewalld_enabled`         | `true`  | Enable the firewalld role              |
-| `firewalld_service_enabled` | `true`  | Enable and start the firewalld service |
+| Variable                                        | Default | Description                                     |
+|-------------------------------------------------|---------|-------------------------------------------------|
+| `firewalld_enabled`                             | `true`  | Enable the firewalld role                       |
+| `firewalld_service_enabled`                     | `true`  | Enable and start the firewalld service          |
+| `firewalld_service_wait_for_connection_delay`   | `5`     | wait_for_connection delay (s) after a restart   |
+| `firewalld_service_wait_for_connection_timeout` | `180`   | wait_for_connection timeout (s) after a restart |
+
+> **HW-token-friendly tuning:** only a firewalld *restart* (triggered by
+> `firewalld.conf` changes) flushes the ruleset and can drop the SSH session —
+> the far more common *reload* path is gentle. When the restart drops the
+> connection and the SSH key on the controller lives on a hardware token,
+> re-authentication needs a fresh PIN prompt that the default 60 s
+> `wait_for_connection` timeout may not survive. The raised default of 180 s
+> gives the PIN window room; set
+> `firewalld_service_wait_for_connection_timeout` higher on slow links.
 
 ### Daemon Settings
 

--- a/roles/firewalld/defaults/main.yml
+++ b/roles/firewalld/defaults/main.yml
@@ -9,6 +9,16 @@ firewalld_enabled: true
 # Enable and start the firewalld service
 firewalld_service_enabled: true
 
+# wait_for_connection settings applied after a firewalld restart. Only the
+# restart path uses them — a reload re-reads rules without dropping active
+# connections. A restart flushes the ruleset, which can tear down the SSH
+# session used to reach the host until the daemon rebuilds its rules, so
+# recovery may outlast the 60 s Ansible default on slow links or when the SSH
+# key sits on a hardware token needing a fresh PIN prompt. Raise the timeout or
+# extend the delay to fit your environment.
+firewalld_service_wait_for_connection_delay: 5
+firewalld_service_wait_for_connection_timeout: 180
+
 #
 # firewalld.conf — Global Daemon Settings
 #

--- a/roles/firewalld/handlers/main.yml
+++ b/roles/firewalld/handlers/main.yml
@@ -17,3 +17,14 @@
     name: '{{ __firewalld_service_name }}'
     state: restarted
   when: firewalld_service_enabled | bool
+  notify: Wait for network recovery
+
+# Restarting the daemon flushes the ruleset, which can drop the SSH session used
+# to reach the host. Wait for the connection to recover before continuing so the
+# play does not fail on the 60 s Ansible default. Defined after "Restart
+# firewalld" so it runs afterwards (handler order follows definition order).
+- name: Wait for network recovery
+  ansible.builtin.wait_for_connection:
+    delay: '{{ firewalld_service_wait_for_connection_delay }}'
+    timeout: '{{ firewalld_service_wait_for_connection_timeout }}'
+  when: firewalld_service_enabled | bool

--- a/roles/wireguard/README.md
+++ b/roles/wireguard/README.md
@@ -40,11 +40,21 @@ overrides if needed.
 
 ### Role Control
 
-| Variable                    | Default            | Description                             |
-|-----------------------------|--------------------|-----------------------------------------|
-| `wireguard_enabled`         | `true`             | Enable the wireguard role               |
-| `wireguard_service_enabled` | `true`             | Enable and start services per interface |
-| `wireguard_config_dir`      | `'/etc/wireguard'` | Key/config directory                    |
+| Variable                                        | Default            | Description                                   |
+|-------------------------------------------------|--------------------|-----------------------------------------------|
+| `wireguard_enabled`                             | `true`             | Enable the wireguard role                     |
+| `wireguard_service_enabled`                     | `true`             | Enable and start services per interface       |
+| `wireguard_service_wait_for_connection_delay`   | `5`                | wait_for_connection delay (s) after restart   |
+| `wireguard_service_wait_for_connection_timeout` | `180`              | wait_for_connection timeout (s) after restart |
+| `wireguard_config_dir`                          | `'/etc/wireguard'` | Key/config directory                          |
+
+> **HW-token-friendly tuning:** when Ansible reaches the host through the tunnel
+> it is restarting, the control connection drops until `wg-quick@<iface>` comes
+> back. If the SSH key on the controller lives on a hardware token,
+> re-authentication needs a fresh PIN prompt that the default 60 s
+> `wait_for_connection` timeout may not survive. The raised default of 180 s
+> gives the PIN window room; set `wireguard_service_wait_for_connection_timeout`
+> higher on slow links.
 
 ### Interface Configuration
 

--- a/roles/wireguard/defaults/main.yml
+++ b/roles/wireguard/defaults/main.yml
@@ -9,6 +9,15 @@ wireguard_enabled: true
 # Enable and start WireGuard services (per interface)
 wireguard_service_enabled: true
 
+# wait_for_connection settings applied after a WireGuard interface restart.
+# Restarting wg-quick@<iface> tears down the tunnel, so when Ansible reaches the
+# host through that very tunnel the control connection drops until the interface
+# comes back. Recovery can outlast the 60 s Ansible default on slow links or
+# when the SSH key sits on a hardware token needing a fresh PIN prompt. Raise
+# the timeout or extend the delay to fit your environment.
+wireguard_service_wait_for_connection_delay: 5
+wireguard_service_wait_for_connection_timeout: 180
+
 #
 # Global Configuration
 #

--- a/roles/wireguard/tasks/configure.yml
+++ b/roles/wireguard/tasks/configure.yml
@@ -16,3 +16,14 @@
   when:
     - __wireguard_config_changed is changed
     - wireguard_service_enabled | bool
+
+# Restarting the tunnel can drop the control connection when Ansible reaches the
+# host through this very interface. Wait for the connection to recover before
+# continuing so the play does not fail on the 60 s Ansible default.
+- name: Configure | Wait for connection recovery
+  ansible.builtin.wait_for_connection:
+    delay: '{{ wireguard_service_wait_for_connection_delay }}'
+    timeout: '{{ wireguard_service_wait_for_connection_timeout }}'
+  when:
+    - __wireguard_config_changed is changed
+    - wireguard_service_enabled | bool


### PR DESCRIPTION
Closes #240

## What

Adds `<role>_service_wait_for_connection_delay` / `_timeout` knobs (default `5` / `180`, matching `docker` and `networkmanager`) to the two roles whose restart can drop the Ansible control connection, and wires them into a `wait_for_connection` recovery step.

- **firewalld** — the `Restart firewalld` handler (triggered by `firewalld.conf` changes) flushes the ruleset and can tear down SSH. It now notifies a new `Wait for network recovery` handler. The far more common `Reload firewalld` path stays gentle and is untouched.
- **wireguard** — restarting `wg-quick@<iface>` drops the tunnel. A `wait_for_connection` recovery step is added after the per-interface restart in `configure.yml`, gated on the same condition so idempotence holds.

## Audit scope

The issue listed five candidates. Audit of every restart/reboot across all roles narrowed the real scope to these two. `base` (journald + timesyncd), `openssh` (established sessions survive an sshd restart) and `resolved` (DNS-only blip) are not connection-critical and were intentionally left unchanged. `docker` and `networkmanager` already expose the knobs.

## Test plan

- [x] `ansible-lint`, `yamllint`, `markdownlint-cli2` pass on all changed files
- [x] Molecule `firewalld-rocky-10` (podman): converge + idempotence + verify pass; `Restart firewalld` → `Wait for network recovery` handler chain executes
- [x] Molecule `wireguard-archlinux` (vagrant): converge + idempotence + verify pass; `Wait for connection recovery` runs (5.66 s delay) after the interface restart and is skipped on the idempotence pass