### PR TITLE
test(firejail): drop become from disable scenario prepare.yml

### DIFF
--- a/roles/firejail/molecule/disable/prepare.yml
+++ b/roles/firejail/molecule/disable/prepare.yml
@@ -6,7 +6,6 @@
 
 - name: Prepare | Refresh caches
   hosts: all
-  become: true
   gather_facts: true
 
   tasks:
@@ -42,7 +41,6 @@
 
 - name: Prepare | Pre-install firejail via role
   hosts: all
-  become: true
   gather_facts: true
 
   vars:


### PR DESCRIPTION
## Summary

The `firejail` role's `disable` molecule scenario fails on the Rocky-9 and Rocky-10 platforms in CI (surfaced by #251, which made CI run all `molecule/*/` scenarios). `prepare.yml` set `become: true` on both plays; on the geerlingguy Rocky containers under GitHub-hosted runners, sudo/pam_unix cannot complete account management, so fact gathering fails with a PAM account management error before any task runs.

The container runs as root, so `become` is a no-op here. This drops it from both plays, matching the `default` scenario and all `converge`/`verify` files in the role.

## Test plan

- [x] Molecule `disable` scenario on `firejail-disable-rocky-9` (podman): full matrix passes (create, prepare, converge, idempotence, verify, destroy)
- [x] ansible-lint clean
- [x] yamllint clean

Closes #259
