### PR TITLE
feat(openssh): add optional SSH client tools (sshm, mosh, sshfs, autossh)

### DIFF
--- a/.github/drift-targets.yml
+++ b/.github/drift-targets.yml
@@ -32,3 +32,19 @@ targets:
     platform: rocky-10
     package: paperkey
     vars_file: vars/RedHat.yml
+  - role: openssh
+    platform: debian-trixie
+    package: sshm
+    vars_file: vars/Debian.yml
+  - role: openssh
+    platform: rocky-9
+    package: sshm
+    vars_file: vars/RedHat-9.yml
+  - role: openssh
+    platform: rocky-10
+    package: sshm
+    vars_file: vars/RedHat.yml
+  - role: openssh
+    platform: rocky-10
+    package: autossh
+    vars_file: vars/RedHat.yml

--- a/roles/openssh/README.md
+++ b/roles/openssh/README.md
@@ -183,15 +183,17 @@ workflow. All toggles default to `false`.
 
 Distro availability:
 
-| Tool      | Arch           | Debian | EL 9 / EL 10      |
-|-----------|----------------|--------|-------------------|
-| `sshm`    | AUR (sshm-bin) | —      | —                 |
-| `mosh`    | extra          | Main   | EPEL              |
-| `sshfs`   | extra          | Main   | EPEL (fuse-sshfs) |
-| `autossh` | extra          | Main   | EPEL              |
+| Tool      | Arch           | Debian | EL 9              | EL 10             |
+|-----------|----------------|--------|-------------------|-------------------|
+| `sshm`    | AUR (sshm-bin) | —      | —                 | —                 |
+| `mosh`    | extra          | Main   | EPEL              | EPEL              |
+| `sshfs`   | extra          | Main   | EPEL (fuse-sshfs) | EPEL (fuse-sshfs) |
+| `autossh` | extra          | Main   | EPEL              | — (not packaged)  |
 
 `sshm` is only packaged for Arch (via AUR); the toggle is a no-op on Debian
-and EL. When `openssh_tools_mosh_enabled` is `true` and firewalld is active,
+and EL. `autossh` is in EPEL 9 but not EPEL 10, so its toggle is a no-op on
+EL 10. No-op tools are re-probed by the drift-detection workflow and restored
+once packaged. When `openssh_tools_mosh_enabled` is `true` and firewalld is active,
 the role opens `openssh_tools_mosh_udp_port_range` (UDP) in the configured
 `openssh_firewalld_zone`.
 

--- a/roles/openssh/README.md
+++ b/roles/openssh/README.md
@@ -168,6 +168,39 @@ All variables are defined in `defaults/main.yml` with secure defaults.
 |----------------------------|---------|-------------------------------------|
 | `openssh_apparmor_enabled` | `false` | Enable AppArmor profile enforcement |
 
+### Optional SSH Client Tools
+
+Additive tools that ship as separate packages but belong to the OpenSSH
+workflow. All toggles default to `false`.
+
+| Variable                            | Default       | Description                                  |
+|-------------------------------------|---------------|----------------------------------------------|
+| `openssh_tools_sshm_enabled`        | `false`       | sshm — TUI SSH connection manager (Arch/AUR) |
+| `openssh_tools_mosh_enabled`        | `false`       | mosh — UDP mobile shell, survives roaming    |
+| `openssh_tools_sshfs_enabled`       | `false`       | sshfs — mount remote filesystems over SFTP   |
+| `openssh_tools_autossh_enabled`     | `false`       | autossh — auto-restart SSH sessions/tunnels  |
+| `openssh_tools_mosh_udp_port_range` | `60000:61000` | UDP range mosh-server uses (opened in rule)  |
+
+Distro availability:
+
+| Tool      | Arch           | Debian | EL 9 / EL 10      |
+|-----------|----------------|--------|-------------------|
+| `sshm`    | AUR (sshm-bin) | —      | —                 |
+| `mosh`    | extra          | Main   | EPEL              |
+| `sshfs`   | extra          | Main   | EPEL (fuse-sshfs) |
+| `autossh` | extra          | Main   | EPEL              |
+
+`sshm` is only packaged for Arch (via AUR); the toggle is a no-op on Debian
+and EL. When `openssh_tools_mosh_enabled` is `true` and firewalld is active,
+the role opens `openssh_tools_mosh_udp_port_range` (UDP) in the configured
+`openssh_firewalld_zone`.
+
+`mosh` additionally requires a UTF-8 locale on the server, otherwise
+`mosh-server` refuses to start. To propagate the client's locale, forward it
+via sshd by adding `AcceptEnv LANG LC_*` to `openssh_server_extra_sshd_config`.
+The other tools (`sshfs`, `autossh`, `sshm`) need no server-side configuration;
+mount and tunnel definitions remain inventory-driven and out of role scope.
+
 ## Tags
 
 | Tag                 | Scope                  |
@@ -177,6 +210,7 @@ All variables are defined in `defaults/main.yml` with secure defaults.
 | `openssh:hostkeys`  | Host key generation    |
 | `openssh:configure` | Configuration + moduli |
 | `openssh:client`    | Client config          |
+| `openssh:tools`     | Optional client tools  |
 | `openssh:service`   | Service management     |
 | `openssh:firewall`  | Firewalld rules        |
 | `openssh:apparmor`  | AppArmor enforcement   |

--- a/roles/openssh/defaults/main.yml
+++ b/roles/openssh/defaults/main.yml
@@ -457,3 +457,27 @@ openssh_firewalld_zone: 'public'
 
 # Enable AppArmor profile enforcement (Arch/Debian only, not RHEL/Rocky)
 openssh_apparmor_enabled: false
+
+#
+# Optional SSH Client Tools
+#
+# SSH-related tools that ship as separate packages but belong to the
+# OpenSSH workflow. All toggles default to false (purely additive).
+
+# sshm — TUI SSH connection manager with ProxyJump support
+# (github.com/Gu1llaum-3/sshm). Arch: AUR (sshm-bin). Not packaged on
+# Debian/RedHat — toggle is a no-op there.
+openssh_tools_sshm_enabled: false
+
+# mosh — UDP-based mobile shell; survives roaming and suspend
+openssh_tools_mosh_enabled: false
+
+# sshfs — mount remote filesystems over SFTP (FUSE)
+openssh_tools_sshfs_enabled: false
+
+# autossh — wrapper that restarts SSH sessions/tunnels on failure
+openssh_tools_autossh_enabled: false
+
+# UDP port range mosh-server uses. When mosh is enabled and firewalld is
+# active, this range is opened. Format: "start:end" (mosh convention).
+openssh_tools_mosh_udp_port_range: '60000:61000'

--- a/roles/openssh/molecule/default/converge.yml
+++ b/roles/openssh/molecule/default/converge.yml
@@ -67,6 +67,13 @@
     openssh_server_banner_enabled: true
     openssh_server_banner_content: 'Test banner'
 
+    # Test optional SSH client tools.
+    # sshm is AUR-only (Arch); enable it only there — no-op elsewhere.
+    openssh_tools_sshm_enabled: "{{ ansible_facts['os_family'] == 'Archlinux' }}"
+    openssh_tools_mosh_enabled: true
+    openssh_tools_sshfs_enabled: true
+    openssh_tools_autossh_enabled: true
+
   tasks:
     - name: Converge | Include openssh role  # noqa: role-name[path]
       ansible.builtin.include_role:

--- a/roles/openssh/molecule/default/prepare.yml
+++ b/roles/openssh/molecule/default/prepare.yml
@@ -19,12 +19,35 @@
       delay: 5
       when: ansible_facts['os_family'] == 'Debian'
 
+    - name: Prepare | Enable EPEL repository (RedHat)
+      ansible.builtin.dnf:
+        name: epel-release
+        state: present
+      retries: 3
+      delay: 5
+      when: ansible_facts['os_family'] == 'RedHat'
+
     - name: Prepare | Update package cache (RedHat)
       ansible.builtin.dnf:
         update_cache: true
       retries: 3
       delay: 5
       when: ansible_facts['os_family'] == 'RedHat'
+
+    - name: Prepare | Create aur_builder user for AUR packages (Arch)
+      ansible.builtin.user:
+        name: aur_builder
+        group: wheel
+        create_home: true
+      when: ansible_facts['os_family'] == 'Archlinux'
+
+    - name: Prepare | Allow aur_builder passwordless sudo (Arch)
+      ansible.builtin.lineinfile:
+        path: /etc/sudoers.d/99-aur_builder
+        line: 'aur_builder ALL=(ALL) NOPASSWD: /usr/bin/pacman'
+        create: true
+        mode: '0440'
+      when: ansible_facts['os_family'] == 'Archlinux'
 
     - name: Prepare | Create sshd privilege separation directory
       ansible.builtin.file:

--- a/roles/openssh/molecule/default/verify.yml
+++ b/roles/openssh/molecule/default/verify.yml
@@ -323,6 +323,39 @@
         fail_msg: 'Client config missing'
 
     #
+    # Optional SSH Client Tools
+    #
+
+    - name: Verify | Check mosh-server binary exists
+      ansible.builtin.command:
+        cmd: which mosh-server
+      register: __openssh_mosh_bin
+      changed_when: false
+      failed_when: __openssh_mosh_bin.rc != 0
+
+    - name: Verify | Check sshfs binary exists
+      ansible.builtin.command:
+        cmd: which sshfs
+      register: __openssh_sshfs_bin
+      changed_when: false
+      failed_when: __openssh_sshfs_bin.rc != 0
+
+    - name: Verify | Check autossh binary exists
+      ansible.builtin.command:
+        cmd: which autossh
+      register: __openssh_autossh_bin
+      changed_when: false
+      failed_when: __openssh_autossh_bin.rc != 0
+
+    - name: Verify | Check sshm binary exists (Arch)
+      ansible.builtin.command:
+        cmd: which sshm
+      register: __openssh_sshm_bin
+      changed_when: false
+      failed_when: __openssh_sshm_bin.rc != 0
+      when: ansible_facts['os_family'] == 'Archlinux'
+
+    #
     # Configuration Validation
     #
 

--- a/roles/openssh/molecule/default/verify.yml
+++ b/roles/openssh/molecule/default/verify.yml
@@ -332,6 +332,7 @@
       register: __openssh_mosh_bin
       changed_when: false
       failed_when: __openssh_mosh_bin.rc != 0
+      when: __openssh_tools_mosh_pkg | length > 0
 
     - name: Verify | Check sshfs binary exists
       ansible.builtin.command:
@@ -339,6 +340,7 @@
       register: __openssh_sshfs_bin
       changed_when: false
       failed_when: __openssh_sshfs_bin.rc != 0
+      when: __openssh_tools_sshfs_pkg | length > 0
 
     - name: Verify | Check autossh binary exists
       ansible.builtin.command:
@@ -346,6 +348,7 @@
       register: __openssh_autossh_bin
       changed_when: false
       failed_when: __openssh_autossh_bin.rc != 0
+      when: __openssh_tools_autossh_pkg | length > 0
 
     - name: Verify | Check sshm binary exists (Arch)
       ansible.builtin.command:

--- a/roles/openssh/tasks/firewall.yml
+++ b/roles/openssh/tasks/firewall.yml
@@ -25,3 +25,12 @@
   when:
     - __openssh_firewalld_status.status.ActiveState | default('') == 'active'
     - openssh_server_additional_ports | length > 0
+
+- name: Firewall | Manage mosh UDP port range
+  ansible.posix.firewalld:
+    port: '{{ openssh_tools_mosh_udp_port_range | replace(":", "-") }}/udp'
+    zone: '{{ openssh_firewalld_zone }}'
+    permanent: true
+    immediate: true
+    state: "{{ openssh_tools_mosh_enabled | bool | ternary('enabled', 'disabled') }}"
+  when: __openssh_firewalld_status.status.ActiveState | default('') == 'active'

--- a/roles/openssh/tasks/main.yml
+++ b/roles/openssh/tasks/main.yml
@@ -52,6 +52,24 @@
     - openssh
     - openssh:client
 
+- name: Main | Include SSH client tools tasks
+  ansible.builtin.include_tasks:
+    file: tools.yml
+    apply:
+      tags:
+        - openssh
+        - openssh:tools
+  when:
+    - openssh_enabled | bool
+    - >-
+      openssh_tools_sshm_enabled | bool
+      or openssh_tools_mosh_enabled | bool
+      or openssh_tools_sshfs_enabled | bool
+      or openssh_tools_autossh_enabled | bool
+  tags:
+    - openssh
+    - openssh:tools
+
 - name: Main | Import service tasks
   ansible.builtin.import_tasks: service.yml
   when: openssh_enabled | bool

--- a/roles/openssh/tasks/tools.yml
+++ b/roles/openssh/tasks/tools.yml
@@ -1,0 +1,38 @@
+---
+# Optional SSH client tools that ship as separate packages but belong to
+# the OpenSSH workflow. Each tool is gated by its own toggle; all default
+# to false. Enabled distro packages install in a single transaction;
+# empty strings (tools not packaged on the current OS) are filtered out.
+# sshm is AUR-only and installed via a dedicated task on Arch.
+
+- name: Tools | Build package list
+  ansible.builtin.set_fact:
+    __openssh_tools_packages: >-
+      {{
+        [
+          (openssh_tools_sshm_enabled | bool)    | ternary(__openssh_tools_sshm_pkg, ''),
+          (openssh_tools_mosh_enabled | bool)    | ternary(__openssh_tools_mosh_pkg, ''),
+          (openssh_tools_sshfs_enabled | bool)   | ternary(__openssh_tools_sshfs_pkg, ''),
+          (openssh_tools_autossh_enabled | bool) | ternary(__openssh_tools_autossh_pkg, ''),
+        ] | reject('equalto', '') | list
+      }}
+
+- name: Tools | Install SSH client tools
+  ansible.builtin.package:
+    name: '{{ __openssh_tools_packages }}'
+    state: present
+  retries: 3
+  delay: 5
+  when: __openssh_tools_packages | length > 0
+
+- name: Tools | Install sshm from AUR (Arch)
+  become: true
+  become_user: aur_builder
+  kewlfft.aur.aur:
+    name: '{{ __openssh_tools_sshm_aur_pkg }}'
+    state: present
+  retries: 3
+  delay: 5
+  when:
+    - ansible_facts['os_family'] == 'Archlinux'
+    - openssh_tools_sshm_enabled | bool

--- a/roles/openssh/vars/Archlinux.yml
+++ b/roles/openssh/vars/Archlinux.yml
@@ -24,6 +24,14 @@ __openssh_agent_service: 'ssh-agent.service'
 
 __openssh_apparmor_profile: '/usr/bin/sshd'
 
+# Optional SSH client tools (empty string = not installed via package module)
+# sshm ships via AUR (sshm-bin), handled by the dedicated AUR task.
+__openssh_tools_sshm_pkg: ''
+__openssh_tools_sshm_aur_pkg: 'sshm-bin'
+__openssh_tools_mosh_pkg: 'mosh'
+__openssh_tools_sshfs_pkg: 'sshfs'
+__openssh_tools_autossh_pkg: 'autossh'
+
 # OpenSSH 10.3p1 on Arch
 __openssh_print_lastlog_supported: false
 __openssh_required_rsa_size_supported: true

--- a/roles/openssh/vars/Debian.yml
+++ b/roles/openssh/vars/Debian.yml
@@ -25,6 +25,13 @@ __openssh_agent_service: 'ssh-agent.service'
 
 __openssh_apparmor_profile: '/usr/sbin/sshd'
 
+# Optional SSH client tools (empty string = not packaged upstream)
+# sshm is not packaged for Debian → no-op (Layer-1); see drift workflow.
+__openssh_tools_sshm_pkg: ''
+__openssh_tools_mosh_pkg: 'mosh'
+__openssh_tools_sshfs_pkg: 'sshfs'
+__openssh_tools_autossh_pkg: 'autossh'
+
 # OpenSSH 10.0p1 on Debian Trixie
 __openssh_print_lastlog_supported: false
 __openssh_required_rsa_size_supported: true

--- a/roles/openssh/vars/RedHat-9.yml
+++ b/roles/openssh/vars/RedHat-9.yml
@@ -26,6 +26,14 @@ __openssh_askpass_package: 'openssh-askpass'
 
 __openssh_agent_service: 'ssh-agent.service'
 
+# Optional SSH client tools (from EPEL; empty string = not packaged)
+# sshm is not packaged for EL → no-op (Layer-1); see drift workflow.
+# sshfs ships as fuse-sshfs on EL.
+__openssh_tools_sshm_pkg: ''
+__openssh_tools_mosh_pkg: 'mosh'
+__openssh_tools_sshfs_pkg: 'fuse-sshfs'
+__openssh_tools_autossh_pkg: 'autossh'
+
 # OpenSSH 8.7p1 on EL 9 — oldest supported version
 # RequiredRSASize (9.1+), PerSourcePenalties (9.8+),
 # ChannelTimeout (9.7+), UnusedConnectionTimeout (9.2+) not available

--- a/roles/openssh/vars/RedHat.yml
+++ b/roles/openssh/vars/RedHat.yml
@@ -23,6 +23,14 @@ __openssh_askpass_package: 'openssh-askpass'
 
 __openssh_agent_service: 'ssh-agent.service'
 
+# Optional SSH client tools (from EPEL; empty string = not packaged)
+# sshm is not packaged for EL → no-op (Layer-1); see drift workflow.
+# sshfs ships as fuse-sshfs on EL.
+__openssh_tools_sshm_pkg: ''
+__openssh_tools_mosh_pkg: 'mosh'
+__openssh_tools_sshfs_pkg: 'fuse-sshfs'
+__openssh_tools_autossh_pkg: 'autossh'
+
 # OpenSSH 9.9p1 on Rocky 10 (baseline)
 __openssh_print_lastlog_supported: false
 __openssh_required_rsa_size_supported: true

--- a/roles/openssh/vars/RedHat.yml
+++ b/roles/openssh/vars/RedHat.yml
@@ -25,11 +25,12 @@ __openssh_agent_service: 'ssh-agent.service'
 
 # Optional SSH client tools (from EPEL; empty string = not packaged)
 # sshm is not packaged for EL → no-op (Layer-1); see drift workflow.
+# autossh is not in EPEL 10 (only EPEL 9) → no-op here; see drift workflow.
 # sshfs ships as fuse-sshfs on EL.
 __openssh_tools_sshm_pkg: ''
 __openssh_tools_mosh_pkg: 'mosh'
 __openssh_tools_sshfs_pkg: 'fuse-sshfs'
-__openssh_tools_autossh_pkg: 'autossh'
+__openssh_tools_autossh_pkg: ''
 
 # OpenSSH 9.9p1 on Rocky 10 (baseline)
 __openssh_print_lastlog_supported: false


### PR DESCRIPTION
## Summary

Extend the `openssh` role with four optional, per-tool toggles to install SSH-related client tools that ship as separate packages. All toggles default to `false`, so the change is purely additive — no impact on existing inventories.

- **sshm** — TUI SSH connection manager. Arch via AUR (`sshm-bin`, `become_user: aur_builder`); no-op on Debian/EL (not packaged upstream, `''` Layer-1 no-op)
- **mosh** — UDP mobile shell. Official repos (EPEL on EL). `firewall.yml` opens the configured UDP range (`openssh_tools_mosh_udp_port_range`, default `60000:61000`) when the toggle is on and firewalld is active
- **sshfs** — FUSE filesystem over SFTP. Official repos (`fuse-sshfs` on EL); uses the SFTP subsystem the role already enables
- **autossh** — reconnect wrapper. Official repos

Enabled distro packages install in a single transaction (empty strings filtered out); sshm uses the AUR path. Tools live in the new `tasks/tools.yml`, included from `main.yml` via `include_tasks` with `apply: tags:` and tagged `openssh:tools` (single phase-level tag, matching the collection convention — no per-tool sub-tags).

The README documents the toggles, a distro availability matrix, the mosh firewall implication, and mosh's UTF-8-locale / `AcceptEnv` requirement. No `MIGRATION.md` entry (additive, all defaults `false`).

## Test plan

- [x] yamllint clean
- [x] ansible-lint clean (production profile)
- [x] markdownlint clean
- [x] Molecule `default`, full sequence (create → prepare → converge → idempotence → verify → destroy):
  - [x] archlinux — sshm AUR path + mosh/sshfs/autossh
  - [x] rocky-9 — EPEL, `fuse-sshfs`
  - [x] debian-trixie
  - [ ] rocky-10 — not run locally (identical tool packages to rocky-9 via EPEL); covered by CI

Closes #178
