### PR TITLE
fix: replace hardcoded aur_builder with aur_builder_user variable

### DIFF
--- a/roles/aide/tasks/install.yml
+++ b/roles/aide/tasks/install.yml
@@ -1,7 +1,7 @@
 ---
 - name: Install | Import GPG keys for AUR package verification
   become: true
-  become_user: 'aur_builder'
+  become_user: "{{ aur_builder_user | default('aur_builder') }}"
   ansible.builtin.command:
     cmd: 'gpg --keyserver keys.openpgp.org --recv-keys {{ item }}'
   loop: '{{ __aide_gpg_keys | default([]) }}'
@@ -13,7 +13,7 @@
 
 - name: Install | AIDE package (AUR)
   become: true
-  become_user: 'aur_builder'
+  become_user: "{{ aur_builder_user | default('aur_builder') }}"
   kewlfft.aur.aur:
     name: '{{ __aide_aur_packages.aide }}'
     state: present

--- a/roles/ansible/tasks/install.yml
+++ b/roles/ansible/tasks/install.yml
@@ -28,7 +28,7 @@
 
     - name: Install | molecule-plugins from AUR (Arch)
       become: true
-      become_user: 'aur_builder'
+      become_user: "{{ aur_builder_user | default('aur_builder') }}"
       kewlfft.aur.aur:
         name: '{{ __ansible_tools_aur_packages.molecule }}'
         use: 'makepkg'

--- a/roles/openssh/tasks/tools.yml
+++ b/roles/openssh/tasks/tools.yml
@@ -27,7 +27,7 @@
 
 - name: Tools | Install sshm from AUR (Arch)
   become: true
-  become_user: aur_builder
+  become_user: "{{ aur_builder_user | default('aur_builder') }}"
   kewlfft.aur.aur:
     name: '{{ __openssh_tools_sshm_aur_pkg }}'
     state: present

--- a/roles/php/tasks/install_version.yml
+++ b/roles/php/tasks/install_version.yml
@@ -132,7 +132,7 @@
 
 - name: Install Version | PHP packages from AUR (Arch)
   become: true
-  become_user: aur_builder
+  become_user: "{{ aur_builder_user | default('aur_builder') }}"
   kewlfft.aur.aur:
     name: '{{ __php_version_packages }}'
     state: present

--- a/roles/podman/tasks/install.yml
+++ b/roles/podman/tasks/install.yml
@@ -50,7 +50,7 @@
 
 - name: Install | Podman Desktop (AUR)
   become: true
-  become_user: aur_builder
+  become_user: "{{ aur_builder_user | default('aur_builder') }}"
   kewlfft.aur.aur:
     name: '{{ __podman_aur_packages.desktop }}'
     state: present

--- a/roles/python/tasks/install.yml
+++ b/roles/python/tasks/install.yml
@@ -48,7 +48,7 @@
 
 - name: Install | Extra Python packages (AUR)
   become: true
-  become_user: aur_builder
+  become_user: "{{ aur_builder_user | default('aur_builder') }}"
   kewlfft.aur.aur:
     name: '{{ __python_aur_packages.extra }}'
     state: present

--- a/roles/shell/tasks/install.yml
+++ b/roles/shell/tasks/install.yml
@@ -45,7 +45,7 @@
 
 - name: Install | ble.sh from AUR
   become: true
-  become_user: 'aur_builder'
+  become_user: "{{ aur_builder_user | default('aur_builder') }}"
   kewlfft.aur.aur:
     name: '{{ __shell_blesh_package }}'
     state: present

--- a/roles/utils/tasks/install.yml
+++ b/roles/utils/tasks/install.yml
@@ -107,7 +107,7 @@
 
 - name: Install | AUR packages (Arch)
   become: true
-  become_user: aur_builder
+  become_user: "{{ aur_builder_user | default('aur_builder') }}"
   kewlfft.aur.aur:
     name: '{{ __utils_aur_install_list }}'
     state: present


### PR DESCRIPTION
Replaces all 9 hardcoded `become_user: aur_builder` occurrences (quoted and unquoted) across 8 task files with `become_user: "{{ aur_builder_user | default('aur_builder') }}"`, so overriding `aur_builder_user` from inventory works consistently outside `package_management`. The `default()` fallback keeps standalone runs (molecule) working, since role defaults are not visible to other roles.

Closes #264

🤖 Generated with [Claude Code](https://claude.com/claude-code)