### PR TITLE
fix(python): declare python3-packaging for the EL pip module

### DIFF
--- a/roles/python/vars/RedHat-9.yml
+++ b/roles/python/vars/RedHat-9.yml
@@ -1,6 +1,11 @@
 ---
+# python3-packaging: the ansible-core pip module imports `packaging` on the
+# target interpreter (/usr/bin/python3 = 3.9 on EL9) — declared explicitly so
+# the role does not rely on it being pulled in incidentally, which varies
+# between EL9 point releases (present on 9.7, absent on a minimal 9.8).
 __python_packages:
   - 'python3'
+  - 'python3-packaging'
   - 'python3.12'
 
 __python_pip_packages:

--- a/roles/python/vars/RedHat.yml
+++ b/roles/python/vars/RedHat.yml
@@ -1,6 +1,10 @@
 ---
+# python3-packaging: the ansible-core pip module imports `packaging` on the
+# target interpreter — declared explicitly so roles using the pip module do
+# not depend on it being pulled in incidentally across EL point releases.
 __python_packages:
   - 'python3'
+  - 'python3-packaging'
 
 __python_pip_packages:
   - 'python3-pip'


### PR DESCRIPTION
## What

Add `python3-packaging` to the EL package list in the `python` role (`vars/RedHat-9.yml` and `vars/RedHat.yml`).

## Why

The `ansible.builtin.pip` module (ansible-core 2.20) imports `packaging` on the target interpreter (`/usr/bin/python3` = Python 3.9 on EL9). `python3-packaging` is not guaranteed on a minimal EL9 install — the incidental dependency chain that provided it changed between 9.7 and 9.8, breaking the EL9 pipx bootstrap (`Install | pipx in bootstrap venv`). The role now declares the dependency instead of relying on the point release.

## Test plan

- [x] `python` role completes the pipx bootstrap on a fresh EL9 (Rocky 9.8) install without the `No module named 'packaging'` error.

Closes #268
