### PR TITLE
fix(shell): only configure starship where the package is installed

### DIFF
--- a/roles/shell/molecule/default/converge.yml
+++ b/roles/shell/molecule/default/converge.yml
@@ -50,7 +50,7 @@
       ansible.builtin.include_role:
         name: '{{ playbook_dir }}/../..'
 
-- name: Converge — Starship config (Arch only — starship not in Debian/EL repos)
+- name: Converge — Starship config (all distros — role gates init on package availability)
   hosts: all
   gather_facts: true
 
@@ -74,7 +74,6 @@
     - name: Converge | Include shell role (starship)  # noqa: role-name[path]
       ansible.builtin.include_role:
         name: '{{ playbook_dir }}/../..'
-      when: ansible_facts['os_family'] == 'Archlinux'
 
 - name: Converge — Zoxide init (all distros — zoxide ships in every repo)
   hosts: all

--- a/roles/shell/molecule/default/verify.yml
+++ b/roles/shell/molecule/default/verify.yml
@@ -84,7 +84,7 @@
         - __shell_fzf_package | default('') | length > 0
 
     #
-    # Starship (Arch only)
+    # Starship (init/config gated on package availability)
     #
 
     - name: Verify | Check starship installed (Arch)
@@ -96,6 +96,40 @@
       when:
         - ansible_facts['os_family'] == 'Archlinux'
         - __shell_starship_package | default('') | length > 0
+
+    # The role adds the `starship init` line and deploys starship.toml only
+    # where it installs the binary. On Arch the package exists -> both present;
+    # on EL/Debian __shell_starship_package is '' -> both must be absent
+    # (otherwise every login prints "starship: command not found").
+    - name: Verify | starship init line present in .bashrc (Arch)
+      ansible.builtin.command:
+        cmd: 'grep -q "starship init bash" /home/testuser/.bashrc'
+      register: _shell_starship_init_arch
+      changed_when: false
+      failed_when: _shell_starship_init_arch.rc != 0
+      when: ansible_facts['os_family'] == 'Archlinux'
+
+    - name: Verify | starship.toml deployed (Arch)
+      ansible.builtin.stat:
+        path: /home/testuser/.config/starship.toml
+      register: _shell_starship_toml_arch
+      failed_when: not _shell_starship_toml_arch.stat.exists
+      when: ansible_facts['os_family'] == 'Archlinux'
+
+    - name: Verify | starship init line absent in .bashrc (non-Arch)
+      ansible.builtin.command:
+        cmd: 'grep -q "starship init bash" /home/testuser/.bashrc'
+      register: _shell_starship_init_other
+      changed_when: false
+      failed_when: _shell_starship_init_other.rc == 0
+      when: ansible_facts['os_family'] != 'Archlinux'
+
+    - name: Verify | starship.toml absent (non-Arch)
+      ansible.builtin.stat:
+        path: /home/testuser/.config/starship.toml
+      register: _shell_starship_toml_other
+      failed_when: _shell_starship_toml_other.stat.exists
+      when: ansible_facts['os_family'] != 'Archlinux'
 
     #
     # Oh My Zsh

--- a/roles/shell/tasks/main.yml
+++ b/roles/shell/tasks/main.yml
@@ -65,6 +65,7 @@
     - shell_enabled | bool
     - shell_starship_enabled | bool
     - shell_starship_config_enabled | bool
+    - __shell_starship_package | default('') | length > 0
   tags:
     - shell
     - shell:starship
@@ -75,6 +76,7 @@
     - shell_enabled | bool
     - shell_starship_enabled | bool
     - shell_starship_shells | length > 0
+    - __shell_starship_package | default('') | length > 0
   tags:
     - shell
     - shell:starship


### PR DESCRIPTION
## What

Gate the starship config and init imports in `main.yml` on `__shell_starship_package | length > 0`. De-mask the molecule starship converge (it now runs on all platforms) and assert the per-OS outcome in verify.

## Why

On EL and Debian `__shell_starship_package` is empty, so starship is never installed, yet `main.yml` still added `eval "$(starship init bash)"` to users' rc files — every login printed `starship: command not found`. The install task already filtered the empty package; the config and init imports did not check availability. The converge masked the bug by enabling starship only on Arch.

## Test plan

- [ ] shell molecule asserts the starship init line and starship.toml are present on Arch and absent on Debian and Rocky 9/10 (verified by CI on this PR).

Closes #273
