### PR TITLE
ci: pin molecule and molecule-plugins to the last schema-compatible release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,8 +105,8 @@ jobs:
       - name: Install dependencies
         run: |
           pip install "ansible-core~=2.21.0" \
-                      molecule \
-                      molecule-plugins[podman] \
+                      "molecule==26.6.0" \
+                      "molecule-plugins[podman]==26.7.8" \
                       passlib
 
       - name: Install collection dependencies
@@ -273,8 +273,8 @@ jobs:
       - name: Install dependencies
         run: |
           pip install "ansible-core~=2.17.0" \
-                      molecule \
-                      molecule-plugins[podman] \
+                      "molecule==26.6.0" \
+                      "molecule-plugins[podman]==26.7.8" \
                       passlib
 
       - name: Install collection dependencies


### PR DESCRIPTION
molecule-plugins 26.7.15 changed the podman driver `tmpfs` schema to require an array, which is incompatible with `containers.podman.podman_container.tmpfs` (`type: dict`). Every `molecule.yml` uses `tmpfs` as a dict, so all Molecule scenarios fail schema validation — including roles with no code change.

Pins `molecule==26.6.0` and `molecule-plugins[podman]==26.7.8` (the versions of the last green run) in both `ci.yml` install blocks. No `molecule.yml` changes. Verified locally: 26.7.15 reproduces the failure, 26.7.8 validates the existing configs cleanly.

Closes #277
