### PR TITLE
feat(hardening): optional /proc hidepid mounting for servers

### DIFF
--- a/roles/hardening/README.md
+++ b/roles/hardening/README.md
@@ -83,6 +83,39 @@ existing data or breaking services that hold open files there. Set
 `hardening_fs_tmp_force_tmpfs: true` to opt in — appropriate for fresh
 installs where `/tmp` is known to be empty.
 
+### /proc hidepid
+
+| Variable                                 | Default                    | Description                                |
+|------------------------------------------|----------------------------|--------------------------------------------|
+| `hardening_proc_hidepid_enabled`         | `false`                    | Mount /proc with hidepid (opt-in)          |
+| `hardening_proc_hidepid_mode`            | `2`                        | `2` = invisible, `1` = listed not readable |
+| `hardening_proc_hidepid_group`           | `'proc'`                   | Exemption group with full /proc visibility |
+| `hardening_proc_hidepid_exempt_services` | `polkit`                   | Services granted the exemption via drop-in |
+
+Hiding foreign process information keeps short-lived secrets that tools
+accept as command-line arguments out of reach of unprivileged users.
+Non-root services that must see foreign processes break under hidepid —
+the role grants the exemption group through `SupplementaryGroups`
+drop-ins and restarts the listed services before the remount. Add
+further non-root services (e.g. monitoring agents that scan processes)
+to `hardening_proc_hidepid_exempt_services` as needed. Root services
+such as `systemd-logind` do not belong in the list: root bypasses
+hidepid, and restarting logind under an active graphical session severs
+the compositor's session devices. Drop-ins of services removed from the
+list are pruned. Disabling the toggle rolls the drop-ins, the fstab
+entry and the mount options back.
+
+> **Warning — server hardening only.** hidepid is incompatible with
+> desktop polkit authentication agents (KDE, XFCE, hyprpolkitagent and
+> other PolkitQt/GLib agents): the agent process runs as the desktop
+> user, fails to determine its own session under any hidepid level and
+> cannot register — all polkit authentication dialogs stop working.
+> This is a long-standing upstream limitation, not a configuration
+> issue. Enable the toggle on servers without a graphical session.
+> Adding a desktop user to the exemption group restores the agent but
+> defeats the purpose, as that user's processes regain full /proc
+> visibility.
+
 ## Tags
 
 | Tag                    | Scope                  |
@@ -91,6 +124,7 @@ installs where `/tmp` is known to be empty.
 | `hardening:kernel`     | Sysctl configuration   |
 | `hardening:modules`    | Module blacklisting    |
 | `hardening:filesystem` | Mount option hardening |
+| `hardening:proc`       | /proc hidepid mounting |
 
 ## Example Playbook
 

--- a/roles/hardening/defaults/main.yml
+++ b/roles/hardening/defaults/main.yml
@@ -129,3 +129,33 @@ hardening_fs_vartmp_bind_enabled: true
 # and can break services that hold open files there. Intended for fresh
 # installs where /tmp is known to be empty.
 hardening_fs_tmp_force_tmpfs: false
+
+#
+# /proc hidepid
+#
+# Mount /proc with hidepid so unprivileged users cannot read foreign
+# process information (/proc/<pid>/cmdline exposes short-lived secrets
+# that tools accept as arguments). Opt-in: services that must see
+# foreign processes (privilege prompts) rely on the exemption group
+# below and are restarted when their drop-ins change.
+#
+# SERVER HARDENING ONLY: hidepid breaks desktop polkit authentication
+# agents (the agent cannot register its session) — see the role README.
+
+# Enable /proc hidepid mounting (disabling rolls the change back)
+hardening_proc_hidepid_enabled: false
+
+# hidepid mode: 2 = foreign processes fully invisible,
+# 1 = visible in listings but their /proc entries are not readable
+hardening_proc_hidepid_mode: 2
+
+# Exemption group granted full /proc visibility (gid=<group>)
+hardening_proc_hidepid_group: 'proc'
+
+# Non-root system services that need the exemption via a
+# SupplementaryGroups drop-in. Listed services are RESTARTED when their
+# drop-in changes. Root services (e.g. systemd-logind) never belong
+# here: root bypasses hidepid, and restarting logind under an active
+# graphical session severs the compositor's session devices.
+hardening_proc_hidepid_exempt_services:
+  - 'polkit'

--- a/roles/hardening/tasks/main.yml
+++ b/roles/hardening/tasks/main.yml
@@ -38,3 +38,13 @@
   tags:
     - hardening
     - hardening:filesystem
+
+# No feature gate on the import: proc.yml also handles the rollback
+# when hardening_proc_hidepid_enabled is false.
+- name: Main | Import proc hidepid tasks
+  ansible.builtin.import_tasks: proc.yml
+  when:
+    - hardening_enabled | bool
+  tags:
+    - hardening
+    - hardening:proc

--- a/roles/hardening/tasks/proc.yml
+++ b/roles/hardening/tasks/proc.yml
@@ -1,0 +1,164 @@
+---
+#
+# /proc hidepid — hide foreign process information from unprivileged users
+#
+# Order matters: the exemption group and the service drop-ins must be in
+# place and the services restarted BEFORE the remount, otherwise
+# privilege prompts break the moment hidepid takes effect. Only
+# non-root services belong in the exemption list — root bypasses
+# hidepid, and restarting root session infrastructure (systemd-logind)
+# under an active graphical session severs the compositor's devices.
+# Disabling the toggle rolls everything back (drop-ins, fstab entry,
+# remount without hidepid); the exemption group is left in place.
+#
+
+- name: Proc | Validate hidepid mode
+  ansible.builtin.assert:
+    that:
+      - hardening_proc_hidepid_mode | int in [1, 2]
+    fail_msg: 'hardening_proc_hidepid_mode must be 1 or 2'
+  when: hardening_proc_hidepid_enabled | bool
+
+- name: Proc | Create hidepid exemption group
+  ansible.builtin.group:
+    name: '{{ hardening_proc_hidepid_group }}'
+    system: true
+    state: present
+  when: hardening_proc_hidepid_enabled | bool
+
+- name: Proc | Create service drop-in directories
+  ansible.builtin.file:
+    path: '/etc/systemd/system/{{ item }}.service.d'
+    state: directory
+    owner: root
+    group: root
+    mode: '0755'
+  loop: '{{ hardening_proc_hidepid_exempt_services }}'
+  when: hardening_proc_hidepid_enabled | bool
+
+- name: Proc | Deploy service exemption drop-ins
+  ansible.builtin.copy:
+    content: |
+      {{ ansible_managed | comment }}
+      [Service]
+      SupplementaryGroups={{ hardening_proc_hidepid_group }}
+    dest: '/etc/systemd/system/{{ item }}.service.d/10-hidepid-proc.conf'
+    owner: root
+    group: root
+    mode: '0644'
+  loop: '{{ hardening_proc_hidepid_exempt_services }}'
+  register: __hardening_proc_dropins
+  when: hardening_proc_hidepid_enabled | bool
+
+# Drop-ins of services that are no longer in the exemption list are
+# removed (the service keeps the group until its next restart or boot —
+# harmless, and deliberately no restart here).
+- name: Proc | Find existing hidepid drop-ins
+  ansible.builtin.find:
+    paths: '/etc/systemd/system'
+    patterns: '10-hidepid-proc.conf'
+    recurse: true
+  register: __hardening_proc_dropins_found
+  when: hardening_proc_hidepid_enabled | bool
+
+- name: Proc | Remove drop-ins of unlisted services
+  ansible.builtin.file:
+    path: '{{ item }}'
+    state: absent
+  loop: >-
+    {{ __hardening_proc_dropins_found.files | default([])
+       | map(attribute='path')
+       | reject('search',
+                '/(' + (hardening_proc_hidepid_exempt_services
+                        | map('regex_escape') | join('|'))
+                + ')\.service\.d/')
+       | list }}
+  register: __hardening_proc_dropins_pruned
+  when: hardening_proc_hidepid_enabled | bool
+
+- name: Proc | Reload systemd after drop-in pruning  # noqa: no-handler
+  ansible.builtin.systemd_service:
+    daemon_reload: true
+  when:
+    - hardening_proc_hidepid_enabled | bool
+    - __hardening_proc_dropins_pruned is changed
+    - not ansible_check_mode
+
+# Runs immediately, not as a handler: the exempted services must carry
+# the supplementary group before the remount below hides /proc entries.
+- name: Proc | Restart exempted services after drop-in change  # noqa: no-handler
+  ansible.builtin.systemd_service:
+    name: '{{ item.item }}'
+    state: restarted
+    daemon_reload: true
+  loop: '{{ __hardening_proc_dropins.results | default([]) }}'
+  loop_control:
+    label: '{{ item.item | default(item) }}'
+  when:
+    - hardening_proc_hidepid_enabled | bool
+    - item is changed
+    - not ansible_check_mode
+
+- name: Proc | Configure /proc fstab entry
+  ansible.posix.mount:
+    path: '/proc'
+    src: 'proc'
+    fstype: 'proc'
+    opts: >-
+      nosuid,nodev,noexec,hidepid={{ hardening_proc_hidepid_mode }},gid={{
+      hardening_proc_hidepid_group }}
+    state: present
+  register: __hardening_proc_fstab
+  when: hardening_proc_hidepid_enabled | bool
+
+# Skip in check mode: the prior task only registers the fstab change,
+# so a remount would still apply the old options. Skipped in containers:
+# their /proc is namespaced/masked by the runtime and cannot carry
+# hidepid; the fstab entry above still covers the real-host case.
+- name: Proc | Remount /proc with hidepid  # noqa: no-handler
+  ansible.posix.mount:
+    path: '/proc'
+    state: remounted
+  when:
+    - hardening_proc_hidepid_enabled | bool
+    - __hardening_proc_fstab is changed
+    - not ansible_check_mode
+    - ansible_facts['virtualization_type'] | default('') not in ['container', 'docker', 'podman', 'lxc']
+
+#
+# Rollback when disabled
+#
+
+- name: Proc | Remove service exemption drop-ins (disabled)
+  ansible.builtin.file:
+    path: '/etc/systemd/system/{{ item }}.service.d/10-hidepid-proc.conf'
+    state: absent
+  loop: '{{ hardening_proc_hidepid_exempt_services }}'
+  register: __hardening_proc_dropins_removed
+  when: not hardening_proc_hidepid_enabled | bool
+
+- name: Proc | Reload systemd after drop-in removal (disabled)  # noqa: no-handler
+  ansible.builtin.systemd_service:
+    daemon_reload: true
+  when:
+    - not hardening_proc_hidepid_enabled | bool
+    - __hardening_proc_dropins_removed is changed
+    - not ansible_check_mode
+
+- name: Proc | Remove /proc fstab entry (disabled)
+  ansible.posix.mount:
+    path: '/proc'
+    state: absent_from_fstab
+  register: __hardening_proc_fstab_removed
+  when: not hardening_proc_hidepid_enabled | bool
+
+- name: Proc | Remount /proc without hidepid (disabled)  # noqa: no-handler
+  ansible.posix.mount:
+    path: '/proc'
+    opts: 'hidepid=off,gid=0'
+    state: remounted
+  when:
+    - not hardening_proc_hidepid_enabled | bool
+    - __hardening_proc_fstab_removed is changed
+    - not ansible_check_mode
+    - ansible_facts['virtualization_type'] | default('') not in ['container', 'docker', 'podman', 'lxc']


### PR DESCRIPTION
## Summary

Process command lines are world-readable via `/proc/<pid>/cmdline`, which exposes short-lived secrets that tools accept as arguments (e.g. PKCS#11 URIs carrying `pin-value`, since the OpenSSL engine does not support `pin-source`). This adds an opt-in toggle (default `false`) that mounts `/proc` with `hidepid` and a gid exemption group.

Non-root services that must see foreign processes get the group through `SupplementaryGroups` drop-ins and are restarted before the remount; drop-ins of services removed from the exemption list are pruned. Root services never belong in the list: root bypasses hidepid, and restarting logind under an active graphical session severs the compositor's session devices. Disabling the toggle rolls the drop-ins, the fstab entry and the mount options back. Remounts are guarded for check mode and container environments.

Server hardening only: hidepid breaks desktop polkit authentication agents (the agent process cannot determine its session under any hidepid level and fails to register) — a long-standing upstream limitation, prominently documented in the README.

## Test plan

- [x] `yamllint`, `ansible-lint` and `markdownlint` pass on all changed files
- [x] Full enable cycle live-tested on an Arch host: exemption group, polkit drop-in, service restart, fstab entry and remount applied; foreign processes invisible to unprivileged users afterwards; subsequent run idempotent (drop-in pruning of a removed service was the only change)
- [x] Full disable cycle live-tested: drop-ins removed, fstab entry removed, /proc remounted without hidepid, desktop polkit agent registers and authenticates again
- [x] The documented desktop limitation is the observed live behaviour: the polkit agent fails to register under hidepid=1 and =2 and recovers without it

Closes #284

🤖 Generated with [Claude Code](https://claude.com/claude-code)