### PR TITLE
fix(package_management): make the shared paru clone cache usable for manual upgrades

### DIFF
--- a/roles/package_management/README.md
+++ b/roles/package_management/README.md
@@ -102,11 +102,25 @@ overrides if needed.
 | `paru_search_by`        | `name-desc`             | Search by field                  |
 | `paru_shared_users`     | `[]`                    | Users sharing AUR clone cache    |
 
-The shared clone directory is group-owned by `aur_shared` with the SGID bit,
-and carries default ACLs granting the group `rwX`. This ensures packages that
-`aur_builder` clones can later be rebuilt by any `aur_shared` member even when
-a restrictive default umask (such as the `hardening` role's `0077`) would
-otherwise strip group permissions from newly created files.
+The shared clone directory is owned by the `aur_builder` user and group-owned
+by `aur_shared` with the SGID bit. All builds run as `aur_builder` under an
+enforced `022` umask (set through the user's GECOS `umask=` field and a
+sudoers `umask_override`), so cloned sources and built packages stay readable
+and executable for the `aur_shared` group even when a restrictive default
+umask (such as the `hardening` role's `0077`) is in effect. ACLs are
+deliberately **not** used: default ACLs make `libarchive`/`bsdtar` skip its
+final `chmod` during source extraction, which would bake the restrictive
+modes of the initial secure `open()` into the built packages. Because
+`makepkg` only chmods paths for their owner, the tree is owned by a single
+user; other `aur_shared` members get read/execute access (never write)
+through the SGID bit and the enforced umask.
+
+Manual upgrades must therefore run as the build user. The role installs a
+`/usr/local/bin/paru` wrapper that transparently re-executes `paru` as
+`aur_builder` via `sudo`, so `paru -Syu` works from any `wheel` account
+(authenticating with the caller's own password) or as `root`. Never invoke
+the real `/usr/bin/paru` directly as a login user — that would create clone
+entries owned by the wrong user and lock the builder out on the next run.
 
 ### Arch Linux - Tools
 

--- a/roles/package_management/molecule/paru-perms/prepare.yml
+++ b/roles/package_management/molecule/paru-perms/prepare.yml
@@ -30,12 +30,15 @@
         create_home: true
 
     # Recreate the legacy state earlier role versions left behind: default
-    # ACLs on the clone directory and a clone entry owned by root. Converge
-    # must strip the ACLs and adopt the entry for the builder.
+    # ACLs on the clone directory and a clone entry owned by root. The entry
+    # is mode 0700 as a hardened 0077 umask would have left it, so converge
+    # must strip the ACLs, adopt the entry for the builder AND normalize its
+    # mode back to group-readable.
     - name: Prepare | Create clone directory with a legacy root-owned entry
       ansible.builtin.shell: |
         mkdir -p /var/cache/paru/clone/legacypkg
         echo x > /var/cache/paru/clone/legacypkg/PKGBUILD
+        chmod 0700 /var/cache/paru/clone/legacypkg
         setfacl -m d:g::rwX /var/cache/paru/clone
       args:
         creates: /var/cache/paru/clone/legacypkg/PKGBUILD

--- a/roles/package_management/molecule/paru-perms/verify.yml
+++ b/roles/package_management/molecule/paru-perms/verify.yml
@@ -47,6 +47,20 @@
           - __pm_legacy_stat.stat.gr_name == 'aur_shared'
         fail_msg: 'Legacy clone entry was not adopted by the builder'
 
+    - name: Verify | Stat the legacy directory
+      ansible.builtin.stat:
+        path: '{{ paru_clone_dir }}/legacypkg'
+      register: __pm_legacy_dir_stat
+
+    - name: Verify | Assert the legacy 0700 directory was made group-readable
+      ansible.builtin.assert:
+        that:
+          - __pm_legacy_dir_stat.stat.rgrp
+          - __pm_legacy_dir_stat.stat.xgrp
+        fail_msg: >-
+          Legacy directory kept its restrictive 0700 mode — chown alone does
+          not repair modes, so the aur_shared group stays locked out.
+
     - name: Verify | Stat the builder-created entry
       ansible.builtin.stat:
         path: '{{ paru_clone_dir }}/testpkg'
@@ -61,3 +75,40 @@
         fail_msg: >-
           Builder-created entry did not inherit aur_shared group access
           through the SGID bit under the enforced 022 umask.
+
+    - name: Verify | Stat the manual-invocation wrapper
+      ansible.builtin.stat:
+        path: /usr/local/bin/paru
+      register: __pm_wrapper_stat
+
+    - name: Verify | Read the wrapper contents
+      ansible.builtin.slurp:
+        src: /usr/local/bin/paru
+      register: __pm_wrapper_content
+
+    - name: Verify | Assert the wrapper re-executes paru as the builder user
+      ansible.builtin.assert:
+        that:
+          - __pm_wrapper_stat.stat.exists
+          - __pm_wrapper_stat.stat.executable
+          - "'sudo -u aur_builder' in (__pm_wrapper_content.content | b64decode)"
+          - "'/usr/bin/paru' in (__pm_wrapper_content.content | b64decode)"
+        fail_msg: >-
+          /usr/local/bin/paru wrapper is missing, not executable, or does not
+          re-execute /usr/bin/paru as the aur_builder user.
+
+    - name: Verify | Validate the builder sudoers file
+      ansible.builtin.command:
+        cmd: 'visudo -cf /etc/sudoers.d/99-aur_builder'
+      changed_when: false
+
+    - name: Verify | Read the builder sudoers file
+      ansible.builtin.slurp:
+        src: /etc/sudoers.d/99-aur_builder
+      register: __pm_sudoers_content
+
+    - name: Verify | Assert the wheel-to-builder paru rule is present
+      ansible.builtin.assert:
+        that:
+          - "'%wheel ALL=(aur_builder) /usr/bin/paru' in (__pm_sudoers_content.content | b64decode)"
+        fail_msg: 'The wheel-to-aur_builder paru sudoers rule is missing.'

--- a/roles/package_management/tasks/archlinux/paru.yml
+++ b/roles/package_management/tasks/archlinux/paru.yml
@@ -73,6 +73,18 @@
     cmd: 'chown -R {{ aur_builder_user }}:aur_shared {{ paru_clone_dir }}'
   changed_when: false
 
+# chown alone does not repair modes: directories created under a hardened
+# umask (0077) stay 2700 and keep locking the aur_shared group out even
+# after ownership is corrected. Normalize them additively — group and
+# other gain read, X adds execute only on directories and already
+# executable files, so regular file exec bits survive. This matches what
+# the SGID bit plus the builder's enforced 022 umask produces for newly
+# created entries. changed_when is false like the ownership recovery above.
+- name: Paru | Normalize modes on existing clone entries
+  ansible.builtin.command:
+    cmd: 'chmod -R g+rX,o+rX {{ paru_clone_dir }}'
+  changed_when: false
+
 # git refuses to operate on repositories owned by another user
 # (CVE-2022-24765 safe.directory check). In the shared clone directory
 # that is the normal case: any aur_shared member may have cloned a
@@ -111,3 +123,30 @@
     owner: root
     group: root
     mode: '0644'
+
+# Manual paru runs must happen as the builder user, otherwise the shared
+# clone tree gains entries owned by the login user and locks the builder
+# out on the next Ansible run. The wrapper shadows /usr/bin/paru in PATH
+# and transparently re-executes it as the builder user via sudo, so a bare
+# "paru -Syu" is safe from any wheel account or as root.
+- name: Paru | Install manual-invocation wrapper
+  ansible.builtin.template:
+    src: 'archlinux/paru-wrapper.j2'
+    dest: '/usr/local/bin/paru'
+    owner: root
+    group: root
+    mode: '0755'
+
+# Companion rule for the wrapper: let wheel members run paru as the builder
+# user. Authentication is required on purpose (no NOPASSWD) — the same bar
+# as "sudo pacman", so a manual upgrade still asks for the caller's
+# password. root does not need this rule.
+- name: Paru | Allow wheel to run paru as the builder user
+  ansible.builtin.lineinfile:
+    path: '/etc/sudoers.d/99-{{ aur_builder_user }}'
+    line: '%wheel ALL=({{ aur_builder_user }}) /usr/bin/paru'
+    create: true
+    owner: root
+    group: root
+    mode: '0440'
+    validate: 'visudo -cf %s'

--- a/roles/package_management/templates/archlinux/paru-wrapper.j2
+++ b/roles/package_management/templates/archlinux/paru-wrapper.j2
@@ -1,0 +1,11 @@
+#!/bin/sh
+{{ ansible_managed | comment }}
+# Route manual/interactive paru calls through the dedicated build user so
+# the shared clone cache (owned by {{ aur_builder_user }}) stays consistent
+# and never gains entries owned by a login user. Regular users need the
+# matching "%wheel ... ({{ aur_builder_user }}) /usr/bin/paru" sudoers rule
+# and authenticate with their own password; root is allowed by default.
+# /usr/bin/paru is called by absolute path to avoid recursing into this
+# wrapper, which shadows the real binary earlier in PATH. -H points HOME at
+# the builder's home so paru does not try to write into the caller's home.
+exec sudo -u {{ aur_builder_user }} -H /usr/bin/paru "$@"


### PR DESCRIPTION
## Summary

Makes the shared paru clone cache usable for manual `paru` upgrades and fixes two related gaps in the same mechanism.

- Add a `/usr/local/bin/paru` wrapper that re-executes `paru` as the builder user via `sudo`, plus an authenticated `%wheel ALL=(aur_builder) /usr/bin/paru` sudoers rule (no NOPASSWD — the same bar as `sudo pacman`).
- Normalize modes on existing clone entries after the ownership recovery so `2700` directories become group-readable again.
- Correct the README: the tree uses SGID + an enforced `022` umask (not ACLs), granting the group read/execute but not write.
- Extend the `paru-perms` molecule scenario with a `0700` legacy fixture and assertions for the wrapper and the sudoers rule.

## Test plan

- [x] `ansible-lint` (production profile), `yamllint`, `markdownlint` pass locally
- [x] `molecule test -s paru-perms` passes (converge, idempotence, verify)
- [x] Applied on Arch Linux via `--tags package-management`: wrapper and sudoers rule apply cleanly, `visudo` validation passes
- [x] Manual `paru -Syu` as a login user runs through the wrapper (authenticates, builds as the builder user, no permission errors)

Closes #290
