### PR TITLE
ci: pin crun to a spec-compatible release for molecule podman jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,6 +113,18 @@ jobs:
         run: |
           ansible-galaxy collection install community.general community.crypto ansible.posix kewlfft.aur containers.podman
 
+      - name: Pin crun to a spec-compatible release
+        # ubuntu-latest ships crun versions that vary with the runner image
+        # rollout; crun < 1.14.3 cannot parse the OCI runtime spec v1.2.1
+        # config that podman 5.x writes, failing container create with
+        # "crun: unknown version specified". Pin a known-good static build.
+        run: |
+          CRUN_VERSION=1.28
+          sudo curl -fsSL -o /usr/bin/crun \
+            "https://github.com/containers/crun/releases/download/${CRUN_VERSION}/crun-${CRUN_VERSION}-linux-amd64"
+          sudo chmod +x /usr/bin/crun
+          crun --version
+
       - name: Run Molecule test
         working-directory: roles/${{ matrix.role }}
         run: molecule test
@@ -280,6 +292,18 @@ jobs:
       - name: Install collection dependencies
         run: |
           ansible-galaxy collection install community.general community.crypto ansible.posix kewlfft.aur containers.podman
+
+      - name: Pin crun to a spec-compatible release
+        # ubuntu-latest ships crun versions that vary with the runner image
+        # rollout; crun < 1.14.3 cannot parse the OCI runtime spec v1.2.1
+        # config that podman 5.x writes, failing container create with
+        # "crun: unknown version specified". Pin a known-good static build.
+        run: |
+          CRUN_VERSION=1.28
+          sudo curl -fsSL -o /usr/bin/crun \
+            "https://github.com/containers/crun/releases/download/${CRUN_VERSION}/crun-${CRUN_VERSION}-linux-amd64"
+          sudo chmod +x /usr/bin/crun
+          crun --version
 
       - name: Run Molecule test
         working-directory: roles/${{ matrix.role }}


### PR DESCRIPTION
## Summary

Fixes intermittent molecule/podman CI failures caused by an outdated `crun` on `ubuntu-latest`.

`podman` 5.x writes the container `config.json` with OCI Runtime Spec v1.2.1; `crun` below 1.14.3 cannot parse it and fails container create with "crun: unknown version specified". Which `crun` version a runner ships varies with the image rollout, hence the flakiness.

This pins a known-good static `crun` build (1.28) before the `molecule test` step in both the `molecule-roles` and `molecule-compat` jobs. Updating `crun` alone suffices — `podman` generates the config correctly.

## Test plan

- [x] `yamllint` passes on `ci.yml`
- [x] Full molecule matrix (162 jobs, all podman roles across all platforms) run green on this branch via `workflow_dispatch` — no `crun` create failures

Closes #292
