### PR TITLE
ci: centralize pip dependencies into requirements files and enable caching

### DIFF
--- a/.github/requirements-ci.txt
+++ b/.github/requirements-ci.txt
@@ -1,0 +1,3 @@
+ansible-core
+ansible-lint
+yamllint

--- a/.github/requirements-molecule.txt
+++ b/.github/requirements-molecule.txt
@@ -1,0 +1,3 @@
+molecule==26.6.0
+molecule-plugins[podman]==26.7.8
+passlib

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,10 +27,11 @@ jobs:
         uses: actions/setup-python@v7
         with:
           python-version: '3.13'
+          cache: 'pip'
+          cache-dependency-path: .github/requirements-ci.txt
 
       - name: Install dependencies
-        run: |
-          pip install ansible-core ansible-lint
+        run: pip install -r .github/requirements-ci.txt
 
       - name: Install collection dependencies
         run: |
@@ -66,9 +67,11 @@ jobs:
         uses: actions/setup-python@v7
         with:
           python-version: '3.13'
+          cache: 'pip'
+          cache-dependency-path: .github/requirements-ci.txt
 
-      - name: Install yamllint
-        run: pip install yamllint
+      - name: Install dependencies
+        run: pip install -r .github/requirements-ci.txt
 
       - name: Run yamllint
         run: yamllint -c .yamllint .
@@ -101,13 +104,11 @@ jobs:
         uses: actions/setup-python@v7
         with:
           python-version: '3.13'
+          cache: 'pip'
+          cache-dependency-path: .github/requirements-molecule.txt
 
       - name: Install dependencies
-        run: |
-          pip install "ansible-core~=2.21.0" \
-                      "molecule==26.6.0" \
-                      "molecule-plugins[podman]==26.7.8" \
-                      passlib
+        run: pip install "ansible-core~=2.21.0" -r .github/requirements-molecule.txt
 
       - name: Install collection dependencies
         run: |
@@ -281,13 +282,11 @@ jobs:
         uses: actions/setup-python@v7
         with:
           python-version: '3.13'
+          cache: 'pip'
+          cache-dependency-path: .github/requirements-molecule.txt
 
       - name: Install dependencies
-        run: |
-          pip install "ansible-core~=2.17.0" \
-                      "molecule==26.6.0" \
-                      "molecule-plugins[podman]==26.7.8" \
-                      passlib
+        run: pip install "ansible-core~=2.17.0" -r .github/requirements-molecule.txt
 
       - name: Install collection dependencies
         run: |
@@ -425,9 +424,11 @@ jobs:
         uses: actions/setup-python@v7
         with:
           python-version: '3.13'
+          cache: 'pip'
+          cache-dependency-path: .github/requirements-ci.txt
 
-      - name: Install Ansible
-        run: pip install ansible-core
+      - name: Install dependencies
+        run: pip install -r .github/requirements-ci.txt
 
       - name: Build collection
         run: ansible-galaxy collection build

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,9 +18,11 @@ jobs:
         uses: actions/setup-python@v7
         with:
           python-version: '3.13'
+          cache: 'pip'
+          cache-dependency-path: .github/requirements-ci.txt
 
-      - name: Install Ansible
-        run: pip install ansible-core
+      - name: Install dependencies
+        run: pip install -r .github/requirements-ci.txt
 
       - name: Build and publish to Galaxy
         run: |


### PR DESCRIPTION
## Summary

Applies the CI requirements-file + pip-caching convention (design in #289) to this collection.

## Changes

- Add `.github/requirements-ci.txt` (unpinned `ansible-core` / `ansible-lint` / `yamllint`) and `.github/requirements-molecule.txt` (the pinned molecule stack — single source of truth for pins that previously lived inline in both `molecule-compat` and `molecule-roles`).
- Wire every `setup-python` job (`lint`, `yaml-lint`, `build`, `publish`, `molecule-compat`, `molecule-roles`) to `cache: 'pip'` + `cache-dependency-path`, installing via `pip install -r`. Both molecule jobs keep their `ansible-core` matrix version (`~=2.21.0` / `~=2.17.0`) inline.
- `detect-changes` keeps its inline `pyyaml` install — it has no `setup-python` step, so pip caching does not apply.

The `.github` tree is in `build_ignore`, so the requirements files stay out of the Galaxy tarball.

## Acceptance criteria

- [x] `.github/requirements-ci.txt` and `.github/requirements-molecule.txt` added
- [x] All Python jobs install via `pip install -r …` and set `cache: 'pip'` + `cache-dependency-path`
- [x] Molecule pins exist only in `requirements-molecule.txt` (no inline duplication)
- [ ] CI green — `lint` / `build` run on this PR; `molecule-compat` / `molecule-roles` run on push to `main` after merge (skipped on `.github`-only PRs)

References #289
